### PR TITLE
Extend Ad Unit Data Model

### DIFF
--- a/includes/class-newspack-ads-blocks.php
+++ b/includes/class-newspack-ads-blocks.php
@@ -18,6 +18,7 @@ class Newspack_Ads_Blocks {
 	public static function init() {
 		require_once NEWSPACK_ADS_ABSPATH . 'src/blocks/ad-unit/view.php';
 		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_block_editor_assets' ) );
+		add_action( 'wp_head', array( __CLASS__, 'insert_google_ad_manager_header_code' ), 30 );
 	}
 
 	/**
@@ -103,6 +104,19 @@ class Newspack_Ads_Blocks {
 				array(),
 				NEWSPACK_ADS_VERSION
 			);
+		}
+	}
+
+	/**
+	 * Google Ad Manager header code
+	 */
+	public static function insert_google_ad_manager_header_code() {
+		$is_amp = function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
+
+		if ( ! $is_amp ) {
+			// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo Newspack_Ads_Model::get_header_code( 'google_ad_manager' );
+			// phpcs:enable phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 	}
 }

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -14,6 +14,9 @@ class Newspack_Ads_Model {
 	const AMP_AD_CODE = 'amp_ad_code';
 	const AD_SERVICE  = 'ad_service';
 
+	const NEWSPACK_ADS_SERVICE_PREFIX     = '_newspack_ads_service_';
+	const NEWSPACK_ADS_HEADER_CODE_SUFFIX = '_header_code';
+
 	/**
 	 * Custom post type
 	 *
@@ -207,6 +210,29 @@ class Newspack_Ads_Model {
 			return true;
 		}
 	}
+
+	/**
+	 * Update/create the header code for a service.
+	 *
+	 * @param string $service The service.
+	 * @param string $header_code The code.
+	 */
+	public static function set_header_code( $service, $header_code ) {
+		$id = self::NEWSPACK_ADS_SERVICE_PREFIX . $service . self::NEWSPACK_ADS_HEADER_CODE_SUFFIX;
+		update_option( self::NEWSPACK_ADS_SERVICE_PREFIX . $service . self::NEWSPACK_ADS_HEADER_CODE_SUFFIX, $header_code );
+		return true;
+	}
+
+	/**
+	 * Retrieve the header code for a service.
+	 *
+	 * @param string $service The service.
+	 * @return string $header_code The code.
+	 */
+	public static function get_header_code( $service ) {
+		return get_option( self::NEWSPACK_ADS_SERVICE_PREFIX . $service . self::NEWSPACK_ADS_HEADER_CODE_SUFFIX, '' );
+	}
+
 
 	/**
 	 * Sanitize an ad unit.

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -12,6 +12,7 @@ class Newspack_Ads_Model {
 
 	const AD_CODE     = 'ad_code';
 	const AMP_AD_CODE = 'amp_ad_code';
+	const AD_SERVICE  = 'ad_service';
 
 	/**
 	 * Custom post type
@@ -58,6 +59,7 @@ class Newspack_Ads_Model {
 				'name'            => $ad_unit->post_title,
 				self::AD_CODE     => \get_post_meta( $ad_unit->ID, self::AD_CODE, true ),
 				self::AMP_AD_CODE => \get_post_meta( $ad_unit->ID, self::AMP_AD_CODE, true ),
+				self::AD_SERVICE  => \get_post_meta( $ad_unit->ID, self::AD_SERVICE, true ),
 			);
 		} else {
 			return new WP_Error(
@@ -89,6 +91,7 @@ class Newspack_Ads_Model {
 					'name'            => html_entity_decode( \get_the_title(), ENT_QUOTES ),
 					self::AD_CODE     => \get_post_meta( get_the_ID(), self::AD_CODE, true ),
 					self::AMP_AD_CODE => \get_post_meta( get_the_ID(), self::AMP_AD_CODE, true ),
+					self::AD_SERVICE  => \get_post_meta( get_the_ID(), self::AD_SERVICE, true ),
 				);
 			}
 		}
@@ -137,6 +140,7 @@ class Newspack_Ads_Model {
 			'name'            => $ad_unit['name'],
 			self::AD_CODE     => $ad_unit[ self::AD_CODE ],
 			self::AMP_AD_CODE => $ad_unit[ self::AMP_AD_CODE ],
+			self::AD_SERVICE  => $ad_unit[ self::AD_SERVICE ],
 		);
 	}
 
@@ -172,12 +176,14 @@ class Newspack_Ads_Model {
 		);
 		\update_post_meta( $ad_unit['id'], self::AD_CODE, $ad_unit[ self::AD_CODE ] );
 		\update_post_meta( $ad_unit['id'], self::AMP_AD_CODE, $ad_unit[ self::AMP_AD_CODE ] );
+		\update_post_meta( $ad_unit['id'], self::AD_SERVICE, $ad_unit[ self::AD_SERVICE ] );
 
 		return array(
 			'id'              => $ad_unit['id'],
 			'name'            => $ad_unit['name'],
 			self::AD_CODE     => $ad_unit[ self::AD_CODE ],
 			self::AMP_AD_CODE => $ad_unit[ self::AMP_AD_CODE ],
+			self::AD_SERVICE  => $ad_unit[ self::AD_SERVICE ],
 		);
 	}
 
@@ -225,6 +231,7 @@ class Newspack_Ads_Model {
 			'name'            => \esc_html( $ad_unit['name'] ),
 			self::AD_CODE     => $ad_unit[ self::AD_CODE ], // esc_js( $ad_unit['code'] ), @todo If a `script` tag goes here, esc_js is the wrong function to use.
 			self::AMP_AD_CODE => $ad_unit[ self::AMP_AD_CODE ], // esc_js( $ad_unit['code'] ), @todo If a `script` tag goes here, esc_js is the wrong function to use.
+			self::AD_SERVICE  => $ad_unit[ self::AD_SERVICE ],
 
 		);
 

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -107,7 +107,9 @@ class Newspack_Ads_Model {
 	 * @param array $ad_unit The new ad unit info to add.
 	 */
 	public static function add_ad_unit( $ad_unit ) {
-
+		if ( ! current_user_can( 'unfiltered_html' ) ) {
+			return false;
+		}
 		// Sanitise the values.
 		$ad_unit = self::sanitise_ad_unit( $ad_unit );
 		if ( \is_wp_error( $ad_unit ) ) {
@@ -152,7 +154,9 @@ class Newspack_Ads_Model {
 	 * @param array $ad_unit The updated ad unit.
 	 */
 	public static function update_ad_unit( $ad_unit ) {
-
+		if ( ! current_user_can( 'unfiltered_html' ) ) {
+			return false;
+		}
 		// Sanitise the values.
 		$ad_unit = self::sanitise_ad_unit( $ad_unit );
 		if ( \is_wp_error( $ad_unit ) ) {
@@ -195,6 +199,9 @@ class Newspack_Ads_Model {
 	 * @param integer $id The id of the ad unit to delete.
 	 */
 	public static function delete_ad_unit( $id ) {
+		if ( ! current_user_can( 'unfiltered_html' ) ) {
+			return false;
+		}
 		$ad_unit_post = \get_post( $id );
 		if ( ! is_a( $ad_unit_post, 'WP_Post' ) ) {
 			return new WP_Error(

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -10,6 +10,9 @@
  */
 class Newspack_Ads_Model {
 
+	const AD_CODE     = 'ad_code';
+	const AMP_AD_CODE = 'amp_ad_code';
+
 	/**
 	 * Custom post type
 	 *
@@ -51,9 +54,10 @@ class Newspack_Ads_Model {
 		$ad_unit = \get_post( $id );
 		if ( is_a( $ad_unit, 'WP_Post' ) ) {
 			return array(
-				'id'   => $ad_unit->ID,
-				'name' => $ad_unit->post_title,
-				'code' => \get_post_meta( $ad_unit->ID, self::$custom_post_type, true ),
+				'id'              => $ad_unit->ID,
+				'name'            => $ad_unit->post_title,
+				self::AD_CODE     => \get_post_meta( $ad_unit->ID, self::AD_CODE, true ),
+				self::AMP_AD_CODE => \get_post_meta( $ad_unit->ID, self::AMP_AD_CODE, true ),
 			);
 		} else {
 			return new WP_Error(
@@ -81,9 +85,10 @@ class Newspack_Ads_Model {
 			while ( $query->have_posts() ) {
 				$query->the_post();
 				$ad_units[] = array(
-					'id'   => \get_the_ID(),
-					'name' => html_entity_decode( \get_the_title(), ENT_QUOTES ),
-					'code' => \get_post_meta( get_the_ID(), self::$custom_post_type, true ),
+					'id'              => \get_the_ID(),
+					'name'            => html_entity_decode( \get_the_title(), ENT_QUOTES ),
+					self::AD_CODE     => \get_post_meta( get_the_ID(), self::AD_CODE, true ),
+					self::AMP_AD_CODE => \get_post_meta( get_the_ID(), self::AMP_AD_CODE, true ),
 				);
 			}
 		}
@@ -124,12 +129,14 @@ class Newspack_Ads_Model {
 		}
 
 		// Add the code to our new post.
-		\add_post_meta( $ad_unit_post, self::$custom_post_type, $ad_unit['code'] );
+		\add_post_meta( $ad_unit_post, self::AD_CODE, $ad_unit[ self::AD_CODE ] );
+		\add_post_meta( $ad_unit_post, self::AMP_AD_CODE, $ad_unit[ self::AMP_AD_CODE ] );
 
 		return array(
-			'id'   => $ad_unit_post,
-			'name' => $ad_unit['name'],
-			'code' => $ad_unit['code'],
+			'id'              => $ad_unit_post,
+			'name'            => $ad_unit['name'],
+			self::AD_CODE     => $ad_unit[ self::AD_CODE ],
+			self::AMP_AD_CODE => $ad_unit[ self::AMP_AD_CODE ],
 		);
 	}
 
@@ -163,12 +170,14 @@ class Newspack_Ads_Model {
 				'post_title' => $ad_unit['name'],
 			)
 		);
-		\update_post_meta( $ad_unit['id'], self::$custom_post_type, $ad_unit['code'] );
+		\update_post_meta( $ad_unit['id'], self::AD_CODE, $ad_unit[ self::AD_CODE ] );
+		\update_post_meta( $ad_unit['id'], self::AMP_AD_CODE, $ad_unit[ self::AMP_AD_CODE ] );
 
 		return array(
-			'id'   => $ad_unit['id'],
-			'name' => $ad_unit['name'],
-			'code' => $ad_unit['code'],
+			'id'              => $ad_unit['id'],
+			'name'            => $ad_unit['name'],
+			self::AD_CODE     => $ad_unit[ self::AD_CODE ],
+			self::AMP_AD_CODE => $ad_unit[ self::AMP_AD_CODE ],
 		);
 	}
 
@@ -201,7 +210,7 @@ class Newspack_Ads_Model {
 	public static function sanitise_ad_unit( $ad_unit ) {
 		if (
 			! array_key_exists( 'name', $ad_unit ) ||
-			! array_key_exists( 'code', $ad_unit )
+			( ! array_key_exists( self::AD_CODE, $ad_unit ) && ! array_key_exists( self::AMP_AD_CODE, $ad_unit ) )
 		) {
 			return new WP_Error(
 				'newspack_invalid_ad_unit_data',
@@ -213,8 +222,9 @@ class Newspack_Ads_Model {
 		}
 
 		$sanitised_ad_unit = array(
-			'name' => \esc_html( $ad_unit['name'] ),
-			'code' => $ad_unit['code'], // esc_js( $ad_unit['code'] ), @todo If a `script` tag goes here, esc_js is the wrong function to use.
+			'name'            => \esc_html( $ad_unit['name'] ),
+			self::AD_CODE     => $ad_unit[ self::AD_CODE ], // esc_js( $ad_unit['code'] ), @todo If a `script` tag goes here, esc_js is the wrong function to use.
+			self::AMP_AD_CODE => $ad_unit[ self::AMP_AD_CODE ], // esc_js( $ad_unit['code'] ), @todo If a `script` tag goes here, esc_js is the wrong function to use.
 
 		);
 

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -32,7 +32,6 @@ class Newspack_Ads_Model {
 	 */
 	public static function init() {
 		add_action( 'init', array( __CLASS__, 'register_ad_post_type' ) );
-		add_action( 'amp_post_template_head', array( __CLASS__, 'amp_post_template_head' ) );
 	}
 
 	/**
@@ -218,6 +217,9 @@ class Newspack_Ads_Model {
 	 * @param string $header_code The code.
 	 */
 	public static function set_header_code( $service, $header_code ) {
+		if ( ! current_user_can( 'unfiltered_html' ) ) {
+			return false;
+		}
 		$id = self::NEWSPACK_ADS_SERVICE_PREFIX . $service . self::NEWSPACK_ADS_HEADER_CODE_SUFFIX;
 		update_option( self::NEWSPACK_ADS_SERVICE_PREFIX . $service . self::NEWSPACK_ADS_HEADER_CODE_SUFFIX, $header_code );
 		return true;

--- a/src/blocks/ad-unit/edit.js
+++ b/src/blocks/ad-unit/edit.js
@@ -58,13 +58,15 @@ class Edit extends Component {
 
 	activeAdDataForActiveAd = activeAd => {
 		const { adUnits } = this.state;
-		const data = adUnits && adUnits.find( adUnit => parseInt( adUnit.id ) === parseInt( activeAd ) );
+		const data =
+			adUnits && adUnits.find( adUnit => parseInt( adUnit.id ) === parseInt( activeAd ) );
 		return this.dimensionsFromAd( data );
 	};
 
 	dimensionsFromAd = adData => {
 		const { noticeOperations } = this.props;
-		const { code } = adData || {};
+		const { ad_code, amp_ad_code } = adData || {};
+		const code = ad_code ? ad_code : amp_ad_code;
 		const widthRegex = /width[:=].*?([0-9].*?)(?:px|\s)/i;
 		const widthMatch = ( code || '' ).match( widthRegex );
 		const heightRegex = /height[:=].*?([0-9].*?)(?:px|\s)/i;
@@ -72,7 +74,8 @@ class Edit extends Component {
 		const width = widthMatch && parseInt( widthMatch[ 1 ] );
 		const height = heightMatch && parseInt( heightMatch[ 1 ] );
 		return {
-			code,
+			ad_code,
+			amp_ad_code,
 			width,
 			height,
 		};

--- a/src/blocks/ad-unit/edit.js
+++ b/src/blocks/ad-unit/edit.js
@@ -23,8 +23,8 @@ class Edit extends Component {
 	}
 
 	componentDidMount() {
-		apiFetch( { path: '/newspack/v1/wizard/adunits' } ).then( adUnits =>
-			this.setState( { adUnits, initialUpdate: true } )
+		apiFetch( { path: '/newspack/v1/wizard/advertising' } ).then( response =>
+			this.setState( { adUnits: response.ad_units, initialUpdate: true } )
 		);
 	}
 

--- a/src/blocks/ad-unit/view.php
+++ b/src/blocks/ad-unit/view.php
@@ -21,10 +21,19 @@ function newspack_ads_render_block_ad_unit( $attributes ) {
 	$classes = Newspack_Ads_Blocks::block_classes( 'wp-block-newspack-ads-blocks-ad-unit', $attributes );
 
 	$ad_unit = Newspack_Ads_Model::get_ad_unit( $active_ad );
+
+	$is_amp = function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
+
+	$code = $is_amp ? $ad_unit['amp_ad_code'] : $ad_unit['ad_code'];
+
+	if ( empty( $code ) ) {
+		return '';
+	}
+
 	$content = sprintf(
 		'<div class="%s">%s</div>',
 		esc_attr( $classes ),
-		$ad_unit['code'] /* TODO: escape with wp_kses() */
+		$code /* TODO: escape with wp_kses() */
 	);
 
 	Newspack_Ads_Blocks::enqueue_view_assets( 'ad-unit' );

--- a/tests/unit-tests/class-newspack-ads-tests-model.php
+++ b/tests/unit-tests/class-newspack-ads-tests-model.php
@@ -5,8 +5,6 @@
  * @package Newspack\Tests
  */
 
-use Newspack_Ads_Model;
-
 /**
  * Test plugin management functionality.
  */
@@ -17,14 +15,16 @@ class Newspack_Ads_Test_Plugin_Manager extends WP_UnitTestCase {
 	 */
 	public function test_add_unit() {
 		$unit = array(
-			'name' => 'test',
-			'code' => '<script>console.log("test");</script>',
+			'name'        => 'test',
+			'ad_code'     => "<!-- /123456789/ll_sidebar_med_rect --><div id='div-gpt-ad-123456789-0' style='width: 300px; height: 250px;'><script>googletag.cmd.push(function() { googletag.display('div-gpt-ad-1563275607117-0'); });</script></div>",
+			'amp_ad_code' => '<amp-ad width=120 height=90 ype="doubleclick" data-slot="/123456789/Small"></amp-ad>',
 		);
 
 		$result = Newspack_Ads_Model::add_ad_unit( $unit );
 		$this->assertTrue( $result['id'] > 0 );
 		$this->assertEquals( $unit['name'], $result['name'] );
-		$this->assertEquals( $unit['code'], $result['code'] );
+		$this->assertEquals( $unit['ad_code'], $result['ad_code'] );
+		$this->assertEquals( $unit['amp_ad_code'], $result['amp_ad_code'] );
 		$saved_unit = Newspack_Ads_Model::get_ad_unit( $result['id'] );
 		$this->assertEquals( $result, $saved_unit );
 	}
@@ -34,15 +34,18 @@ class Newspack_Ads_Test_Plugin_Manager extends WP_UnitTestCase {
 	 */
 	public function test_update_unit() {
 		$unit = array(
-			'name' => 'test',
-			'code' => '<script>console.log("test");</script>',
+			'name'        => 'test',
+			'ad_code'     => "<!-- /123456789/ll_sidebar_med_rect --><div id='div-gpt-ad-123456789-0' style='width: 300px; height: 250px;'><script>googletag.cmd.push(function() { googletag.display('div-gpt-ad-1563275607117-0'); });</script></div>",
+			'amp_ad_code' => '<amp-ad width=120 height=90 ype="doubleclick" data-slot="/123456789/Small"></amp-ad>',
 		);
 
-		$result         = Newspack_Ads_Model::add_ad_unit( $unit );
-		$update         = $result;
-		$update['name'] = 'new test';
-		$update['code'] = '<script>console.log("updated");</script>';
-		$update_result  = Newspack_Ads_Model::update_ad_unit( $update );
+		$result                = Newspack_Ads_Model::add_ad_unit( $unit );
+		$update                = $result;
+		$update['name']        = 'new test';
+		$update['ad_code']     = '<script>console.log("updated");</script>';
+		$update['amp_ad_code'] = '<script>console.log("updated");</script>';
+
+		$update_result = Newspack_Ads_Model::update_ad_unit( $update );
 		$this->assertEquals( $update, $update_result );
 		$saved_unit = Newspack_Ads_Model::get_ad_unit( $update_result['id'] );
 		$this->assertEquals( $update, $saved_unit );
@@ -54,8 +57,9 @@ class Newspack_Ads_Test_Plugin_Manager extends WP_UnitTestCase {
 	 */
 	public function test_delete_unit() {
 		$unit = array(
-			'name' => 'test',
-			'code' => '<script>console.log("test");</script>',
+			'name'        => 'test',
+			'ad_code'     => "<!-- /123456789/ll_sidebar_med_rect --><div id='div-gpt-ad-123456789-0' style='width: 300px; height: 250px;'><script>googletag.cmd.push(function() { googletag.display('div-gpt-ad-1563275607117-0'); });</script></div>",
+			'amp_ad_code' => '<amp-ad width=120 height=90 ype="doubleclick" data-slot="/123456789/Small"></amp-ad>',
 		);
 
 		$result        = Newspack_Ads_Model::add_ad_unit( $unit );
@@ -70,12 +74,14 @@ class Newspack_Ads_Test_Plugin_Manager extends WP_UnitTestCase {
 	 */
 	public function test_get_units() {
 		$unit1 = array(
-			'name' => 'test1',
-			'code' => '<script>console.log("test1");</script>',
+			'name'        => 'test1',
+			'ad_code'     => "<!-- /123456789/ll_sidebar_med_rect --><div id='div-gpt-ad-123456789-0' style='width: 300px; height: 250px;'><script>googletag.cmd.push(function() { googletag.display('div-gpt-ad-1563275607117-0'); });</script></div>",
+			'amp_ad_code' => '<amp-ad width=120 height=90 ype="doubleclick" data-slot="/123456789/Small"></amp-ad>',
 		);
 		$unit2 = array(
-			'name' => 'test2',
-			'code' => '<script>console.log("test2");</script>',
+			'name'        => 'test2',
+			'ad_code'     => "<!-- /123456789/ll_sidebar_med_rect --><div id='div-gpt-ad-123456789-0' style='width: 300px; height: 250px;'><script>googletag.cmd.push(function() { googletag.display('div-gpt-ad-1563275607117-0'); });</script></div>",
+			'amp_ad_code' => '<amp-ad width=120 height=90 ype="doubleclick" data-slot="/123456789/Small"></amp-ad>',
 		);
 		Newspack_Ads_Model::add_ad_unit( $unit1 );
 		Newspack_Ads_Model::add_ad_unit( $unit2 );
@@ -84,7 +90,8 @@ class Newspack_Ads_Test_Plugin_Manager extends WP_UnitTestCase {
 		foreach ( $units as $unit ) {
 			$this->assertTrue( $unit['id'] > 0 );
 			$this->assertTrue( $unit['name'] === $unit1['name'] || $unit['name'] === $unit2['name'] );
-			$this->assertTrue( $unit['code'] === $unit1['code'] || $unit['code'] === $unit2['code'] );
+			$this->assertTrue( $unit['ad_code'] === $unit1['ad_code'] || $unit['ad_code'] === $unit2['ad_code'] );
+			$this->assertTrue( $unit['amp_ad_code'] === $unit1['amp_ad_code'] || $unit['amp_ad_code'] === $unit2['amp_ad_code'] );
 		}
 	}
 }


### PR DESCRIPTION
This PR is an expansion of the data model for Ads. This includes:

- Support for AMP and non-AMP fields
- Support for different Ad providers (Google Ad Manager, etc)
- Header code stored as an option.

The header code will also be injected into the HEAD in non-AMP requests. This is meant to be tested along with https://github.com/Automattic/newspack-plugin/pull/190. Complete testing instructions can be found there.