### PR TITLE
Handle errors in block rendering, generally due to ad unit that was d…

### DIFF
--- a/src/blocks/ad-unit/view.php
+++ b/src/blocks/ad-unit/view.php
@@ -22,6 +22,10 @@ function newspack_ads_render_block_ad_unit( $attributes ) {
 
 	$ad_unit = Newspack_Ads_Model::get_ad_unit( $active_ad );
 
+	if ( is_wp_error( $ad_unit ) ) {
+		return;
+	}
+
 	$is_amp = function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
 
 	$code = $is_amp ? $ad_unit['amp_ad_code'] : $ad_unit['ad_code'];


### PR DESCRIPTION
Handle errors which will occur when rendering an Ad Unit that has been deleted. Fixes #7.

## Testing Instructions

1. Checkout `master` branch.
2. In Newspack plugin, go to Advertising Wizard and create an Ad Unit ( `/wp-admin/admin.php?page=newspack-advertising-wizard#/google_ad_manager` ). The contents are irrelevant to this test.
3. Create a post, add the Ad Unit block, select the new unit.
4. Publish and view the post. There should be no errors.
5. Return to the Newspack Advertising Wizard and delete the Ad Unit.
6. Refresh the published post. You should see an error.
7. Branch switch to `fix/check-for-deleted-ad-unit`.
8. Refresh the published post again. This time there should be no error.