### PR TITLE
Load Newspack Ads block scripts in widget blocks editor

### DIFF
--- a/includes/class-newspack-ads-blocks.php
+++ b/includes/class-newspack-ads-blocks.php
@@ -19,6 +19,7 @@ class Newspack_Ads_Blocks {
 		require_once NEWSPACK_ADS_ABSPATH . 'src/blocks/ad-unit/view.php';
 		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_block_editor_assets' ) );
 		add_action( 'wp_head', array( __CLASS__, 'insert_google_ad_manager_header_code' ), 30 );
+		add_filter( 'script_loader_tag', array( __CLASS__, 'enqueue_assets_for_block_widgets' ), 10, 2 );
 	}
 
 	/**
@@ -105,6 +106,22 @@ class Newspack_Ads_Blocks {
 				NEWSPACK_ADS_VERSION
 			);
 		}
+	}
+
+	/**
+	 * Enqueue Ads Block scripts on Customizer Widget Blocks screen.
+	 * This is done in a sort-of roundabout way because there is no interface for adding block scripts
+	 * to the widget blocks screen yet. In the future it should be simplified.
+	 *
+	 * @see https://github.com/WordPress/gutenberg/blob/master/lib/widgets-page.php#L38
+	 * @param string $hook Page.
+	 */
+	public static function enqueue_assets_for_block_widgets( $tag, $handle ) {
+		if ( 'wp-edit-widgets' === $handle ) {
+			self::enqueue_block_editor_assets();
+		}
+
+	    return $tag;
 	}
 
 	/**


### PR DESCRIPTION
Using the new Widget Blocks editor, Newspack Theme sidebars, and Super Cool Ad Inserter, we can insert arbitrary block-based content in the sidebar, footer, above-content, below-content, and in-content on all pages. This should meet our needs for all common scenarios: newsletter sign-ups, CTAs, ads, pop-up block, etc.

My main concern is that Widget Blocks is not super robust right now, but that might be something we can help with as the first people using it in production.

This PR adds some handling to load up the Ad Unit Block scripts in the Customizer experimental widget blocks screen, so that they will be available. We'll need to do something similar for any other custom blocks we want available in Widget Blocks.

To test:
1. Have the latest version of Gutenberg active and this PR.
2. Go to Customizer > Widget Blocks.
3. You should be able to add an Ad Unit block in the Widget Blocks (styling issues to be resolved later):
<img width="330" alt="Screen Shot 2019-09-13 at 2 59 10 PM" src="https://user-images.githubusercontent.com/7317227/64888157-3f4c7a00-d638-11e9-9964-cf56b79021a9.png">
4. Add an ad unit to a widget and view on frontend:
<img width="587" alt="Screen Shot 2019-09-13 at 2 59 35 PM" src="https://user-images.githubusercontent.com/7317227/64888163-41aed400-d638-11e9-8e8a-844da0cb1ccf.png">