### PR TITLE
Responsive Ads

### DIFF
--- a/includes/class-newspack-ads-blocks.php
+++ b/includes/class-newspack-ads-blocks.php
@@ -140,7 +140,7 @@ class Newspack_Ads_Blocks {
 
 		$formatted_sizes = [];
 		foreach ( Newspack_Ads_Model::$ad_ids as $unique_id => $ad_unit ) {
-			$sizes = $ad_unit->sizes;
+			$sizes = $ad_unit['sizes'];
 			usort(
 				$sizes,
 				function( $a, $b ) {
@@ -160,7 +160,7 @@ class Newspack_Ads_Blocks {
 		<script>
 			googletag.cmd.push(function() {
 				<?php foreach ( Newspack_Ads_Model::$ad_ids as $unique_id => $ad_unit ) : ?>
-					googletag.defineSlot('/<?php echo esc_attr( $network_code ); ?>/<?php echo esc_attr( $ad_unit->code ); ?>', [ <?php echo esc_attr( implode( ',', $formatted_sizes[ $unique_id ] ) ); ?> ], 'div-gpt-ad-<?php echo esc_attr( $unique_id ); ?>-0').addService(googletag.pubads());
+					googletag.defineSlot('/<?php echo esc_attr( $network_code ); ?>/<?php echo esc_attr( $ad_unit['code'] ); ?>', [ <?php echo esc_attr( implode( ',', $formatted_sizes[ $unique_id ] ) ); ?> ], 'div-gpt-ad-<?php echo esc_attr( $unique_id ); ?>-0').addService(googletag.pubads());
 				<?php endforeach; ?>
 				googletag.pubads().enableSingleRequest();
 				googletag.enableServices();

--- a/includes/class-newspack-ads-blocks.php
+++ b/includes/class-newspack-ads-blocks.php
@@ -160,12 +160,24 @@ class Newspack_Ads_Blocks {
 		<script>
 			googletag.cmd.push(function() {
 				<?php foreach ( Newspack_Ads_Model::$ad_ids as $unique_id => $ad_unit ) : ?>
-					googletag.defineSlot('/<?php echo esc_attr( $network_code ); ?>/<?php echo esc_attr( $ad_unit['code'] ); ?>', [ <?php echo esc_attr( implode( ',', $formatted_sizes[ $unique_id ] ) ); ?> ], 'div-gpt-ad-<?php echo esc_attr( $unique_id ); ?>-0').addService(googletag.pubads());
+					<?php if ( $ad_unit['responsive'] ) : ?>
+						<?php foreach ( $ad_unit['sizes'] as $size ) : ?>
+							googletag.defineSlot('/<?php echo esc_attr( $network_code ); ?>/<?php echo esc_attr( $ad_unit['code'] ); ?>', [ [ <?php echo absint( $size[0] ); ?>, <?php echo absint( $size[1] ); ?> ] ], 'div-gpt-<?php echo esc_attr( $ad_unit['code'] ); ?>-<?php echo absint( $size[0] ); ?>x<?php echo absint( $size[1] ); ?>').addService(googletag.pubads());
+						<?php endforeach; ?>
+					<?php else : ?>
+						googletag.defineSlot('/<?php echo esc_attr( $network_code ); ?>/<?php echo esc_attr( $ad_unit['code'] ); ?>', [ <?php echo esc_attr( implode( ',', $formatted_sizes[ $unique_id ] ) ); ?> ], 'div-gpt-ad-<?php echo esc_attr( $unique_id ); ?>-0').addService(googletag.pubads());
+					<?php endif; ?>
 				<?php endforeach; ?>
 				googletag.pubads().enableSingleRequest();
 				googletag.enableServices();
 				<?php foreach ( Newspack_Ads_Model::$ad_ids as $unique_id => $ad_unit ) : ?>
-				googletag.display('div-gpt-ad-<?php echo esc_attr( $unique_id ); ?>-0');
+					<?php if ( $ad_unit['responsive'] ) : ?>
+						<?php foreach ( $ad_unit['sizes'] as $size ) : ?>
+						googletag.display('div-gpt-<?php echo esc_attr( $ad_unit['code'] ); ?>-<?php echo absint( $size[0] ); ?>x<?php echo absint( $size[1] ); ?>');
+						<?php endforeach; ?>
+					<?php else : ?>
+						googletag.display('div-gpt-ad-<?php echo esc_attr( $unique_id ); ?>-0');
+					<?php endif; ?>
 				<?php endforeach; ?>
 			});
 		</script>

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -59,8 +59,9 @@ class Newspack_Ads_Model {
 	 * Get a single ad unit.
 	 *
 	 * @param number $id The id of the ad unit to retrieve.
+	 * @param string $placement The id of the placement region.
 	 */
-	public static function get_ad_unit( $id ) {
+	public static function get_ad_unit( $id, $placement = null ) {
 		$ad_unit = \get_post( $id );
 		if ( is_a( $ad_unit, 'WP_Post' ) ) {
 			$prepared_ad_unit = [
@@ -69,6 +70,7 @@ class Newspack_Ads_Model {
 				self::SIZES      => self::sanitize_sizes( \get_post_meta( $ad_unit->ID, self::SIZES, true ) ),
 				self::CODE       => \get_post_meta( $ad_unit->ID, self::CODE, true ),
 				self::AD_SERVICE => self::sanitize_ad_service( \get_post_meta( $ad_unit->ID, self::AD_SERVICE, true ) ),
+				'responsive'     => in_array( $placement, [ 'global_above_header', 'global_below_header', 'global_above_footer' ] ), // TODO: Add a filter, so other plugins can register responsive regions.
 			];
 
 			$prepared_ad_unit['ad_code']     = self::code_for_ad_unit( $prepared_ad_unit );

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -63,15 +63,17 @@ class Newspack_Ads_Model {
 	public static function get_ad_unit( $id ) {
 		$ad_unit = \get_post( $id );
 		if ( is_a( $ad_unit, 'WP_Post' ) ) {
-			return array(
+			$prepared_ad_unit = [
 				'id'             => $ad_unit->ID,
 				'name'           => $ad_unit->post_title,
 				self::SIZES      => self::sanitize_sizes( \get_post_meta( $ad_unit->ID, self::SIZES, true ) ),
-				self::CODE       => absint( \get_post_meta( $ad_unit->ID, self::CODE, true ) ),
-				'ad_code'        => self::code_for_ad_unit( $ad_unit ),
-				'amp_ad_code'    => self::amp_code_for_ad_unit( $ad_unit ),
+				self::CODE       => \get_post_meta( $ad_unit->ID, self::CODE, true ),
 				self::AD_SERVICE => self::sanitize_ad_service( \get_post_meta( $ad_unit->ID, self::AD_SERVICE, true ) ),
-			);
+			];
+
+			$prepared_ad_unit['ad_code']     = self::code_for_ad_unit( $prepared_ad_unit );
+			$prepared_ad_unit['amp_ad_code'] = self::amp_code_for_ad_unit( $prepared_ad_unit );
+			return $prepared_ad_unit;
 		} else {
 			return new WP_Error(
 				'newspack_no_adspot_found',
@@ -322,8 +324,8 @@ class Newspack_Ads_Model {
 	 * @param array $ad_unit The ad unit to generate code for.
 	 */
 	public static function code_for_ad_unit( $ad_unit ) {
-		$sizes        = $ad_unit->sizes;
-		$code         = $ad_unit->code;
+		$sizes        = $ad_unit['sizes'];
+		$code         = $ad_unit['code'];
 		$network_code = self::get_network_code( 'google_ad_manager' );
 		$unique_id    = uniqid();
 
@@ -353,8 +355,8 @@ class Newspack_Ads_Model {
 	 * @param array $ad_unit The ad unit to generate AMP code for.
 	 */
 	public static function amp_code_for_ad_unit( $ad_unit ) {
-		$sizes        = $ad_unit->sizes;
-		$code         = $ad_unit->code;
+		$sizes        = $ad_unit['sizes'];
+		$code         = $ad_unit['code'];
 		$network_code = self::get_network_code( 'google_ad_manager' );
 
 		if ( ! is_array( $sizes ) ) {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,6 +6,10 @@
 	<rule ref="WordPress-Docs" />
 	<rule ref="WordPress-VIP-Go" />
 
+	<rule ref="WordPress">
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
+	</rule>
+
 	<rule ref="PHPCompatibilityWP"/>
 	<config name="testVersion" value="5.6-"/>
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR approaches the the problem of responsive ads by rendering containers for each defined size and using media queries to control visibility. 

#### The Problem 

In Newspack plugin's Ads UI it is possible to define multiple sizes for a single unit. We incorrectly assumed that this would cause the appropriate creative to be served based on viewport size, but this functionality doesn't come for free. 

#### Research

[This doc](https://support.google.com/admanager/answer/7177589?hl=en) states:

> You can use CSS Media queries to define different ad sizes based on viewports

For non-AMP, [this doc](https://support.google.com/admanager/answer/3423562?hl=en&authuser=0) explains an approach to responsiveness using GPT `defineSizeMapping`. I wasn't enthusiastic about taking different approaches to AMP and non-AMP, so I opted to use CSS media queries in the non-AMP solution as well.

#### Approach

The idea here is that banner units should be treated as responsive (above header/below header/footer), while other ad units should not (widget, blocks, etc). This approach applies new rendering logic only to ad units in placements that suggest responsiveness. The rendering takes all of the sizes defined for the assigned ad unit and renders a separate container for each one. CSS is rendered programmatically that will hide/show each container based on viewport size. 

#### Open Questions

1. The documentation seems to fully support this approach for AMP, but I'm not 1000% confident that this is the right approach for non-AMP requests. The concern is that by defining multiple slots for the same unit the ad will be served more than once, and possibly counted.

2. If a user wished to use a different unit for mobile in the same location, we don't yet have an answer. 

3. The generated media queries assume the unit will be full width. In other words, if the defined sizes are 320x50 and 728x90, the resulting media queries would look like this:

```
@media (min-width:728px){}
@media (min-width:320px) and (max-width:728px){}
```
Is it appropriate that these match precisely to the size of the units, or should we account for any padding?

### How to test the changes in this Pull Request:

1. Create a Google Ad Manager ad unit with a typical desktop banner size (e.g. 728x90) and a typical mobile size (320x50). Use creative that will clearly show if the unit is appropriate for the viewport. Alternatively contact me or @philipjohn for sample codes to use.
2. Before switching any branches, ad this unit in Newspack plugin with both sizes defined. In Pre-defined ad placements, set the unit to display in `Global: Above Header`.
3. Verify that the ad is NOT responsive. Sometimes you'll see the mobile creative in desktop, and you should almost always see the desktop creative in mobile, overflowing the container.
4. Switch `newspack-ads` to this branch, and switch `newspack-plugin` to https://github.com/Automattic/newspack-plugin/pull/403.
5. After the switch the add should be responsive. You should see the correct creative for desktop and mobile. If you resize a window from one to the other you should see the creative change. 
6. Verify in both AMP and non-AMP requests.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->