### PR TITLE
Allow for valid characters in the ad unit code

### DIFF
--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -107,7 +107,7 @@ class Newspack_Ads_Model {
 					'id'             => \get_the_ID(),
 					'name'           => html_entity_decode( \get_the_title(), ENT_QUOTES ),
 					self::SIZES      => self::sanitize_sizes( \get_post_meta( get_the_ID(), self::SIZES, true ) ),
-					self::CODE       => sanitize_title( \get_post_meta( get_the_ID(), self::CODE, true ) ),
+					self::CODE       => esc_html( \get_post_meta( get_the_ID(), self::CODE, true ) ),
 					self::AD_SERVICE => \get_post_meta( get_the_ID(), self::AD_SERVICE, true ),
 				);
 			}
@@ -279,7 +279,7 @@ class Newspack_Ads_Model {
 
 		$sanitised_ad_unit = array(
 			'name'           => \esc_html( $ad_unit['name'] ),
-			self::CODE       => sanitize_title( $ad_unit[ self::CODE ] ),
+			self::CODE       => esc_html( $ad_unit[ self::CODE ] ),
 			self::SIZES      => self::sanitize_sizes( $ad_unit[ self::SIZES ] ),
 			self::AD_SERVICE => self::sanitize_ad_service( $ad_unit[ self::AD_SERVICE ] ),
 
@@ -421,7 +421,7 @@ class Newspack_Ads_Model {
 			$div_id = sprintf(
 				'%s%s-%dx%d',
 				$prefix,
-				esc_attr( $ad_unit['code'] ),
+				sanitize_title( $ad_unit['code'] ),
 				$width,
 				$height
 			);


### PR DESCRIPTION
Use esc_html() instead of sanitize_title() for checking the saved ad unit code. Also use sanitize_title() instead of esc_attr() for a more valid CSS class on output.

To test:

1. In Newspack > Advertising enable Google Ad Manager
1. Click Configure
1. In the Global Code tab enter `000000000` in the "Google Ad Manager Network Code" setting
1. Go to the Individual Ad Units tab and add a new ad unit
1. Use `AT TopBanner` as the name
1. Use `AsiaTimes/Atimes_AMP/TopBanner` as the Ad unit code
1. Use `350` as width and `200` as height
1. Save the ad unit
1. Observe that the code has been changed to lowercase and slashes removed
1. Return to the Advertising Options screen
1. In the Global Settings, select the ad to appear in the "Global: Above Header" spot
1. View the home page, and observe the ad slot at the top of the page
1. View the source and observe code that should look like this: `<amp-ad width="300" height="250" type="doubleclick" data-slot="/339474670/asiatimes-atimes_amp-topbanner"></amp-ad>`
1. Apply the patch
1. Edit the ad unit you added earlier, re-adding the ad unit code as `AsiaTimes/Atimes_AMP/TopBanner`
1. Observe that the ad unit code remains as entered
1. Refresh the home page
1. Observe the code should now look like `<amp-ad width="300px" height="250px" type="doubleclick" data-slot="/339474670/AsiaTimes/Atimes_AMP/TopBanner"></amp-ad>`
1. Approve this PR and then eat your choice of sweet treat in celebration.

Fixes #24 