### PR TITLE
fix: placeholder box-shadow and background color since gutenberg 7.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3476,6 +3476,12 @@
       "integrity": "sha512-b45c4x1+OvQm1f6egrBruO8eVF4bRVRZ8ojM1ttDcMi+K/qXfun3J6O8xXpSnA5eeNCZaJL3DhIk/aoNBbpwzw==",
       "dev": true
     },
+    "@wordpress/base-styles": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-1.4.0.tgz",
+      "integrity": "sha512-yG2JsLxEpa5zqZc/H6CoB7qb22OJOiG0AQIyhkw8CgvFA0FxiiYIXObAe0yjh2T7EQQbsxq88vxR/cPnupqnEw==",
+      "dev": true
+    },
     "@wordpress/blob": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-2.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "@automattic/calypso-build": "^5.1.0",
     "@babel/core": "^7.5.4",
+    "@wordpress/base-styles": "^1.4.0",
     "@wordpress/blocks": "^6.4.0",
     "@wordpress/element": "^2.5.0",
     "classnames": "^2.2.6",

--- a/src/blocks/ad-unit/editor.scss
+++ b/src/blocks/ad-unit/editor.scss
@@ -1,3 +1,5 @@
+@import '~@wordpress/base-styles/colors';
+
 .newspack-ads-ad-unit {
 	margin: 0 0 28px;
 	max-width: 100%;
@@ -10,16 +12,19 @@
 		max-width: calc(100vw - 116px);
 	}
 
-	.newspack-ads-ad-unit__ratio {
+	&__ratio {
 		padding: 0 0 75%;
 	}
 
 	.components-placeholder {
+		background: $light-gray-200;
+		border-radius: 0;
+		box-shadow: none;
 		margin: 0;
 		min-height: 100px;
 		padding: 0;
 
-		.components-placeholder__label {
+		&__label {
 			display: none;
 		}
 	}
@@ -39,7 +44,7 @@
 		right: 1.5384615385em;
 		top: 1.5384615385em;
 
-		.components-base-control__field {
+		&__field {
 			display: flex;
 			flex-direction: column;
 			justify-content: center;
@@ -47,7 +52,7 @@
 			width: 100%;
 		}
 
-		.components-base-control__label {
+		&__label {
 			font-weight: 600;
 		}
 	}


### PR DESCRIPTION
Placeholders have been updated since Gutenberg 7.7 and the Ad Unit block looked broken with the new style.

This PR reverts the placeholder to its original style.

__How to test:__

1. Add Ad Unit block to a post -- See new style
2. Switch to this branch.
3. Refresh the editor