### PR TITLE
fix: unique IDs for responsive ads

### DIFF
--- a/includes/class-newspack-ads-blocks.php
+++ b/includes/class-newspack-ads-blocks.php
@@ -171,7 +171,7 @@ class Newspack_Ads_Blocks {
 				<?php foreach ( Newspack_Ads_Model::$ad_ids as $unique_id => $ad_unit ) : ?>
 					<?php if ( $ad_unit['responsive'] ) : ?>
 						<?php foreach ( $ad_unit['sizes'] as $size ) : ?>
-							googletag.defineSlot('/<?php echo esc_attr( $network_code ); ?>/<?php echo esc_attr( $ad_unit['code'] ); ?>', [ [ <?php echo absint( $size[0] ); ?>, <?php echo absint( $size[1] ); ?> ] ], 'div-gpt-<?php echo esc_attr( $ad_unit['code'] ); ?>-<?php echo absint( $size[0] ); ?>x<?php echo absint( $size[1] ); ?>').addService(googletag.pubads());
+							googletag.defineSlot('/<?php echo esc_attr( $network_code ); ?>/<?php echo esc_attr( $ad_unit['code'] ); ?>', [ [ <?php echo absint( $size[0] ); ?>, <?php echo absint( $size[1] ); ?> ] ], 'div-gpt-<?php echo esc_attr( $ad_unit['code'] ); ?>-<?php echo esc_attr( $unique_id ); ?>-<?php echo absint( $size[0] ); ?>x<?php echo absint( $size[1] ); ?>').addService(googletag.pubads());
 						<?php endforeach; ?>
 					<?php else : ?>
 						googletag.defineSlot('/<?php echo esc_attr( $network_code ); ?>/<?php echo esc_attr( $ad_unit['code'] ); ?>', [ <?php echo esc_attr( implode( ',', $formatted_sizes[ $unique_id ] ) ); ?> ], 'div-gpt-ad-<?php echo esc_attr( $unique_id ); ?>-0').addService(googletag.pubads());
@@ -182,7 +182,7 @@ class Newspack_Ads_Blocks {
 				<?php foreach ( Newspack_Ads_Model::$ad_ids as $unique_id => $ad_unit ) : ?>
 					<?php if ( $ad_unit['responsive'] ) : ?>
 						<?php foreach ( $ad_unit['sizes'] as $size ) : ?>
-						googletag.display('div-gpt-<?php echo esc_attr( $ad_unit['code'] ); ?>-<?php echo absint( $size[0] ); ?>x<?php echo absint( $size[1] ); ?>');
+						googletag.display('div-gpt-<?php echo esc_attr( $ad_unit['code'] ); ?>-<?php echo esc_attr( $unique_id ); ?>-<?php echo absint( $size[0] ); ?>x<?php echo absint( $size[1] ); ?>');
 						<?php endforeach; ?>
 					<?php else : ?>
 						googletag.display('div-gpt-ad-<?php echo esc_attr( $unique_id ); ?>-0');

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -341,7 +341,6 @@ class Newspack_Ads_Model {
 		$code         = $ad_unit['code'];
 		$network_code = self::get_network_code( 'google_ad_manager' );
 		$unique_id    = uniqid();
-
 		if ( ! is_array( $sizes ) ) {
 			$sizes = [];
 		}
@@ -349,7 +348,7 @@ class Newspack_Ads_Model {
 		self::$ad_ids[ $unique_id ] = $ad_unit;
 
 		if ( $ad_unit['responsive'] ) {
-			return self::ad_elements_for_sizes( $ad_unit );
+			return self::ad_elements_for_sizes( $ad_unit, $unique_id );
 		}
 
 		$largest = self::largest_ad_size( $sizes );
@@ -375,13 +374,14 @@ class Newspack_Ads_Model {
 		$sizes        = $ad_unit['sizes'];
 		$code         = $ad_unit['code'];
 		$network_code = self::get_network_code( 'google_ad_manager' );
+		$unique_id    = uniqid();
 
 		if ( ! is_array( $sizes ) ) {
 			$sizes = [];
 		}
 
 		if ( $ad_unit['responsive'] ) {
-			return self::ad_elements_for_sizes( $ad_unit, true );
+			return self::ad_elements_for_sizes( $ad_unit, $unique_id, true );
 		}
 
 		$largest = self::largest_ad_size( $sizes );
@@ -401,9 +401,10 @@ class Newspack_Ads_Model {
 	 * Generate divs for a series of ad sizes.
 	 *
 	 * @param array   $ad_unit The ad unit to generate code for.
+	 * @param string  $unique_id Unique ID for this ad unit instance.
 	 * @param boolean $is_amp Are these AMP units or not.
 	 */
-	public static function ad_elements_for_sizes( $ad_unit, $is_amp = false ) {
+	public static function ad_elements_for_sizes( $ad_unit, $unique_id, $is_amp = false ) {
 		$network_code = self::get_network_code( 'google_ad_manager' );
 		$code         = $ad_unit['code'];
 		$sizes        = $ad_unit['sizes'];
@@ -446,9 +447,10 @@ class Newspack_Ads_Model {
 			$height      = absint( $size[1] );
 			$prefix      = $is_amp ? 'div-gpt-amp-' : 'div-gpt-';
 			$div_id      = sprintf(
-				'%s%s-%dx%d',
+				'%s%s-%s-%dx%d',
 				$prefix,
 				sanitize_title( $ad_unit['code'] ),
+				$unique_id,
 				$width,
 				$height
 			);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Several problems have popped up related to duplicate IDs for Ad Unit elements:

- In non-AMP requests the presence of duplicates leads to the units completely failing to fill, and rendering as blank white space.
- In other cases, duplicate units lead to conflicting media queries, which can break the responsive handling.

This PR resolves this by injecting a unique ID into element name for responsive Ad unit containers. Previously, non-responsive units already had a Unique ID, but responsive ones did not.

### How to test the changes in this Pull Request:

1. Try a variety of ad configurations, using Super Cool Ad Inserter, Newspack Ads block, and Newspack Plugin placements. Experiment with duplicate ad units.
2. Verify correct rendering and responsiveness.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->