### PR TITLE
Fix ad centering in non-AMP mode

### DIFF
--- a/includes/class-newspack-ads-blocks.php
+++ b/includes/class-newspack-ads-blocks.php
@@ -107,6 +107,10 @@ class Newspack_Ads_Blocks {
 				NEWSPACK_ADS_VERSION
 			);
 		}
+
+		wp_register_style( "newspack-blocks-{$type}", false );
+		wp_add_inline_style( "newspack-blocks-{$type}", '.wp-block-newspack-blocks-wp-block-newspack-ads-blocks-ad-unit.aligncenter > div { margin-left: auto; margin-right: auto; }' );
+		wp_enqueue_style( "newspack-blocks-{$type}" );
 	}
 
 	/**

--- a/includes/class-newspack-ads-blocks.php
+++ b/includes/class-newspack-ads-blocks.php
@@ -108,7 +108,7 @@ class Newspack_Ads_Blocks {
 			);
 		}
 
-		wp_register_style( "newspack-blocks-{$type}", false );
+		wp_register_style( "newspack-blocks-{$type}", false ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 		wp_add_inline_style( "newspack-blocks-{$type}", '.wp-block-newspack-blocks-wp-block-newspack-ads-blocks-ad-unit.aligncenter > div { margin-left: auto; margin-right: auto; }' );
 		wp_enqueue_style( "newspack-blocks-{$type}" );
 	}


### PR DESCRIPTION
Closes #12 

In non-AMP mode, the ad block is a div. Since divs are full-width block elements, giving them `margin-left: auto; margin-right: auto` doesn't center them. This PR solves the issue by centering the child ad unit inside the div.

I chose to just use an inline script for this because Newspack Ads doesn't have a stylesheet, and the extra HTTP request would be a much bigger performance hit than an inline style on a fake stylesheet. If we ever need a stylesheet for this plugin we can refactor, but until then this should work well.

To test:
**1. Set up an ad unit. 
2. Take AMP off Standard mode or toggle it off for the current post.
3. Insert an Ad Block into a post or page. Select the center alignment for the block.
4. On frontend, observe the block is not centered.**
<img width="493" alt="Screen Shot 2020-04-25 at 11 07 59 AM" src="https://user-images.githubusercontent.com/7317227/80287280-942f9300-86e5-11ea-8b5b-72a6a664470c.png">
**5. Apply patch.
6. On frontend, observe the block is centered.**
<img width="498" alt="Screen Shot 2020-04-25 at 11 03 01 AM" src="https://user-images.githubusercontent.com/7317227/80287285-97c31a00-86e5-11ea-99d4-849380a2e529.png">
