### PR TITLE
Add support for ad targeting via filter

### DIFF
--- a/includes/class-newspack-ads-blocks.php
+++ b/includes/class-newspack-ads-blocks.php
@@ -172,13 +172,21 @@ class Newspack_Ads_Blocks {
 		?>
 		<script>
 			googletag.cmd.push(function() {
+				var ad_units = [];
 				<?php foreach ( Newspack_Ads_Model::$ad_ids as $unique_id => $ad_unit ) : ?>
 					<?php if ( $ad_unit['responsive'] ) : ?>
 						<?php foreach ( $ad_unit['sizes'] as $size ) : ?>
-							googletag.defineSlot('/<?php echo esc_attr( $network_code ); ?>/<?php echo esc_attr( $ad_unit['code'] ); ?>', [ [ <?php echo absint( $size[0] ); ?>, <?php echo absint( $size[1] ); ?> ] ], 'div-gpt-<?php echo esc_attr( $ad_unit['code'] ); ?>-<?php echo esc_attr( $unique_id ); ?>-<?php echo absint( $size[0] ); ?>x<?php echo absint( $size[1] ); ?>').addService(googletag.pubads());
+							ad_units['<?php echo esc_attr( $ad_unit['code'] ); ?>'] = googletag.defineSlot('/<?php echo esc_attr( $network_code ); ?>/<?php echo esc_attr( $ad_unit['code'] ); ?>', [ [ <?php echo absint( $size[0] ); ?>, <?php echo absint( $size[1] ); ?> ] ], 'div-gpt-<?php echo esc_attr( $ad_unit['code'] ); ?>-<?php echo esc_attr( $unique_id ); ?>-<?php echo absint( $size[0] ); ?>x<?php echo absint( $size[1] ); ?>').addService(googletag.pubads());
 						<?php endforeach; ?>
 					<?php else : ?>
-						googletag.defineSlot('/<?php echo esc_attr( $network_code ); ?>/<?php echo esc_attr( $ad_unit['code'] ); ?>', [ <?php echo esc_attr( implode( ',', $formatted_sizes[ $unique_id ] ) ); ?> ], 'div-gpt-ad-<?php echo esc_attr( $unique_id ); ?>-0').addService(googletag.pubads());
+						ad_units['<?php echo esc_attr( $ad_unit['code'] ); ?>'] = googletag.defineSlot('/<?php echo esc_attr( $network_code ); ?>/<?php echo esc_attr( $ad_unit['code'] ); ?>', [ <?php echo esc_attr( implode( ',', $formatted_sizes[ $unique_id ] ) ); ?> ], 'div-gpt-ad-<?php echo esc_attr( $unique_id ); ?>-0').addService(googletag.pubads());
+					<?php endif; ?>
+
+					<?php $targeting = apply_filters( 'newspack_ads_ad_targeting', [], $ad_unit ); ?>
+					<?php if ( ! empty( $targeting ) ) : ?>
+						<?php foreach ( $targeting as $key => $val ) : ?>
+							ad_units['<?php echo esc_attr( $ad_unit['code'] ); ?>'].setTargeting( '<?php echo esc_attr( $key ); ?>', '<?php echo esc_attr( $val ); ?>' );
+						<?php endforeach; ?>
 					<?php endif; ?>
 				<?php endforeach; ?>
 				googletag.pubads().enableSingleRequest();

--- a/includes/class-newspack-ads-blocks.php
+++ b/includes/class-newspack-ads-blocks.php
@@ -176,16 +176,16 @@ class Newspack_Ads_Blocks {
 				<?php foreach ( Newspack_Ads_Model::$ad_ids as $unique_id => $ad_unit ) : ?>
 					<?php if ( $ad_unit['responsive'] ) : ?>
 						<?php foreach ( $ad_unit['sizes'] as $size ) : ?>
-							ad_units['<?php echo esc_attr( $ad_unit['code'] ); ?>'] = googletag.defineSlot('/<?php echo esc_attr( $network_code ); ?>/<?php echo esc_attr( $ad_unit['code'] ); ?>', [ [ <?php echo absint( $size[0] ); ?>, <?php echo absint( $size[1] ); ?> ] ], 'div-gpt-<?php echo esc_attr( $ad_unit['code'] ); ?>-<?php echo esc_attr( $unique_id ); ?>-<?php echo absint( $size[0] ); ?>x<?php echo absint( $size[1] ); ?>').addService(googletag.pubads());
+							ad_units['<?php echo esc_attr( $ad_unit['name'] ); ?>'] = googletag.defineSlot('/<?php echo esc_attr( $network_code ); ?>/<?php echo esc_attr( $ad_unit['code'] ); ?>', [ [ <?php echo absint( $size[0] ); ?>, <?php echo absint( $size[1] ); ?> ] ], 'div-gpt-<?php echo esc_attr( $ad_unit['code'] ); ?>-<?php echo esc_attr( $unique_id ); ?>-<?php echo absint( $size[0] ); ?>x<?php echo absint( $size[1] ); ?>').addService(googletag.pubads());
 						<?php endforeach; ?>
 					<?php else : ?>
-						ad_units['<?php echo esc_attr( $ad_unit['code'] ); ?>'] = googletag.defineSlot('/<?php echo esc_attr( $network_code ); ?>/<?php echo esc_attr( $ad_unit['code'] ); ?>', [ <?php echo esc_attr( implode( ',', $formatted_sizes[ $unique_id ] ) ); ?> ], 'div-gpt-ad-<?php echo esc_attr( $unique_id ); ?>-0').addService(googletag.pubads());
+						ad_units['<?php echo esc_attr( $ad_unit['name'] ); ?>'] = googletag.defineSlot('/<?php echo esc_attr( $network_code ); ?>/<?php echo esc_attr( $ad_unit['code'] ); ?>', [ <?php echo esc_attr( implode( ',', $formatted_sizes[ $unique_id ] ) ); ?> ], 'div-gpt-ad-<?php echo esc_attr( $unique_id ); ?>-0').addService(googletag.pubads());
 					<?php endif; ?>
 
 					<?php $targeting = apply_filters( 'newspack_ads_ad_targeting', [], $ad_unit ); ?>
 					<?php if ( ! empty( $targeting ) ) : ?>
 						<?php foreach ( $targeting as $key => $val ) : ?>
-							ad_units['<?php echo esc_attr( $ad_unit['code'] ); ?>'].setTargeting( '<?php echo esc_attr( $key ); ?>', '<?php echo esc_attr( $val ); ?>' );
+							ad_units['<?php echo esc_attr( $ad_unit['name'] ); ?>'].setTargeting( '<?php echo esc_attr( $key ); ?>', '<?php echo esc_attr( $val ); ?>' );
 						<?php endforeach; ?>
 					<?php endif; ?>
 				<?php endforeach; ?>


### PR DESCRIPTION
Part of https://github.com/Automattic/newspack-issues/issues/167

This PR adds support for adding targeting to ad units via a filter. Targeting is arbitrary key->val pairs when initializing an ad and can be used in GAM to fine-tune which creatives get delivered where.

In the future if other publishers want targeting, we can add UI for it to the ad management screens, but with little demand this should work fine.

To test:
1. Add the following code snippet somewhere:
```
add_filter( 'newspack_ads_ad_targeting', function( $targeting ) {
    $targeting['foo'] = 'bar';
    return $targeting;
} );
```
1 (alternate version). Get the custom plugin source [here](https://github.com/Automattic/newspack-issues/issues/167#issuecomment-622040752) and use the visual interface for adding targeting.
2. Examine the page source. In the non-AMP ads code you should see something like:
```
ad_units['banner_home_middle'] = googletag.defineSlot('/65246486/banner_home_middle', [ [ 300, 50 ] ], 'div-gpt-banner_home_middle-5eab192c2a166-300x50').addService(googletag.pubads());
ad_units['banner_home_middle'].setTargeting( 'foo', 'bar' );
```
