### PR TITLE
Add filter for toggling initial ad load off/on

### DIFF
--- a/includes/class-newspack-ads-blocks.php
+++ b/includes/class-newspack-ads-blocks.php
@@ -189,6 +189,9 @@ class Newspack_Ads_Blocks {
 						<?php endforeach; ?>
 					<?php endif; ?>
 				<?php endforeach; ?>
+				<?php if ( apply_filters( 'newspack_ads_disable_gtag_initial_load', false ) ) : ?>
+					googletag.pubads().disableInitialLoad();
+				<?php endif; ?>
 				googletag.pubads().enableSingleRequest();
 				googletag.enableServices();
 				<?php foreach ( Newspack_Ads_Model::$ad_ids as $unique_id => $ad_unit ) : ?>


### PR DESCRIPTION
This PR adds a filter for disabling the ad initial load. Disabling the ads initial load is required for header bidding, so that bids can be fetched before the ad is displayed. This filter shouldn't affect anything unless it's toggled off using a filter.

### To test:
1. Add the following code snippet somewhere:
```
add_filter( 'newspack_ads_disable_gtag_initial_load', '__return_true' );
```
2. Visit a page with an ad. Observe no ad is displayed:
<img width="1054" alt="Screen Shot 2020-06-04 at 10 33 50 AM" src="https://user-images.githubusercontent.com/7317227/83791677-e6ea5c00-a64e-11ea-909e-34b10e1b2e9b.png">
3. Open the browser JS console. Run `googletag.pubads().refresh()` in the console. Observe the ad(s) render:
<img width="1490" alt="Screen Shot 2020-06-04 at 10 34 51 AM" src="https://user-images.githubusercontent.com/7317227/83791787-100aec80-a64f-11ea-9d67-22dc6f6b98b9.png">
4. Remove the code snippet. Ads should work normally as before.