### PR TITLE
Lazy load ads in non-AMP mode

### DIFF
--- a/includes/class-newspack-ads-blocks.php
+++ b/includes/class-newspack-ads-blocks.php
@@ -193,6 +193,11 @@ class Newspack_Ads_Blocks {
 					googletag.pubads().disableInitialLoad();
 				<?php endif; ?>
 				googletag.pubads().enableSingleRequest();
+				googletag.pubads().enableLazyLoad( {
+					fetchMarginPercent: 500,   // Fetch slots within 5 viewports.
+					renderMarginPercent: 200,  // Render slots within 2 viewports.
+					mobileScaling: 2.0         // Double the above values on mobile.
+				} );
 				googletag.enableServices();
 				<?php foreach ( Newspack_Ads_Model::$ad_ids as $unique_id => $ad_unit ) : ?>
 					<?php if ( $ad_unit['responsive'] ) : ?>


### PR DESCRIPTION
This PR enables lazy loading for GAM ads in non-AMP mode.

I think lazy loading makes sense to do across all sites, since rendering ads that never get seen is not super great for a variety of reasons. In AMP mode lazy loading is automatic, since ads only render once they're in the viewport, so no further tweaks should be necessary for AMP.

These params are the ones BDN has been using for a while, so it seems like a sensible default starting point. We can tweak them further in the future if we get new info/data that says they should be tweaked.

To test:
1. Create a post with a custom HTML block at the top: `<div style="height:900vh"></div>` or add many screen lengths of lorem ipsum.
2. Add an ad block at the bottom.
3. View the post on the frontend. Using the browser's element inspector, find the ad unit and confirm nothing is rendered inside it.
<img width="1653" alt="Screen Shot 2020-07-01 at 11 07 28 AM" src="https://user-images.githubusercontent.com/7317227/86285845-38c4ca00-bb9a-11ea-8e2f-622b970a68a7.png">
4. Scroll down towards the ad unit. Observe the ad iframe gets created when you're near the ad unit.
<img width="1624" alt="Screen Shot 2020-07-01 at 11 07 54 AM" src="https://user-images.githubusercontent.com/7317227/86285854-3febd800-bb9a-11ea-985b-74215c4067f6.png">
