### PR TITLE
Don't define slots that aren't present, refactor non-AMP GAM script

### DIFF
--- a/includes/class-newspack-ads-blocks.php
+++ b/includes/class-newspack-ads-blocks.php
@@ -151,59 +151,75 @@ class Newspack_Ads_Blocks {
 
 		$network_code = Newspack_Ads_Model::get_network_code( 'google_ad_manager' );
 
-		$formatted_sizes = [];
+		$prepared_unit_data = [];
 		foreach ( Newspack_Ads_Model::$ad_ids as $unique_id => $ad_unit ) {
-			$sizes = $ad_unit['sizes'];
-			usort(
-				$sizes,
-				function( $a, $b ) {
-					return $a[0] > $b[0] ? -1 : 1;
+			$ad_targeting = apply_filters( 'newspack_ads_ad_targeting', [], $ad_unit );
+
+			if ( $ad_unit['responsive'] ) {
+				foreach ( $ad_unit['sizes'] as $size ) {
+					$container_id = esc_attr( 'div-gpt-' . $ad_unit['code'] . '-' . $unique_id . '-' . absint( $size[0] ) . 'x' . absint( $size[1] ) );
+
+					$prepared_unit_data[ $container_id ] = [
+						'name'      => esc_attr( $ad_unit['name'] ),
+						'code'      => esc_attr( $ad_unit['code'] ),
+						'sizes'     => [ $size ],
+						'targeting' => $ad_targeting,
+					];
 				}
-			);
-			$formatted_sizes[ $unique_id ] = array_map(
-				function( $item ) {
-					return sprintf( '[%d,%d]', $item[0], $item[1] );
-				},
-				$sizes
-			);
+			} else {
+				$container_id = esc_attr( 'div-gpt-ad-' . $unique_id . '-0' );
+
+				$prepared_unit_data[ $container_id ] = [
+					'name'      => esc_attr( $ad_unit['name'] ),
+					'code'      => esc_attr( $ad_unit['code'] ),
+					'sizes'     => $ad_unit['sizes'],
+					'targeting' => $ad_targeting,
+				];
+			}
 		}
+
+		$ad_config = [
+			'network_code'         => esc_attr( $network_code ),
+			'disable_initial_load' => (bool) apply_filters( 'newspack_ads_disable_gtag_initial_load', false ),
+		];
 
 		ob_start();
 		?>
 		<script>
 			googletag.cmd.push(function() {
-				var ad_units = [];
-				<?php foreach ( Newspack_Ads_Model::$ad_ids as $unique_id => $ad_unit ) : ?>
-					<?php if ( $ad_unit['responsive'] ) : ?>
-						<?php foreach ( $ad_unit['sizes'] as $size ) : ?>
-							ad_units['<?php echo esc_attr( $ad_unit['name'] ); ?>'] = googletag.defineSlot('/<?php echo esc_attr( $network_code ); ?>/<?php echo esc_attr( $ad_unit['code'] ); ?>', [ [ <?php echo absint( $size[0] ); ?>, <?php echo absint( $size[1] ); ?> ] ], 'div-gpt-<?php echo esc_attr( $ad_unit['code'] ); ?>-<?php echo esc_attr( $unique_id ); ?>-<?php echo absint( $size[0] ); ?>x<?php echo absint( $size[1] ); ?>').addService(googletag.pubads());
-						<?php endforeach; ?>
-					<?php else : ?>
-						ad_units['<?php echo esc_attr( $ad_unit['name'] ); ?>'] = googletag.defineSlot('/<?php echo esc_attr( $network_code ); ?>/<?php echo esc_attr( $ad_unit['code'] ); ?>', [ <?php echo esc_attr( implode( ',', $formatted_sizes[ $unique_id ] ) ); ?> ], 'div-gpt-ad-<?php echo esc_attr( $unique_id ); ?>-0').addService(googletag.pubads());
-					<?php endif; ?>
+				var ad_config        = <?php echo wp_json_encode( $ad_config ); ?>;
+				var all_ad_units     = <?php echo wp_json_encode( $prepared_unit_data ); ?>;
+				var defined_ad_units = {};
 
-					<?php $targeting = apply_filters( 'newspack_ads_ad_targeting', [], $ad_unit ); ?>
-					<?php if ( ! empty( $targeting ) ) : ?>
-						<?php foreach ( $targeting as $key => $val ) : ?>
-							ad_units['<?php echo esc_attr( $ad_unit['name'] ); ?>'].setTargeting( '<?php echo esc_attr( $key ); ?>', '<?php echo esc_attr( $val ); ?>' );
-						<?php endforeach; ?>
-					<?php endif; ?>
-				<?php endforeach; ?>
-				<?php if ( apply_filters( 'newspack_ads_disable_gtag_initial_load', false ) ) : ?>
+				for ( var container_id in all_ad_units ) {
+					var ad_unit = all_ad_units[ container_id ];
+
+					// Only set up ad units that are present on the page.
+					if ( ! document.querySelector( '#' + container_id ) ) {
+						continue;
+					}
+
+					defined_ad_units[ container_id ] = googletag.defineSlot(
+						'/' + ad_config['network_code'] + '/' + ad_unit['code'],
+						ad_unit['sizes'],
+						container_id
+					).addService( googletag.pubads() );
+
+					for ( var target_key in ad_unit['targeting'] ) {
+						defined_ad_units[ container_id ].setTargeting( target_key, ad_unit['targeting'][ target_key ] );
+					}
+				}
+
+				if ( ad_config['disable_initial_load'] ) {
 					googletag.pubads().disableInitialLoad();
-				<?php endif; ?>
+				}
 				googletag.pubads().enableSingleRequest();
 				googletag.enableServices();
-				<?php foreach ( Newspack_Ads_Model::$ad_ids as $unique_id => $ad_unit ) : ?>
-					<?php if ( $ad_unit['responsive'] ) : ?>
-						<?php foreach ( $ad_unit['sizes'] as $size ) : ?>
-						googletag.display('div-gpt-<?php echo esc_attr( $ad_unit['code'] ); ?>-<?php echo esc_attr( $unique_id ); ?>-<?php echo absint( $size[0] ); ?>x<?php echo absint( $size[1] ); ?>');
-						<?php endforeach; ?>
-					<?php else : ?>
-						googletag.display('div-gpt-ad-<?php echo esc_attr( $unique_id ); ?>-0');
-					<?php endif; ?>
-				<?php endforeach; ?>
-			});
+
+				for ( var container_id in defined_ad_units ) {
+					googletag.display( container_id );
+				}
+			} );
 		</script>
 		<?php
 		$code = ob_get_clean();


### PR DESCRIPTION
The main purpose of this PR is to add a fix that will only define ad slots for ad containers that exist on the current page. This will prevent issues with and further optimize header bidding, ad delivery, etc. [That specific change is right here.](https://github.com/Automattic/newspack-ads/compare/fix/ad-slots?expand=1#diff-f00ee91a5e4c5891df399ba5eae186dcR198)

In order to make this change I had to do quite a bit of refactoring, because the special handling of responsive vs. regular ad units and the mixing of JS and PHP code made the codebase super difficult to work with. I've refactored the code in two ways:
1. Separate the PHP and JS from each other.
2. Within the JS section, simplify things to treat every ad slot the same way regardless of whether it's a responsive or regular slot.

It's difficult to follow along in the GitHub diff, but if you examine `Newspack_Ads_Blocks::insert_google_ad_manager_footer_code()` on its own, it should look much more straightforward than the previous implementation.

This is mostly a note for myself: BDN's Amazon UAM (header bidding) integration code will need to be slightly tweaked after this is merged, but the ad targeting integration and out-of-page-slot integration should continue working with no tweaks required.

### To test:
1. Set up the following ads: a global responsive ad, an ad block and/or widget.
2. Verify ads work nicely in non-AMP mode. There should be no visible changes to ad behavior.
3. (optional) You can view the page source to verify the information is correctly passed from PHP to JS. Check for the `ad_config` and `all_ad_units` variables in the page source.