### PR TITLE
Remove unnecessary, early ad display calls

### DIFF
--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -354,13 +354,12 @@ class Newspack_Ads_Model {
 		$largest = self::largest_ad_size( $sizes );
 
 		$code = sprintf(
-			"<!-- /%s/%s --><div id='div-gpt-ad-%s-0' style='width: %spx; height: %spx;'><script>googletag.cmd.push(function() { googletag.display('div-gpt-ad-%s-0'); });</script></div>",
+			"<!-- /%s/%s --><div id='div-gpt-ad-%s-0' style='width: %spx; height: %spx;'></div>",
 			$network_code,
 			$code,
 			$unique_id,
 			$largest[0],
-			$largest[1],
-			$unique_id
+			$largest[1]
 		);
 		return $code;
 	}
@@ -485,13 +484,12 @@ class Newspack_Ads_Model {
 				);
 			} else {
 				$markup[] = sprintf(
-					'<!-- /%s/%s --><div id="%s" style="width:%dpx;height:%dpx;"><script>googletag.cmd.push(function() { googletag.display("%s"); });</script></div>',
+					'<!-- /%s/%s --><div id="%s" style="width:%dpx;height:%dpx;"></div>',
 					$network_code,
 					$code,
 					$div_id,
 					$width,
-					$height,
-					$div_id
+					$height
 				);
 			}
 		}


### PR DESCRIPTION
This PR fixes some errors that were displayed in the Google Ad Manager console about unknown ad units. The issue was that there were duplicate script tags in the container markup and in the footer script for displaying an ad unit. 

#50 exposed the issue because after that change the container scripts were firing before the ad unit had been defined, but it appears there have always been two competing calls to `googletag.display` - one in the container markup and one in the footer script. This issue shouldn't have caused any problems on any sites, as re-displaying an already displayed ad does nothing.

### To test:
1. Ad an ad unit to a page and visit it in non-AMP mode. In the JS console run `googletag.openConsole()`. Observe errors:
<img width="1119" alt="Screen Shot 2020-07-21 at 10 43 09 AM" src="https://user-images.githubusercontent.com/7317227/88089287-9799b580-cb40-11ea-9037-0a5bf4c3425f.png">

2. Apply this PR. Refresh the page. Observe that ads display and no errors are in the console:
<img width="1386" alt="Screen Shot 2020-07-21 at 10 42 48 AM" src="https://user-images.githubusercontent.com/7317227/88089277-95375b80-cb40-11ea-867e-7cbb673d3260.png">
