### PR TITLE
Automatic responsive ad handling for non-AMP mode.

### DIFF
--- a/includes/class-newspack-ads-blocks.php
+++ b/includes/class-newspack-ads-blocks.php
@@ -208,6 +208,34 @@ class Newspack_Ads_Blocks {
 					for ( var target_key in ad_unit['targeting'] ) {
 						defined_ad_units[ container_id ].setTargeting( target_key, ad_unit['targeting'][ target_key ] );
 					}
+
+					/** 
+					 * Configure responsive ads.
+					 * Ads wider than the viewport should not show.
+					 */
+
+					// Get all of the unique ad widths.
+					var unique_widths = {};
+					ad_unit['sizes'].forEach( function( size ) {
+						unique_widths[ size[0] ] = [];
+					} );
+
+					// For each width, get all of the sizes equal-to-or-smaller than it. 
+					for ( width in unique_widths ) {
+						ad_unit['sizes'].forEach( function( size ) {
+							if ( size[0] <= width ) {
+								unique_widths[ width ].push( size );
+							}
+						} );
+					}
+
+					// Build and set the responsive mapping.
+					// @see https://developers.google.com/doubleclick-gpt/guides/ad-sizes#responsive_ads
+					var mapping = googletag.sizeMapping();
+					for ( width in unique_widths ) {
+						mapping.addSize( [ parseInt( width ), 0 ], unique_widths[ width ] );
+					}
+					defined_ad_units[ container_id ].defineSizeMapping( mapping.build() );
 				}
 
 				if ( ad_config['disable_initial_load'] ) {

--- a/src/blocks/ad-unit/view.php
+++ b/src/blocks/ad-unit/view.php
@@ -70,6 +70,7 @@ function newspack_ads_register_ad_unit() {
 				),
 			),
 			'render_callback' => 'newspack_ads_render_block_ad_unit',
+			'supports'        => [],
 		)
 	);
 }


### PR DESCRIPTION
Closes #51 

This PR adds easy, no-config-necessary handling for responsive ads. It does this by making each unique ad size a responsive breakpoint, so that each ad size will only show on screens equal-to-or-wider than the ad size. This should work nicely for the vast majority of ad units with no further work on the publisher's part.

For example, an ad unit with sizes `[728, 90]` and `[320, 50]` will show ads of both sizes on screens >= `728px` and only `320x50` ads on screens smaller than `728px`.

### To test:
1. Configure an ad unit with multiple widths and add it to a post.
<img width="411" alt="Screen Shot 2020-07-30 at 7 04 36 AM" src="https://user-images.githubusercontent.com/7317227/88932474-f9d67280-d232-11ea-9398-3adb109a843d.png">
2. Visit the post with desktop screen size and confirm the large ad gets displayed (the small ad will also get sometimes displayed).
<img width="601" alt="Screen Shot 2020-07-30 at 7 06 43 AM" src="https://user-images.githubusercontent.com/7317227/88932791-6487ae00-d233-11ea-8de4-6eff1bac4f38.png">
3. Shrink the screen size down. Refresh the page. Confirm only the small ad gets displayed.
<img width="571" alt="Screen Shot 2020-07-30 at 7 07 15 AM" src="https://user-images.githubusercontent.com/7317227/88932797-65b8db00-d233-11ea-9a36-287b039884a8.png">

Note: Also added `supports` tag to prevent PHP notices on Gutenberg 8.6.0.
