### PR TITLE
Dont show ads on viewports smaller than smallest ad size

### DIFF
--- a/includes/class-newspack-ads-blocks.php
+++ b/includes/class-newspack-ads-blocks.php
@@ -235,12 +235,15 @@ class Newspack_Ads_Blocks {
 					for ( width in unique_widths ) {
 						mapping.addSize( [ parseInt( width ), 0 ], unique_widths[ width ] );
 					}
+					// On viewports smaller than the smallest ad size, don't show any ads.
+					mapping.addSize( [0, 0], [] );
 					defined_ad_units[ container_id ].defineSizeMapping( mapping.build() );
 				}
 
 				if ( ad_config['disable_initial_load'] ) {
 					googletag.pubads().disableInitialLoad();
 				}
+				googletag.pubads().collapseEmptyDivs();
 				googletag.pubads().enableSingleRequest();
 				googletag.pubads().enableLazyLoad( {
 					fetchMarginPercent: 500,   // Fetch slots within 5 viewports.


### PR DESCRIPTION
This PR fixes an issue I noticed after #58 had already been merged. There was one edge-case I hadn't thought of: when the viewport is smaller than the smallest ad size. This PR makes it so that if an ad unit only has sizes available wider than the viewport width, that unit will not show any ads. Showing no ads is preferable to showing cut-off ads, which would impact ad viewability metrics.

## To test:
1. Set up an ad with a size greater than 320px wide and add it to a post in an ad block:

<img width="501" alt="Screen Shot 2020-07-30 at 11 44 11 AM" src="https://user-images.githubusercontent.com/7317227/88961523-028e6f00-d25a-11ea-9f3d-429ec8248241.png">

2. Before applying this patch, view the post using a screen smaller than the ad width. Observe ad is cut off:

<img width="549" alt="Screen Shot 2020-07-30 at 11 35 59 AM" src="https://user-images.githubusercontent.com/7317227/88961658-2d78c300-d25a-11ea-9f5d-242230521f7c.png">

3. Apply patch. Refresh the page. Observe ad is simply not shown, and there isn't a big empty space where the ad would have gone:

<img width="505" alt="Screen Shot 2020-07-30 at 11 37 49 AM" src="https://user-images.githubusercontent.com/7317227/88961770-5436f980-d25a-11ea-8f52-e522301bc2d5.png">

4. Make the viewport bigger than the ad size. Refresh the page. Observe ad loads nicely:

<img width="521" alt="Screen Shot 2020-07-30 at 11 38 15 AM" src="https://user-images.githubusercontent.com/7317227/88961819-66189c80-d25a-11ea-91d4-896cdbf35010.png">

