### PR TITLE
Remove redundant responsive ad handling

### DIFF
--- a/includes/class-newspack-ads-blocks.php
+++ b/includes/class-newspack-ads-blocks.php
@@ -155,27 +155,14 @@ class Newspack_Ads_Blocks {
 		foreach ( Newspack_Ads_Model::$ad_ids as $unique_id => $ad_unit ) {
 			$ad_targeting = apply_filters( 'newspack_ads_ad_targeting', [], $ad_unit );
 
-			if ( $ad_unit['responsive'] ) {
-				foreach ( $ad_unit['sizes'] as $size ) {
-					$container_id = esc_attr( 'div-gpt-' . $ad_unit['code'] . '-' . $unique_id . '-' . absint( $size[0] ) . 'x' . absint( $size[1] ) );
+			$container_id = esc_attr( 'div-gpt-ad-' . $unique_id . '-0' );
 
-					$prepared_unit_data[ $container_id ] = [
-						'name'      => esc_attr( $ad_unit['name'] ),
-						'code'      => esc_attr( $ad_unit['code'] ),
-						'sizes'     => [ $size ],
-						'targeting' => $ad_targeting,
-					];
-				}
-			} else {
-				$container_id = esc_attr( 'div-gpt-ad-' . $unique_id . '-0' );
-
-				$prepared_unit_data[ $container_id ] = [
-					'name'      => esc_attr( $ad_unit['name'] ),
-					'code'      => esc_attr( $ad_unit['code'] ),
-					'sizes'     => $ad_unit['sizes'],
-					'targeting' => $ad_targeting,
-				];
-			}
+			$prepared_unit_data[ $container_id ] = [
+				'name'      => esc_attr( $ad_unit['name'] ),
+				'code'      => esc_attr( $ad_unit['code'] ),
+				'sizes'     => $ad_unit['sizes'],
+				'targeting' => $ad_targeting,
+			];
 		}
 
 		$ad_config = [

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -347,19 +347,11 @@ class Newspack_Ads_Model {
 
 		self::$ad_ids[ $unique_id ] = $ad_unit;
 
-		if ( $ad_unit['responsive'] ) {
-			return self::ad_elements_for_sizes( $ad_unit, $unique_id );
-		}
-
-		$largest = self::largest_ad_size( $sizes );
-
 		$code = sprintf(
-			"<!-- /%s/%s --><div id='div-gpt-ad-%s-0' style='width: %spx; height: %spx;'></div>",
+			"<!-- /%s/%s --><div id='div-gpt-ad-%s-0'></div>",
 			$network_code,
 			$code,
-			$unique_id,
-			$largest[0],
-			$largest[1]
+			$unique_id
 		);
 		return $code;
 	}


### PR DESCRIPTION
After #58 and #59, all non-AMP ads have automatic responsive ad handling using only one ad container. This removes the need for the multiple ad containers approach we were doing before. 

The multiple ad container approach where we show/hide the ad units using a media query works well in AMP, where there is no alternative to it. In non-AMP mode it is not the best-practices way of making responsive ads (and appears to be causing issues with BDN's ad targeting).

This PR removes the now unnecessary multiple containers for the global ads and makes them rely fully on the ad config.

## To test:

1. Create an ad unit with multiple sizes.

<img width="427" alt="Screen Shot 2020-08-14 at 11 41 12 AM" src="https://user-images.githubusercontent.com/7317227/90282645-8f712500-de23-11ea-8bfe-58b386c5d426.png">

2. Set it as a global ad.

<img width="427" alt="Screen Shot 2020-08-14 at 11 41 26 AM" src="https://user-images.githubusercontent.com/7317227/90282651-913ae880-de23-11ea-933f-ff85b5231049.png">

3. View the ad on desktop screen size in non-AMP mode. You should see the small or the big ad.

<img width="528" alt="Screen Shot 2020-08-14 at 11 41 39 AM" src="https://user-images.githubusercontent.com/7317227/90282660-939d4280-de23-11ea-878d-5d22796d7c41.png">

4. Shrink the screen to mobile size. Refresh the page. You should only see the small ad.

<img width="571" alt="Screen Shot 2020-08-14 at 11 41 50 AM" src="https://user-images.githubusercontent.com/7317227/90282665-95ff9c80-de23-11ea-8cb2-1f3d7f560dcc.png">

5. Shrink the screen even smaller. Refresh the page. You should see no ad and no space where an ad would go.

<img width="274" alt="Screen Shot 2020-08-14 at 11 44 14 AM" src="https://user-images.githubusercontent.com/7317227/90282666-98fa8d00-de23-11ea-9634-fb556d07a79b.png">

