### PR TITLE
Optimize amp-ads for viewability.

### DIFF
--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -378,7 +378,7 @@ class Newspack_Ads_Model {
 		$largest = self::largest_ad_size( $sizes );
 
 		$code = sprintf(
-			'<amp-ad width=%s height=%s type="doubleclick" data-slot="/%s/%s"></amp-ad>',
+			'<amp-ad width=%s height=%s type="doubleclick" data-slot="/%s/%s" data-loading-strategy="prefer-viewability-over-views"></amp-ad>',
 			$largest[0],
 			$largest[1],
 			$network_code,
@@ -467,7 +467,7 @@ class Newspack_Ads_Model {
 
 			if ( $is_amp ) {
 				$markup[] = sprintf(
-					'<div id="%s"><amp-ad width="%dpx" height="%dpx" type="doubleclick" data-slot="/%s/%s"></amp-ad></div>',
+					'<div id="%s"><amp-ad width="%dpx" height="%dpx" type="doubleclick" data-slot="/%s/%s" data-loading-strategy="prefer-viewability-over-views"></amp-ad></div>',
 					$div_id,
 					$width,
 					$height,


### PR DESCRIPTION
The `data-loading-strategy` attribute controls how eagerly (how many viewports) amp-ads load. See https://amp.dev/documentation/components/amp-ad/#data-loading-strategy-(optional)

This is important because if we load ads a user never scrolls to, these ads are never viewable and overall yield will suffer as a result. Unfortunately the default value is sub-optimal.

This article - https://medium.com/ampfuel/optimize-your-amp-pages-for-high-ad-viewability-rate-or-high-ads-served-311f6b539c73 - does a great job explaining the optimal value to use (and why). Fortunately the AMP runtime provides a constant we can use: `data-loading-strategy="prefer-viewability-over-views"`. This at the moment is 1.25 but may be fine tuned in the future if further testing reveals the need for a different number.

This PR ads the attribute by default with the expectation that it will improve yield for all users; let me know if you prefer this be controllable via a filter or if you plan on doing something broader like https://github.com/Automattic/newspack-ads/issues/55.