### PR TITLE
Update argument order in implode function

### DIFF
--- a/includes/class-newspack-ads-blocks.php
+++ b/includes/class-newspack-ads-blocks.php
@@ -78,7 +78,7 @@ class Newspack_Ads_Blocks {
 		if ( isset( $attributes['className'] ) ) {
 			array_push( $classes, $attributes['className'] );
 		}
-		return implode( $classes, ' ' );
+		return implode( ' ', $classes );
 	}
 
 	/**


### PR DESCRIPTION
The argument order has been updated in PHP, the old argument order is causing this warning to be logged:

```
PHP Deprecated:  implode(): Passing glue string after array is deprecated. Swap the parameters in /wordpress/plugins/newspack-ads/1.6.1/includes/class-newspack-ads-blocks.php on line 81
```

## How to test

1. On `master`, see that the warning is logged
2. Switch to this branch, see that the warning is logged no more
3. Everything should work as expected
