### PR TITLE
Add common ad targeting settings to ad units

### DIFF
--- a/includes/class-newspack-ads-blocks.php
+++ b/includes/class-newspack-ads-blocks.php
@@ -153,7 +153,7 @@ class Newspack_Ads_Blocks {
 
 		$prepared_unit_data = [];
 		foreach ( Newspack_Ads_Model::$ad_ids as $unique_id => $ad_unit ) {
-			$ad_targeting = apply_filters( 'newspack_ads_ad_targeting', [], $ad_unit );
+			$ad_targeting = Newspack_Ads_Model::get_ad_targeting( $ad_unit );
 
 			$container_id = esc_attr( 'div-gpt-ad-' . $unique_id . '-0' );
 

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -539,10 +539,10 @@ class Newspack_Ads_Model {
 			$targeting['ID'] = get_the_ID();
 
 			// Add the category slugs to targeting on category archives.
-		} elseif ( 'WP_Term' === get_class( get_queried_object() ) ) {
-			$term_object = get_queried_object();
-			if ( 'category' === $term_object->taxonomy ) {
-				$targeting['category'] = [ sanitize_text_field( $term_object->slug ) ];
+		} elseif ( get_queried_object() ) {
+			$queried_object = get_queried_object();
+			if ( 'WP_Term' === get_class( $queried_object ) && 'category' === $queried_object->taxonomy ) {
+				$targeting['category'] = [ sanitize_text_field( $queried_object->slug ) ];
 			}
 		}
 


### PR DESCRIPTION
This PR adds some common ad targeting to all ad units. This enables sites to fine-tune their ad delivery in Google Ad Manager:

- It adds category targeting for singles and category archives. This will let people target ads to only deliver on certain categories.
- It adds post/page slug and ID targeting for singles. This will let people target ads to only deliver on certain posts/pages or on the homepage.

These sort of ads are generally more lucrative for publishers than sitewide ads, because publishers can charge a premium on them, and at least a couple of our publishers have been selling ads in this way already.

### To test:

1. Configure and set a global ad unit.
2. With the network inspector open and **AMP enabled**, view a post in a category. Find the network request for the ad unit, scroll down to the `scp` query parameter, and observe category, slug, and ID ad targeting parameters were passed in the ad request:

<img width="1599" alt="Screen Shot 2020-09-18 at 9 57 30 AM" src="https://user-images.githubusercontent.com/7317227/93625912-85e55a80-f997-11ea-85a5-00aea78f863b.png">

3. With the network inspector open and **AMP disabled**, view a post in a category. Find the network request for the ad unit, scroll down to the `prev_scp` query parameter, and observe category, slug, and ID ad targeting parameters were passed in the ad request:

<img width="1605" alt="Screen Shot 2020-09-18 at 9 57 49 AM" src="https://user-images.githubusercontent.com/7317227/93625869-79f99880-f997-11ea-9c2f-04dfd707c9c5.png">

4. Configure and set an ad block.
5. Repeat steps 2 and 3 for the ad block:

<img width="1660" alt="Screen Shot 2020-09-18 at 9 59 19 AM" src="https://user-images.githubusercontent.com/7317227/93625940-8f6ec280-f997-11ea-8f24-8254e0a44217.png">
<img width="1664" alt="Screen Shot 2020-09-18 at 9 56 44 AM" src="https://user-images.githubusercontent.com/7317227/93625956-94337680-f997-11ea-90c9-95bf46f8f6b1.png">
