### PR TITLE
Update block icon style and colour

### DIFF
--- a/src/blocks/ad-unit/index.js
+++ b/src/blocks/ad-unit/index.js
@@ -22,7 +22,11 @@ export const title = __( 'Ad Unit' );
 /* From https://material.io/tools/icons */
 export const icon = (
 	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-		<Path d="M21 3H3c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-9 9H3V5h9v7z" />
+		<Path d="M0 0h24v24H0z" fill="none" />
+		<Path
+			d="M21 3H3c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H3V5h18v14zM4 6h9v7H4z"
+			fill="#36f"
+		/>
 	</SVG>
 );
 export const settings = {


### PR DESCRIPTION
Using Material's outlined instead of filled and add Newspack Blue colour to it.

The idea is to have our blue, just like Jetpack and WooCommerce do with respectively their green and purple.

![Screenshot 2020-10-29 at 16 22 16](https://user-images.githubusercontent.com/177929/97602272-040b3700-1a03-11eb-9d57-0b56d586a1ac.png)
