### PR TITLE
Improved responsive AMP ad handling using multi-size

### DIFF
--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -412,7 +412,7 @@ class Newspack_Ads_Model {
 		// As a heuristic, each ad slot can safely display ads 200px narrower or less than the slot's width.
 		// e.g. for the following setup: [[900,200], [750,200]], 
 		// We can display [[900,200], [750,200]] on viewports >= 900px and [[750,200]] on viewports < 900px.
-		$width_difference_max = 200;
+		$width_difference_max = apply_filters( 'newspack_ads_multisize_size_difference_max', 200, $ad_unit );
 		$all_ad_sizes         = [];
 		foreach ( $widths as $ad_width ) {
 			$valid_ad_sizes = [];
@@ -425,6 +425,7 @@ class Newspack_Ads_Model {
 
 			$all_ad_sizes[] = $valid_ad_sizes;
 		}
+		$all_ad_sizes = apply_filters( 'newspack_ads_multisize_ad_sizes', $all_ad_sizes, $ad_unit );
 
 		// Generate an array of media query data, with a likely min and max width for each size.
 		$media_queries = [];

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -373,7 +373,7 @@ class Newspack_Ads_Model {
 		}
 
 		if ( $ad_unit['responsive'] ) {
-			return self::ad_elements_for_sizes( $ad_unit, $unique_id, true );
+			return self::ad_elements_for_sizes( $ad_unit, $unique_id );
 		}
 
 		$largest = self::largest_ad_size( $sizes );


### PR DESCRIPTION
Closes #87 

This PR modifies the way we're generating responsive AMP ads to fix some issues when there are multiple ad sizes defined with the same width. See the example in #87 to better understand what I mean.

**Note**: I've removed the non-AMP parts out of `ad_elements_for_sizes`. Those bits were vestigial because they and aren't useful with the approach we've been using for non-AMP ads and that function never gets called in non-AMP mode.

## To test

(Ping me on Slack if you need specific GAM codes for these ads)

**1.** Use AMP Standard mode. Set up an ad with `300x250` and `300x50` sizes and assign it as a global header or footer ad:

<img width="406" alt="Screen Shot 2021-01-07 at 11 00 03 AM" src="https://user-images.githubusercontent.com/7317227/103936253-0a412200-50dc-11eb-9ed3-375f0f31fcca.png">

**2.** On the frontend, observe the network request that the ad makes. In the size param, there should be two sizes. There should only be one `amp-ad` element:

<img width="851" alt="Screen Shot 2021-01-07 at 10 48 57 AM" src="https://user-images.githubusercontent.com/7317227/103936227-03b2aa80-50dc-11eb-9df0-76be01e6ca56.png">

**3.** Set up an ad with `400x50` and `300x250` sizes and assign it as a global header or footer ad:

<img width="401" alt="Screen Shot 2021-01-07 at 11 00 20 AM" src="https://user-images.githubusercontent.com/7317227/103936276-1200c680-50dc-11eb-8c04-73773f68a6c1.png">

**4.** On the frontend, observe the network request that the ad makes. In the size param, there should be three sizes (one auto-generated based on the container size being `400x250`, and the two explicitly defined sizes). There should be two `amp-ad` elements (one for viewports >=400px with both sizes and one for viewports between 300px and 399px with the `300x250` ad):

<img width="802" alt="Screen Shot 2021-01-07 at 11 02 30 AM" src="https://user-images.githubusercontent.com/7317227/103936327-204ee280-50dc-11eb-966a-57a3df315d07.png">

<img width="829" alt="Screen Shot 2021-01-07 at 11 01 39 AM" src="https://user-images.githubusercontent.com/7317227/103936339-23e26980-50dc-11eb-8a02-39741531fd0a.png">

**5.** Set up an ad with `970x90`, `728x90`, and `300x50` sizes and assign it as a global header or footer ad:

<img width="420" alt="Screen Shot 2021-01-07 at 11 27 56 AM" src="https://user-images.githubusercontent.com/7317227/103936345-2644c380-50dc-11eb-86b1-808add3964f5.png">

**6.** On the frontend, there should be three `amp-ad` elements, none of which are multisize (The `970x90` for viewports >= 970px, `728x90` for viewports between 728px and 969px, and `300x50` for viewports between 300 and 727px)

<img width="867" alt="Screen Shot 2021-01-07 at 11 34 07 AM" src="https://user-images.githubusercontent.com/7317227/103936439-45dbec00-50dc-11eb-8806-fb87bbd520eb.png">
