### PR TITLE
Add multisizes to non-responsive AMP ads.

### DIFF
--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -86,7 +86,7 @@ class Newspack_Ads_Model {
 
 			$prepared_ad_unit['ad_code']     = self::code_for_ad_unit( $prepared_ad_unit );
 			$prepared_ad_unit['amp_ad_code'] = self::amp_code_for_ad_unit( $prepared_ad_unit );
-			return $prepared_ad_unit;
+			return apply_filters( 'newspack_ads_ad_unit', $prepared_ad_unit );
 		} else {
 			return new WP_Error(
 				'newspack_no_adspot_found',


### PR DESCRIPTION
This PR addresses an issue where e.g. you set up an ad with sizes `300x250` and `300x600` and use that ad in a block or widget. Currently, only one of those ad sizes will ever be shown. Ideally, *either* of those two ad sizes would be shown. This PR implements this using the multi-size attribute, similar to #95, but much simpler because the ads don't have to be responsive. 

This should be fully backwards-compatible and shouldn't cause any issues on existing ad setups, except where someone may have set up an ad with multiple sizes and forgotten about it because only one size was ever shown. :) 

## To test:
1. Set up an ad with sizes 300x250 and 300x600, or you can use an existing responsive ad you have laying around (like the leaderboards from #95)

2. Assign the ad as a widget. On the frontend, inspect the element and network request and verify that all of the ad sizes are present as a `multi-size` attribute and in the network request (you should also get ads of all sizes if you're using real ad sizes):

<img width="799" alt="Screen Shot 2021-01-18 at 4 15 48 PM" src="https://user-images.githubusercontent.com/7317227/104974163-d0a9ca00-59ab-11eb-9ed7-99a2cc78baa0.png">

<img width="971" alt="Screen Shot 2021-01-18 at 4 17 59 PM" src="https://user-images.githubusercontent.com/7317227/104974156-cc7dac80-59ab-11eb-939f-d883a135e742.png">

3. Add a block with the ad unit. On the frontend, inspect the element and network request and verify that all of the ad sizes are present as a `multi-size` attribute and in the network request (you should also get ads of all sizes if you're using real ad sizes):

<img width="1656" alt="Screen Shot 2021-01-18 at 4 21 07 PM" src="https://user-images.githubusercontent.com/7317227/104974161-d0113380-59ab-11eb-9a32-947009addd18.png">


4. (optional) If you want to verify backwards-compatibility, create an ad with only one size and assign it as a widget or add it as a block. There should be no multi-size, and it should continue working as before.