### PR TITLE
fix: limit multisizes of sticky ads

### DIFF
--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -383,15 +383,19 @@ class Newspack_Ads_Model {
 		$multisizes           = [];
 		foreach ( $sizes as $size ) {
 			$multisize = $size[0] . 'x' . $size[1];
-			if ( $multisize !== $ad_size_as_multisize ) {
+			if (
+				( $multisize !== $ad_size_as_multisize ) &&
+				( ! self::is_sticky( $ad_unit ) || ( self::is_sticky( $ad_unit ) && $size[0] < 600 ) )
+			) {
 				$multisizes[] = $multisize;
 			}
 		}
 		$multisize_attribute = '';
 		if ( count( $multisizes ) ) {
-			$multisize_attribute = sprintf( 
-				'data-multi-size=\'%s\' data-multi-size-validation=\'false\'', 
-				implode( ',', $multisizes ) 
+			$multisize_attribute = sprintf(
+				'data-multi-size=\'%s\' data-multi-size-validation=\'false\'%s',
+				implode( ',', $multisizes ),
+				self::is_sticky( $ad_unit ) ? ' data-override-width=\'600\'' : ''
 			);
 		}
 


### PR DESCRIPTION
After #98, sticky ads are able to show any size, so if you fill the sticky placement with an ad unit that has a large size, it can still possibly show the larger ads even though we're only showing the sticky ads at mobile viewports (< 600px).

This fix checks if the ad unit is being rendered in the sticky placement, and if so, overrides the ad unit dimensions so that it can't display any size larger than 600px. Any sizes smaller than 600px can still be shown according to normal multisize rules.

It's still possible for mobile viewports to render an ad size larger than the viewport, for instance if the ad size is 600x80 and the viewport is 375x812. But it's much easier now to ensure that desktop sizes are never served to mobile devices.

### To test:

1. On `master`, create an ad unit that has at least three sizes: two with widths smaller than 600px, one with a width larger than than 600px, with the primary dimensions of the unit matching the largest size. e.g.
  - 300x75
  - 375x46
  - 780x95
2. View the site front-end in AMP mode. In dev tools, filter network requests by  `?ads`. Inspect the request and look at the Query String Parameters. Note that the `sz` param includes all three sizes, including the large size. If you were to refresh the page enough times in this state, you will eventually see the largest size render:

<img width="264" alt="Screen Shot 2021-02-23 at 4 46 48 PM" src="https://user-images.githubusercontent.com/2230142/108923900-dde35580-75f6-11eb-88b0-6ccb14356f8c.png">

3. Check out this branch and refresh the page. Inspect the request again and now note that the largest size is limited to 600px width via an override:

<img width="256" alt="Screen Shot 2021-02-23 at 4 46 29 PM" src="https://user-images.githubusercontent.com/2230142/108923965-fd7a7e00-75f6-11eb-9fff-31fcb9ba6cb4.png">

4. Refresh the page a bunch of times and confirm that you only ever see the smaller sizes, and never the largest size.
5. Test in non-AMP mode as well and ensure that you still only see the smaller sizes.