### PR TITLE
refactor: simplified approach for filtering out large sizes for sticky ads

### DIFF
--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -397,7 +397,7 @@ class Newspack_Ads_Model {
 		if ( count( $multisizes ) ) {
 			$multisize_attribute = sprintf(
 				'data-multi-size=\'%s\' data-multi-size-validation=\'false\'',
-				implode( ',', $multisizes ),
+				implode( ',', $multisizes )
 			);
 		}
 

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -371,6 +371,12 @@ class Newspack_Ads_Model {
 		if ( ! is_array( $sizes ) ) {
 			$sizes = [];
 		}
+		// Remove all ad sizes greater than 600px wide for sticky ads.
+		if ( self::is_sticky( $ad_unit ) ) {
+			$sizes = array_filter( $sizes, function( $size ) {
+				return $size[0] < 600;
+			} );
+		}
 
 		if ( $ad_unit['responsive'] ) {
 			return self::ad_elements_for_sizes( $ad_unit, $unique_id );
@@ -383,19 +389,15 @@ class Newspack_Ads_Model {
 		$multisizes           = [];
 		foreach ( $sizes as $size ) {
 			$multisize = $size[0] . 'x' . $size[1];
-			if (
-				( $multisize !== $ad_size_as_multisize ) &&
-				( ! self::is_sticky( $ad_unit ) || ( self::is_sticky( $ad_unit ) && $size[0] < 600 ) )
-			) {
+			if ( $multisize !== $ad_size_as_multisize ) {
 				$multisizes[] = $multisize;
 			}
 		}
 		$multisize_attribute = '';
 		if ( count( $multisizes ) ) {
 			$multisize_attribute = sprintf(
-				'data-multi-size=\'%s\' data-multi-size-validation=\'false\'%s',
+				'data-multi-size=\'%s\' data-multi-size-validation=\'false\'',
 				implode( ',', $multisizes ),
-				self::is_sticky( $ad_unit ) ? ' data-override-width=\'600\'' : ''
 			);
 		}
 

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -373,9 +373,12 @@ class Newspack_Ads_Model {
 		}
 		// Remove all ad sizes greater than 600px wide for sticky ads.
 		if ( self::is_sticky( $ad_unit ) ) {
-			$sizes = array_filter( $sizes, function( $size ) {
-				return $size[0] < 600;
-			} );
+			$sizes = array_filter(
+				$sizes,
+				function( $size ) {
+					return $size[0] < 600;
+				}
+			);
 		}
 
 		if ( $ad_unit['responsive'] ) {


### PR DESCRIPTION
I liked [your suggestion](https://github.com/Automattic/newspack-ads/pull/109#pullrequestreview-596930952) better than what I implemented, so I implemented and re-tested. Should show no difference in behavior compared to `master` now.