### PR TITLE
Update block placeholder and alignment options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@commitlint/config-conventional": "^8.3.4",
         "@semantic-release/changelog": "^5.0.0",
         "@semantic-release/git": "^9.0.0",
-        "@wordpress/base-styles": "^1.4.0",
+        "@wordpress/base-styles": "^3.4.1",
         "@wordpress/blocks": "^6.4.0",
         "@wordpress/element": "^2.5.0",
         "@wordpress/eslint-plugin": "^4.0.0",
@@ -6986,9 +6986,9 @@
       }
     },
     "node_modules/@wordpress/base-styles": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-1.4.0.tgz",
-      "integrity": "sha512-yG2JsLxEpa5zqZc/H6CoB7qb22OJOiG0AQIyhkw8CgvFA0FxiiYIXObAe0yjh2T7EQQbsxq88vxR/cPnupqnEw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-3.4.1.tgz",
+      "integrity": "sha512-H2a/jzcTEQcYYn+pFPQ8FGrfRGN+qPESyrrF3w+ty8SM4/+xH/Kn5mos/a8/7lGA/ChYeSC5b1lnO19E3gvPcQ==",
       "dev": true
     },
     "node_modules/@wordpress/blob": {
@@ -44126,9 +44126,9 @@
       "dev": true
     },
     "@wordpress/base-styles": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-1.4.0.tgz",
-      "integrity": "sha512-yG2JsLxEpa5zqZc/H6CoB7qb22OJOiG0AQIyhkw8CgvFA0FxiiYIXObAe0yjh2T7EQQbsxq88vxR/cPnupqnEw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-3.4.1.tgz",
+      "integrity": "sha512-H2a/jzcTEQcYYn+pFPQ8FGrfRGN+qPESyrrF3w+ty8SM4/+xH/Kn5mos/a8/7lGA/ChYeSC5b1lnO19E3gvPcQ==",
       "dev": true
     },
     "@wordpress/blob": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@commitlint/config-conventional": "^8.3.4",
     "@semantic-release/changelog": "^5.0.0",
     "@semantic-release/git": "^9.0.0",
-    "@wordpress/base-styles": "^1.4.0",
+    "@wordpress/base-styles": "^3.4.1",
     "@wordpress/blocks": "^6.4.0",
     "@wordpress/element": "^2.5.0",
     "@wordpress/eslint-plugin": "^4.0.0",

--- a/src/blocks/ad-unit/editor.scss
+++ b/src/blocks/ad-unit/editor.scss
@@ -17,7 +17,7 @@
 	}
 
 	.components-placeholder {
-		background: $light-gray-200;
+		border: 1px solid $gray-900;
 		border-radius: 0;
 		box-shadow: none;
 		margin: 0;

--- a/src/blocks/ad-unit/index.js
+++ b/src/blocks/ad-unit/index.js
@@ -52,7 +52,7 @@ export const settings = {
 	},
 	supports: {
 		html: false,
-		align: [ 'left', 'center', 'right' ],
+		align: [ 'left', 'center', 'right', 'wide', 'full' ],
 	},
 	edit,
 	save: () => null, // to use view.php


### PR DESCRIPTION
* Updates `@wordpress/base-styles` to latest version
* Changes style of placeholder to match Image block
* Adds support for wide and full-width