### PR TITLE
Ensure only Ad Unit CPT are handled in query

### DIFF
--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -111,15 +111,16 @@ class Newspack_Ads_Model {
 
 		$query = new \WP_Query( $args );
 		if ( $query->have_posts() ) {
-			while ( $query->have_posts() ) {
-				$query->the_post();
-				$ad_units[] = array(
-					'id'             => \get_the_ID(),
-					'name'           => html_entity_decode( \get_the_title(), ENT_QUOTES ),
-					self::SIZES      => self::sanitize_sizes( \get_post_meta( get_the_ID(), self::SIZES, true ) ),
-					self::CODE       => esc_html( \get_post_meta( get_the_ID(), self::CODE, true ) ),
-					self::AD_SERVICE => \get_post_meta( get_the_ID(), self::AD_SERVICE, true ),
-				);
+			foreach ( $query->posts as $post ) {
+				if ( self::$custom_post_type === $post->post_type ) {
+					$ad_units[] = [
+						'id'             => $post->ID,
+						'name'           => html_entity_decode( $post->post_title, ENT_QUOTES ),
+						self::SIZES      => self::sanitize_sizes( \get_post_meta( $post->ID, self::SIZES, true ) ),
+						self::CODE       => esc_html( \get_post_meta( $post->ID, self::CODE, true ) ),
+						self::AD_SERVICE => \get_post_meta( $post->ID, self::AD_SERVICE, true ),
+					];
+				}
 			}
 		}
 


### PR DESCRIPTION
It turns out that another plugin can [modify](https://github.com/INN/link-roundups/blob/be0f2a93a892904bf1d55a9dfd8ccf9311822d87/inc/link-roundups/class-link-roundups.php#L60) the `WP_Query` ran by this plugin!

## How to test 

1. Install the [Link Roundups plugin](https://github.com/INN/link-roundups/)
2. Create at least one link roundup
3. On `master` visit Newspack->Advertising wizard and observe the link roundups listed as ad units
4. Switch to this branch, observe the problem gone 🪄