### PR TITLE
fix: run composer install on release tasks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,9 @@ jobs:
           name: Install rsync
           command: sudo apt install rsync
       - run:
+          name: Install PHP packages
+          command: composer install --no-dev --no-scripts
+      - run:
           name: Release new version
           command: npm run release
 


### PR DESCRIPTION
Fixes a fatal caused when trying to activate a release package, because composer dependencies are not installed as part of the release build job.

To test, you need to create a build via CircleCI. I've already built https://github.com/Automattic/newspack-ads/releases/tag/v1.14.0-alpha.2 using this branch and confirmed that this build can be activated without a fatal, whereas attempting to activate https://github.com/Automattic/newspack-ads/releases/tag/v1.14.0-alpha.1 does result in a fatal.