### PR TITLE
fix: compare ad unit IDs as int rather than float

### DIFF
--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -80,8 +80,9 @@ class Newspack_Ads_Model {
 		} else {
 			// Ad units saved in options table. Ad unit ID is the GAM Ad Unit ID.
 			$ad_units = self::get_synced_gam_ad_units();
+
 			foreach ( $ad_units as $unit ) {
-				if ( $unit['id'] === $id && 'ACTIVE' === $unit['status'] ) {
+				if ( intval( $id ) === intval( $unit['id'] ) && 'ACTIVE' === $unit['status'] ) {
 					$ad_unit = $unit;
 					break;
 				}


### PR DESCRIPTION
Due to the [limited precision of float values in PHP](https://www.php.net/manual/en/language.types.float.php), using a `===` comparison for ID values can sometimes fail even if the values appear to be the same to the naked eye.

For example, GAM ad unit IDs can sometimes be very large numbers like `21973793522`. When compared using `===` without casting the values as integers, PHP might cast one or the other value as a float instead, which means that `21973793522 === 21973793522` can actually be `false`.

This change explicitly casts both values as integers before making the comparison, avoiding this situation.

To test: 

1. You'll need an ad unit with ID that looks like a very large number like the above. The easiest way to do this is to [enable GAM integration](https://newspackp2.wordpress.com/2021/06/16/setting-up-gam-ads/) and use one of the existing GAM units.
2. Place an active GAM unit with a large number ID into a widget area or into a post via the Ad Unit block.
3. On the front-end, observe that the ad unit is not displayed. If you want to confirm, you can `error_log` both `$id` and `$unit['id']`, then `error_log( $id === $unit['id'] )` right above [this line](https://github.com/Automattic/newspack-ads/blob/master/includes/class-newspack-ads-model.php#L84) and see that the comparison fails even though both IDs look identical.
4. Check out this branch, refresh the front-end, confirm that the ad unit is now displayed.