### PR TITLE
Harden logic when no ad unit selected

### DIFF
--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -64,6 +64,16 @@ class Newspack_Ads_Model {
 	 * @return object Prepared ad unit, with markup for injecting on a page.
 	 */
 	public static function get_ad_unit_for_display( $id, $placement = null, $context = null ) {
+		if ( 0 === (int) $id ) {
+			return new WP_Error(
+				'newspack_no_adspot_found',
+				\esc_html__( 'No such ad spot.', 'newspack' ),
+				array(
+					'status' => '400',
+				)
+			);
+		}
+
 		$ad_unit               = \get_post( $id );
 		$responsive_placements = [ 'global_above_header', 'global_below_header', 'global_above_footer' ];
 

--- a/includes/class-newspack-ads-widget.php
+++ b/includes/class-newspack-ads-widget.php
@@ -33,7 +33,7 @@ class Newspack_Ads_Widget extends WP_Widget {
 	 * @param object $instance The Widget instance.
 	 */
 	public function widget( $args, $instance ) {
-		if ( ! newspack_ads_should_show_ads() || ! isset( $args['id'] ) ) {
+		if ( ! newspack_ads_should_show_ads() || ! isset( $args['id'] ) || 0 === (int) $instance['selected_ad_unit'] ) {
 			return;
 		}
 


### PR DESCRIPTION
This PR fixes an issue with the (soon-to-be-legacy) ads widget. If you save the widget without selecting any ad unit, it throws PHP warnings on the frontend. This is because in `Newspack_Ads_Model::get_ad_unit_for_display`, the call to `get_post( $id )` will return the current post when the default `$id` of `0` is passed in, and the current post has no ad meta data. I've hardened the logic to prevent this issue.

## To test/reproduce:
1. Before applying this patch, add an ads widget to the sidebar, don't select an ad unit, and Save:
<img width="720" alt="Screen Shot 2021-07-15 at 11 12 56 AM" src="https://user-images.githubusercontent.com/7317227/125837066-f9d2a031-ddb4-44f0-b6f2-a31b27c37d64.png">
2. On the frontend, observe the warnings thrown in the sidebar:
<img width="565" alt="Screen Shot 2021-07-15 at 11 09 51 AM" src="https://user-images.githubusercontent.com/7317227/125837118-63ce7054-8b7f-4c42-8cd4-4d4fd08f1ce7.png">
3. Apply this patch. Observe no warnings thrown in the sidebar:
<img width="745" alt="Screen Shot 2021-07-15 at 11 14 25 AM" src="https://user-images.githubusercontent.com/7317227/125837216-66a0d6e3-076b-462c-bf19-23807b2f946b.png">
