### PR TITLE
fix: return all ad units

### DIFF
--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -141,7 +141,7 @@ class Newspack_Ads_Model {
 		$query           = new \WP_Query(
 			[
 				'post_type'      => self::$custom_post_type,
-				'posts_per_page' => 100,
+				'posts_per_page' => -1,
 				'post_status'    => [ 'publish' ],
 			]
 		);


### PR DESCRIPTION
## How to test

Create >100 ad units, or trust [the docs](https://developer.wordpress.org/reference/classes/wp_query/#pagination-parameters) ;) :

> Use 'posts_per_page'=>-1 to show all posts (the 'offset' parameter is ignored with a -1 value).

Closes #106