### PR TITLE
fix: circleci phpunit requirement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,10 +68,10 @@ jobs:
           name: Run Tests
           command: |
             composer install
-            composer global require "phpunit/phpunit=5.7.*"
+            composer require "phpunit/phpunit=5.7.*"
             rm -rf $WP_TESTS_DIR $WP_CORE_DIR
             bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
-            phpunit
+            ./vendor/bin/phpunit
 
   # Release job
   release:


### PR DESCRIPTION
Fix `test-php` CI task by updating how phpunit is installed.

Closes #160.