### PR TITLE
Fix(targeting): remove post slug and add post type

### DIFF
--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -695,17 +695,14 @@ class Newspack_Ads_Model {
 		$targeting = [];
 
 		if ( is_singular() ) {
-			// Add the post slug to targeting.
-			$slug = get_post_field( 'post_name' );
-			if ( $slug ) {
-				$targeting['slug'] = sanitize_text_field( $slug );
-			}
-
 			// Add the category slugs to targeting.
 			$categories = wp_get_post_categories( get_the_ID(), [ 'fields' => 'slugs' ] );
 			if ( ! empty( $categories ) ) {
 				$targeting['category'] = array_map( 'sanitize_text_field', $categories );
 			}
+
+			// Add post type to targeting.
+			$targeting['post_type'] = get_post_type();
 
 			// Add the post ID to targeting.
 			$targeting['ID'] = get_the_ID();


### PR DESCRIPTION
As reported by @kmwilkerson, GAM limits targeting values to 40 characters so longer slugs will only be targetable within GAM using the first 40 characters. To avoid confusion for publishers, this PR removes `slug` as a targetable field and adds `post_type` for broader targetable coverage.

Closes #164.

### How to test

1. Make sure you have a global ad unit visible on a singular post page
2. With the network inspector open, visit a singular post and see make sure `category`, `post_type` and `ID` are being sent through the `scp` (with AMP enabled), or `prev_scp` (with AMP disabled) query parameter in the ad request.

<img width="1303" alt="Captura de Tela 2021-09-02 às 16 09 19" src="https://user-images.githubusercontent.com/820752/131902457-f2562e69-64ca-419b-a856-08ef51640776.png">

