### PR TITLE
feat: allow multiple comma-delmiited GAM network codes

### DIFF
--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -309,7 +309,7 @@ class Newspack_Ads_Model {
 	 */
 	public static function get_active_network_code() {
 		$network_code = get_option( self::OPTION_NAME_NETWORK_CODE, '' );
-		return absint( $network_code );
+		return sanitize_text_field( $network_code );
 	}
 
 	/**

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -359,7 +359,18 @@ class Newspack_Ads_Model {
 		}
 		try {
 			$user_network_code = Newspack_Ads_GAM::get_gam_network_code();
-			return absint( $user_network_code ) === $active_network_code;
+
+			// Active Network Code might be a comma-delimited list of codes.
+			return array_reduce(
+				explode( ',', $active_network_code ),
+				function( $valid_code, $code ) use ( $user_network_code ) {
+					if ( absint( $code ) === absint( $user_network_code ) ) {
+						$valid_code = true;
+					}
+					return $valid_code;
+				},
+				false
+			);
 		} catch ( \Exception $e ) {
 			// Can't get user's network code.
 			return false;


### PR DESCRIPTION
Allows the advertising wizard to accept multiple GAM network codes as a comma-delimited string, as specified by MCM, and renders those codes in the slot attribute for both AMP and non-AMP ad units. Note that it's currently not possible to fully test MCM in a non-production environment.

Also fixes a minor bug in the Advertising wizard where saving a new value to the Network Code field and then navigating to a different view within the React app resets the field back to the previous value.

Closes #157.

## To Test

### Multiple GAM network codes

1. Check out this branch as well as https://github.com/Automattic/newspack-plugin/pull/1123 (make sure to rebuild with `npm run build`).
2. In WP Admin, go to **Newspack > Advertising**. Turn on Google Ad Manager if not already enabled, then click "Configure."
3. In the **Network Codes** field, enter a single GAM code. **Note:** GAM codes must be integers, e.g. `12345`
4. Click "Save" and confirm that the wizard allows the single code to be saved.
5. In the **Network Codes** field, enter multiple GAM codes separated by commas and click "Save" again. Confirm that the wizard allows multiple comma-delimited codes to be saved.
6. Make sure you have at least one GAM ad unit defined here.
7. Go back to **Newspack > Advertising > Global Settings** and enable an ad unit in an ad position.
8. View the ad position on the front-end and confirm that the ad unit renders with multiple GAM network codes in both AMP and non-AMP contexts. Note that unless your test site and all GAM accounts are approved for Google's MCM program, the ad units will fail to render.
  * For AMP (test site must NOT have AMP Plus enabled): View page source, look for `<amp-ad>` elements, confirm that the `data-slot` attribute contains all comma-delimited network codes, e.g.

```html
<amp-ad width="1020px" height="230px" type="doubleclick" data-slot="/12345,67890/AdUnitName" data-loading-strategy="prefer-viewability-over-views" json='{"targeting":{"slug":"homepage","ID":1234}}' ></amp-ad>
```
  * For non-AMP: View page source, look for `var ad_config`, confirm that its `network_code` property contains all comma-delimited network codes.

### Saving and rendering Network Code field value

1. On `master`, go to **WP Admin > Newspack > Advertising** and configure Google Ad Manager.
2. Note the value in the Network Code field rendered on load.
3. Enter a new value, click save.
4. Click "Back to advertising options" then the "Global Settings" tab (basically mount a new React view without reloading the page). Then go back to **Ad Providers** and configure GAM again.
5. Observe that the value rendered in the Network Code field is the original value, not the newly saved value, until you refresh the page entirely.
6. Check out this branch and rebuild.
7. Repeat steps 1–4, but this time confirm that the value rendered when the view mounts matches the most recently saved value.