### PR TITLE
feat(gam): create target key-values on sync

### DIFF
--- a/includes/class-newspack-ads-gam.php
+++ b/includes/class-newspack-ads-gam.php
@@ -55,6 +55,7 @@ class Newspack_Ads_GAM {
 	 */
 	public static $custom_targeting_keys = [
 		'ID',
+		'slug',
 		'category',
 		'post_type',
 	];

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -351,11 +351,7 @@ class Newspack_Ads_Model {
 			} catch ( \Exception $e ) {
 				return new WP_Error(
 					'newspack_ads_failed_gam_sync',
-					__( 'Unable to synchronize with GAM', 'newspack-ads' ),
-					[
-						'status' => 400,
-						'level'  => 'notice',
-					]
+					__( 'Unable to synchronize with GAM', 'newspack-ads' )
 				);
 			}
 		} else {

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -313,7 +313,7 @@ class Newspack_Ads_Model {
 	}
 
 	/**
-	 * Save GAM configuration locally.
+	 * Save GAM configuration locally and update GAM settings.
 	 * First reason is so the GAM API is not queried on frontend requests - information
 	 * about ad units & GAM settings will be read from the DB.
 	 * Second reason is backwards compatibility - in a previous version of the plugin,

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -327,6 +327,8 @@ class Newspack_Ads_Model {
 			$serialised_ad_units = Newspack_Ads_GAM::get_serialised_gam_ad_units();
 		}
 		if ( null === $settings ) {
+			// Update targeting keys when fetching settings from GAM.
+			Newspack_Ads_GAM::update_custom_targeting_keys();
 			$settings             = Newspack_Ads_GAM::get_gam_settings();
 			$network_code_matches = self::is_network_code_matched();
 		} else {
@@ -342,8 +344,6 @@ class Newspack_Ads_Model {
 			$synced_gam_items[ $network_code ]['ad_units'] = $serialised_ad_units;
 			update_option( self::OPTION_NAME_NETWORK_CODE, $network_code );
 			update_option( self::OPTION_NAME_GAM_ITEMS, $synced_gam_items );
-
-			Newspack_Ads_GAM::update_custom_targeting_keys();
 		}
 	}
 

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -342,6 +342,8 @@ class Newspack_Ads_Model {
 			$synced_gam_items[ $network_code ]['ad_units'] = $serialised_ad_units;
 			update_option( self::OPTION_NAME_NETWORK_CODE, $network_code );
 			update_option( self::OPTION_NAME_GAM_ITEMS, $synced_gam_items );
+
+			Newspack_Ads_GAM::update_custom_targeting_keys();
 		}
 	}
 

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -57,6 +57,21 @@ class Newspack_Ads_Model {
 	}
 
 	/**
+	 * Initial GAM setup.
+	 *
+	 * @return object|WP_Error Setup results or error if setup fails.
+	 */
+	public static function setup_gam() {
+		$setup_results = array();
+		try {
+			$setup_results['created_targeting_keys'] = Newspack_Ads_GAM::update_custom_targeting_keys();
+		} catch ( Exception $e ) {
+			return new WP_Error( 'newspack_ads_setup_gam', $e->getMessage() );
+		}
+		return $setup_results;
+	}
+
+	/**
 	 * Get a single ad unit to display on the page.
 	 *
 	 * @param number $id The id of the ad unit to retrieve.


### PR DESCRIPTION
Automatically creates custom keys for [targeting key-values](https://support.google.com/admanager/answer/188092?hl=en). The created keys are `ID`, `category`, and `post_type` of type `FREEFORM` if they are not found `ACTIVE` in GAM.

Closes #165.

### How to test this PR

1. Visit your GAM dashboard at **Inventory -> Key-values** and make sure the keys mentioned above **don't exist**
2. Checkout this PR and make sure your setup is connected to GAM
3. Visit the Advertising wizard page (the custom keys should be checked and updated here, if necessary)
4. Visit your GAM dashboard and make sure the keys exists at **Inventory -> Key-values**
