### PR TITLE
feat(gam): service account credential options

### DIFF
--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -811,6 +811,26 @@ class Newspack_Ads_Model {
 	}
 
 	/**
+	 * Update GAM credentials.
+	 * 
+	 * @param array $credentials Credentials to update.
+	 * 
+	 * @return object Object with status information.
+	 */
+	public static function update_gam_credentials( $credentials ) {
+		try {
+			Newspack_Ads_GAM::get_google_oauth2_credentials( $credentials );
+		} catch ( \Exception $e ) {
+			return new WP_Error( 'newspack_ads_gam_credentials', $e->getMessage() );
+		}
+		$updated = update_option( Newspack_Ads_GAM::CREDENTIALS_OPTION_NAME, $credentials );
+		if ( ! $updated ) {
+			return new WP_Error( 'newspack_ads_gam_credentials', __( 'Unable to update GAM credentials', 'newspack-ads' ) );
+		}
+		return self::get_gam_connection_status();
+	}
+
+	/**
 	 * Update global ad suppresion config.
 	 *
 	 * @param array $config Updated config.


### PR DESCRIPTION
Allow the user to upload Service Account credentials to provide a connection with GAM.

This is an improvement over the current approach implemented by https://github.com/Automattic/newspack-ads/pull/163, which uses a JSON file provided by Google containing credential secrets to connect with GAM. Instead of uploading the file to  `WP_CONTENT_DIR`, we will store the credentials as WordPress options.

## How to test

1. Repeat the steps from https://github.com/Automattic/newspack-ads/pull/163 to create your Service Account and generate your credentials file
2. Checkout this branch and https://github.com/Automattic/newspack-plugin/pull/1149
3. Visit Newspack Ads dashboard and notice the error shown on the Google Ad Manager card
4. Click "Configure" and observe the notice warning legacy mode
5. Click on the button card and select the JSON file
6. Wait until the upload finishes and see your ad units are now reflecting your GAM account

### Error handling

Manually remove the `_newspack_ads_gam_credentials` option from your `wp_options` table to test error handling.

1. Upload an invalid JSON file and observe the error notice
2. Edit your credentials file, alter the `client_email` to a random value, upload and observe the error notice with the "Upload new" button