### PR TITLE
Handle legacy network code and incompatible plugin

### DIFF
--- a/includes/class-newspack-ads-gam.php
+++ b/includes/class-newspack-ads-gam.php
@@ -496,11 +496,32 @@ class Newspack_Ads_GAM {
 	}
 
 	/**
+	 * Verify WP environment to make sure it's safe to use GAM.
+	 * 
+	 * @return bool Wether it's safe to use GAM.
+	 */
+	public static function is_sdk_compatible() {
+		// Constant Contact Form plugin loads an old version of Guzzle that breaks the SDK.
+		if ( class_exists( 'Constant_Contact' ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
 	 * Get GAM connection status.
 	 *
 	 * @return object Object with status information.
 	 */
 	public static function connection_status() {
+		if ( false === self::is_sdk_compatible() ) {
+			return [
+				'incompatible' => true,
+				'can_connect'  => false,
+				'connected'    => false,
+				'error'        => __( 'Cannot connect to Google Ad Manager.', 'newspack-ads' ),
+			];
+		}
 		$response = [ 'can_connect' => false !== self::get_service_account_credentials() ];
 		try {
 			$response['network_code'] = self::get_gam_network_code();

--- a/includes/class-newspack-ads-gam.php
+++ b/includes/class-newspack-ads-gam.php
@@ -503,8 +503,8 @@ class Newspack_Ads_GAM {
 	public static function connection_status() {
 		$response = [ 'can_connect' => false !== self::get_service_account_credentials() ];
 		try {
-			$network_code          = self::get_gam_network_code();
-			$response['connected'] = true;
+			$response['network_code'] = self::get_gam_network_code();
+			$response['connected']    = true;
 		} catch ( \Exception $e ) {
 			$response['connected'] = false;
 			$response['error']     = $e->getMessage();

--- a/tests/test-model.php
+++ b/tests/test-model.php
@@ -17,7 +17,7 @@ class ModelTest extends WP_UnitTestCase {
 
 	public static function setUpBeforeClass() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 		// Set the active network code.
-		update_option( Newspack_Ads_Model::OPTION_NAME_NETWORK_CODE, self::$network_code );
+		update_option( Newspack_Ads_Model::OPTION_NAME_LEGACY_NETWORK_CODE, self::$network_code );
 	}
 
 	public function setUp() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing


### PR DESCRIPTION
Implements and closes #183

As suggested by the issue, the Ad Units editor will never be blocked, instead, the network code related to the credential "replaces" the saved network code. If the credentials are removed, the previous network code will be restored.

This change affects every method that uses `get_active_network_code()`, which includes ad units configuration methods.

This PR also introduces the `is_sdk_compatible()` method, which disables GAM connection and flags `incompatible` in the case Constant Contact Form plugin is enabled. 

### How to test this PR

1. Repeat the steps from https://github.com/Automattic/newspack-ads/pull/163 to create your Service Account and generate your credentials file
2. On a new installation, checkout https://github.com/Automattic/newspack-plugin/pull/1151, visit Newspack Ads dashboard and upload your credentials
3. Notice the network code set on the disabled input, with buttons to replace and remove credentials
4. Remove the credentials and save a random network code
5. Upload the credentials and observe the warning message

### Test incompatible plugin

1. Enable Constant Contact Form plugin
2. Visit Newspack Ads and observe the error notices and that the "upload credentials" button card is not visible