### PR TITLE
chore: update env compatible method

### DIFF
--- a/includes/class-newspack-ads-gam.php
+++ b/includes/class-newspack-ads-gam.php
@@ -498,9 +498,9 @@ class Newspack_Ads_GAM {
 	/**
 	 * Verify WP environment to make sure it's safe to use GAM.
 	 * 
-	 * @return bool Wether it's safe to use GAM.
+	 * @return bool Whether it's safe to use GAM.
 	 */
-	public static function is_sdk_compatible() {
+	public static function is_environment_compatible() {
 		// Constant Contact Form plugin loads an old version of Guzzle that breaks the SDK.
 		if ( class_exists( 'Constant_Contact' ) ) {
 			return false;
@@ -514,12 +514,12 @@ class Newspack_Ads_GAM {
 	 * @return object Object with status information.
 	 */
 	public static function connection_status() {
-		if ( false === self::is_sdk_compatible() ) {
+		if ( false === self::is_environment_compatible() ) {
 			return [
 				'incompatible' => true,
 				'can_connect'  => false,
 				'connected'    => false,
-				'error'        => __( 'Cannot connect to Google Ad Manager.', 'newspack-ads' ),
+				'error'        => __( 'Cannot connect to Google Ad Manager. This WordPress instance is not compatible with this feature.', 'newspack-ads' ),
 			];
 		}
 		$response = [ 'can_connect' => false !== self::get_service_account_credentials() ];


### PR DESCRIPTION
Addresses post-merge concerns brought at https://github.com/Automattic/newspack-ads/pull/184 

### How to test

Activate Constant Contact Form plugin, visit Newspack Ads dashboard and see the new message shown on the Google Ad Manager card.