### PR TITLE
fix: remove network code restriction on sync

### DIFF
--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -352,22 +352,16 @@ class Newspack_Ads_Model {
 		}
 		if ( null === $settings ) {
 			try {
-				$settings             = Newspack_Ads_GAM::get_gam_settings();
-				$network_code_matches = self::is_network_code_matched();
+				$settings = Newspack_Ads_GAM::get_gam_settings();
 			} catch ( \Exception $e ) {
 				return new WP_Error(
 					'newspack_ads_failed_gam_sync',
 					__( 'Unable to synchronize with GAM', 'newspack-ads' )
 				);
 			}
-		} else {
-			$network_code_matches = true;
 		}
 
-		if (
-			$network_code_matches &&
-			isset( $settings['network_code'] ) && $serialised_ad_units && ! empty( $serialised_ad_units )
-		) {
+		if ( isset( $settings['network_code'] ) && $serialised_ad_units && ! empty( $serialised_ad_units ) ) {
 			$synced_gam_items                              = get_option( self::OPTION_NAME_GAM_ITEMS, [] );
 			$network_code                                  = sanitize_text_field( $settings['network_code'] );
 			$synced_gam_items[ $network_code ]['ad_units'] = $serialised_ad_units;


### PR DESCRIPTION
#184 changed how we handle when the stored network code does not match the uploaded service account. It now allows different network code, replacing the active network code.

Residual code from the previous approach is preventing synchronization if the network codes are not matched.

## How to test this PR

 1. On the master branch, set up a service account with unmatched network code on the Advertising wizard:
    1. Without a service account, set your network code to a random number (123456789)
    2. Upload a service account credential and observe the warning notice
 2. Create a new ad unit and place it on a page or global position
 3. Observe it is not displayed or look at the `_newspack_ads_gam_items` option does not contain the created ad unit.
 4. Switch to this branch, repeat steps and confirm it is now working