### PR TITLE
perf: cache ad units

### DIFF
--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -36,6 +36,13 @@ class Newspack_Ads_Model {
 	public static $ad_ids = [];
 
 	/**
+	 * Array of all ad units configurations.
+	 * 
+	 * @var array|null Array or null if not yet initialized.
+	 */
+	public static $ad_units = null;
+
+	/**
 	 * Initialize Google Ads Model
 	 *
 	 * @codeCoverageIgnore
@@ -187,16 +194,20 @@ class Newspack_Ads_Model {
 	 * Get the ad units.
 	 */
 	public static function get_ad_units() {
-		$legacy_ad_units = self::get_legacy_ad_units();
-		if ( ! self::is_gam_connected() ) {
-			return $legacy_ad_units;
+		if ( null !== self::$ad_units ) {
+			return self::$ad_units;
 		}
-		$ad_units    = Newspack_Ads_GAM::get_serialised_gam_ad_units();
-		$sync_result = self::sync_gam_settings( $ad_units );
-		if ( \is_wp_error( $sync_result ) ) {
-			return $sync_result;
+		$ad_units = self::get_legacy_ad_units();
+		if ( self::is_gam_connected() ) {
+			$gam_ad_units = Newspack_Ads_GAM::get_serialised_gam_ad_units();
+			$sync_result  = self::sync_gam_settings( $gam_ad_units );
+			if ( \is_wp_error( $sync_result ) ) {
+				return $sync_result;
+			}
+			$ad_units = array_merge( $ad_units, $gam_ad_units );
 		}
-		return array_merge( $ad_units, $legacy_ad_units );
+		self::$ad_units = $ad_units;
+		return self::$ad_units;
 	}
 
 	/**


### PR DESCRIPTION
GAM API has a rate limit of 8 requests per second, this PR implements a class variable to store fetched ad units to prevent excessive consecutive API calls.

## How to test changes

Make sure ad units are properly loaded and displayed on the Ads GAM wizard and Ad Unit widget configuration. Nothing should change.