### PR TITLE
feat: customizable settings

### DIFF
--- a/includes/class-newspack-ads-blocks.php
+++ b/includes/class-newspack-ads-blocks.php
@@ -191,6 +191,7 @@ class Newspack_Ads_Blocks {
 			googletag.cmd.push(function() {
 				var ad_config        = <?php echo wp_json_encode( $ad_config ); ?>;
 				var all_ad_units     = <?php echo wp_json_encode( $prepared_unit_data ); ?>;
+				var ad_settings      = <?php echo wp_json_encode( Newspack_Ads_Settings::get_settings() ); ?>;
 				var defined_ad_units = {};
 
 				for ( var container_id in all_ad_units ) {
@@ -296,11 +297,13 @@ class Newspack_Ads_Blocks {
 				}
 				googletag.pubads().collapseEmptyDivs();
 				googletag.pubads().enableSingleRequest();
-				googletag.pubads().enableLazyLoad( {
-					fetchMarginPercent: 500,   // Fetch slots within 5 viewports.
-					renderMarginPercent: 200,  // Render slots within 2 viewports.
-					mobileScaling: 2.0         // Double the above values on mobile.
-				} );
+				if ( ad_settings.lazy_load.active ) {
+					googletag.pubads().enableLazyLoad( {
+						fetchMarginPercent: ad_settings.lazy_load.fetch_margin_percent,
+						renderMarginPercent: ad_settings.lazy_load.render_margin_percent,
+						mobileScaling: ad_settings.lazy_load.mobile_scaling
+					} );
+				}
 				googletag.enableServices();
 
 				for ( var container_id in defined_ad_units ) {

--- a/includes/class-newspack-ads-blocks.php
+++ b/includes/class-newspack-ads-blocks.php
@@ -297,7 +297,7 @@ class Newspack_Ads_Blocks {
 				}
 				googletag.pubads().collapseEmptyDivs();
 				googletag.pubads().enableSingleRequest();
-				if ( ad_settings.lazy_load.active ) {
+				if ( ad_settings.lazy_load && ad_settings.lazy_load.active ) {
 					googletag.pubads().enableLazyLoad( {
 						fetchMarginPercent: ad_settings.lazy_load.fetch_margin_percent,
 						renderMarginPercent: ad_settings.lazy_load.render_margin_percent,

--- a/includes/class-newspack-ads-blocks.php
+++ b/includes/class-newspack-ads-blocks.php
@@ -191,7 +191,7 @@ class Newspack_Ads_Blocks {
 			googletag.cmd.push(function() {
 				var ad_config        = <?php echo wp_json_encode( $ad_config ); ?>;
 				var all_ad_units     = <?php echo wp_json_encode( $prepared_unit_data ); ?>;
-				var ad_settings      = <?php echo wp_json_encode( Newspack_Ads_Settings::get_settings( true ) ); ?>;
+				var lazy_load        = <?php echo wp_json_encode( Newspack_Ads_Settings::get_settings( 'lazy_load', true ), JSON_FORCE_OBJECT ); ?>;
 				var defined_ad_units = {};
 
 				for ( var container_id in all_ad_units ) {
@@ -297,11 +297,11 @@ class Newspack_Ads_Blocks {
 				}
 				googletag.pubads().collapseEmptyDivs();
 				googletag.pubads().enableSingleRequest();
-				if ( ad_settings.lazy_load && ad_settings.lazy_load.active ) {
+				if ( lazy_load && lazy_load.active ) {
 					googletag.pubads().enableLazyLoad( {
-						fetchMarginPercent: ad_settings.lazy_load.fetch_margin_percent,
-						renderMarginPercent: ad_settings.lazy_load.render_margin_percent,
-						mobileScaling: ad_settings.lazy_load.mobile_scaling
+						fetchMarginPercent: lazy_load.fetch_margin_percent,
+						renderMarginPercent: lazy_load.render_margin_percent,
+						mobileScaling: lazy_load.mobile_scaling
 					} );
 				}
 				googletag.enableServices();

--- a/includes/class-newspack-ads-blocks.php
+++ b/includes/class-newspack-ads-blocks.php
@@ -191,7 +191,7 @@ class Newspack_Ads_Blocks {
 			googletag.cmd.push(function() {
 				var ad_config        = <?php echo wp_json_encode( $ad_config ); ?>;
 				var all_ad_units     = <?php echo wp_json_encode( $prepared_unit_data ); ?>;
-				var ad_settings      = <?php echo wp_json_encode( Newspack_Ads_Settings::get_settings() ); ?>;
+				var ad_settings      = <?php echo wp_json_encode( Newspack_Ads_Settings::get_settings( true ) ); ?>;
 				var defined_ad_units = {};
 
 				for ( var container_id in all_ad_units ) {

--- a/includes/class-newspack-ads-settings.php
+++ b/includes/class-newspack-ads-settings.php
@@ -36,6 +36,8 @@ class Newspack_Ads_Settings {
 	 * - type: The type of the setting. Used to typecast the value.
 	 * - default: The default value of the setting.
 	 * - options: Options to be used for a select field. Values outside of this array will not update.
+	 *   - name: The name of the option.
+	 *   - value: The value of the option.
 	 * - public: Whether the setting value is allowed to be displayed publicly on the frontend.
 	 *
 	 * Settings without `key` or with the `key` of value `active` should be

--- a/includes/class-newspack-ads-settings.php
+++ b/includes/class-newspack-ads-settings.php
@@ -276,7 +276,7 @@ class Newspack_Ads_Settings {
 	 * @param string $section  The key for the section to update.
 	 * @param object $settings The new settings to update.
 	 *
-	 * @return object All settings.
+	 * @return object|WP_Error The settings list or error if a setting update fails.
 	 */
 	public static function update_section( $section, $settings ) {
 		foreach ( $settings as $key => $value ) {

--- a/includes/class-newspack-ads-settings.php
+++ b/includes/class-newspack-ads-settings.php
@@ -32,7 +32,7 @@ class Newspack_Ads_Settings {
 			self::API_NAMESPACE,
 			'/settings-list',
 			[
-				'methods'             => WP_REST_Server::READABLE,
+				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ __CLASS__, 'api_get_settings_list' ],
 				'permission_callback' => [ __CLASS__, 'api_permissions_check' ],
 			]

--- a/includes/class-newspack-ads-settings.php
+++ b/includes/class-newspack-ads-settings.php
@@ -215,13 +215,20 @@ class Newspack_Ads_Settings {
 			),
 		);
 
+		$default_setting = array(
+			'section' => '',
+			'type'    => 'string',
+			'public'  => false,
+		);
+
 		$settings_list = apply_filters( 'newspack_ads_settings_list', $settings_list );
 
+		// Add default settings and get values.
 		$settings_list = array_map(
-			function ( $item ) {
-				$item['type'] = isset( $item['type'] ) ? $item['type'] : 'string';
-				$default      = isset( $item['default'] ) ? $item['default'] : false;
-				$value        = get_option( self::get_setting_option_name( $item ), $default );
+			function ( $item ) use ( $default_setting ) {
+				$item          = array_merge( $default_setting, $item );
+				$default_value = isset( $item['default'] ) ? $item['default'] : false;
+				$value         = get_option( self::get_setting_option_name( $item ), $default_value );
 				if ( false !== $value ) {
 					settype( $value, $item['type'] );
 					$item['value'] = $value;

--- a/includes/class-newspack-ads-settings.php
+++ b/includes/class-newspack-ads-settings.php
@@ -26,9 +26,23 @@ class Newspack_Ads_Settings {
 	}
 
 	/**
-	 * Retreives list of settings.
+	 * Retrieves list of configured settings.
 	 *
-	 * @return array Settings list.
+	 * A setting is an array with the following keys:
+	 * - description: The description of the setting.
+	 * - help: The help text for the setting.
+	 * - section: The section the setting is in.
+	 * - key: The key of the setting. Should be used along with the section name.
+	 * - type: The type of the setting. Used to typecast the value.
+	 * - default: The default value of the setting.
+	 * - options: Options to be used for a select field. Values outside of this array will not update.
+	 * - public: Whether the setting value is allowed to be displayed publicly on the frontend.
+	 *
+	 * Settings without `key` or with the `key` of value `active` should be
+	 * intepreted as section headers on the UI. In the case of `active`, it is a
+	 * module that can be activated or deactivated.
+	 *
+	 * @return array List of configured settings.
 	 */
 	public static function get_settings_list() {
 		$settings_list = array(

--- a/includes/class-newspack-ads-settings.php
+++ b/includes/class-newspack-ads-settings.php
@@ -232,7 +232,7 @@ class Newspack_Ads_Settings {
 		// Add default settings and get values.
 		$settings_list = array_map(
 			function ( $item ) use ( $default_setting ) {
-				$item          = array_merge( $default_setting, $item );
+				$item          = wp_parse_args( $item, $default_setting );
 				$default_value = isset( $item['default'] ) ? $item['default'] : false;
 				$value         = get_option( self::get_setting_option_name( $item ), $default_value );
 				if ( false !== $value ) {

--- a/includes/class-newspack-ads-settings.php
+++ b/includes/class-newspack-ads-settings.php
@@ -220,6 +220,7 @@ class Newspack_Ads_Settings {
 		$settings_list = array_map(
 			function ( $item ) {
 				$default       = isset( $item['default'] ) ? $item['default'] : false;
+				$item['type']  = isset( $item['type'] ) ? $item['type'] : 'string';
 				$item['value'] = get_option( self::get_setting_option_name( $item ), $default );
 				settype( $item['value'], $item['type'] );
 				return $item;
@@ -238,7 +239,7 @@ class Newspack_Ads_Settings {
 	 *
 	 * @return object|null Setting configuration or null if not found.
 	 */
-	private static function get_setting_config( $section, $key ) {
+	public static function get_setting_config( $section, $key ) {
 		$settings_list    = self::get_settings_list();
 		$filtered_configs = array_filter(
 			$settings_list,

--- a/includes/class-newspack-ads-settings.php
+++ b/includes/class-newspack-ads-settings.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Newspack Ads Settings
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Newspack Ads Settings Class.
+ */
+class Newspack_Ads_Settings {
+
+	const OPTION_KEY_PREFIX = '_newspack_ads_';
+
+	/**
+	 * Get the setting key to be used on the options table.
+	 *
+	 * @param object $setting The setting to retrieve the key from.
+	 *
+	 * @return string Setting key. 
+	 */
+	private static function get_setting_option_key( $setting ) {
+		return self::OPTION_KEY_PREFIX . $setting['section'] . '_' . $setting['key'];
+	}
+
+	/**
+	 * Retreives list of settings.
+	 *
+	 * @return array Settings list.
+	 */
+	public static function get_settings_list() {
+		$settings_list = array(
+			array(
+				'description' => __( 'Lazy loading', 'newspack-ads' ),
+				'help'        => __( 'Enables pages to load faster, reduces resource consumption and contention, and improves viewability rate.', 'newspack-ads' ),
+				'section'     => 'lazy_load',
+				'key'         => 'active',
+				'type'        => 'boolean',
+				'default'     => true,
+			),
+			array(
+				'description' => __( 'Fetch margin percent', 'newspack-ads' ),
+				'help'        => __( 'Minimum distance from the current viewport a slot must be before we fetch the ad as a percentage of viewport size.', 'newspack-ads' ),
+				'section'     => 'lazy_load',
+				'key'         => 'fetch_margin_percent',
+				'type'        => 'int',
+				'default'     => 100,
+			),
+			array(
+				'description' => __( 'Render margin percent', 'newspack-ads' ),
+				'help'        => __( 'Minimum distance from the current viewport a slot must be before we render an ad.', 'newspack-ads' ),
+				'section'     => 'lazy_load',
+				'key'         => 'render_margin_percent',
+				'type'        => 'int',
+				'default'     => 0,
+			),
+			array(
+				'description' => __( 'Mobile scaling', 'newspack-ads' ),
+				'help'        => __( 'A multiplier applied to margins on mobile devices. This allows varying margins on mobile vs. desktop.', 'newspack-ads' ),
+				'section'     => 'lazy_load',
+				'key'         => 'mobile_scaling',
+				'type'        => 'float',
+				'default'     => 2,
+			),
+		);
+
+		$settings_list = array_map(
+			function ( $item ) {
+				$default       = ! empty( $item['default'] ) ? $item['default'] : false;
+				$item['value'] = get_option( self::get_setting_option_key( $item ), $default );
+				return $item;
+			},
+			$settings_list
+		);
+
+		return $settings_list;
+	}
+
+	/**
+	 * Get settings values organized by sections.
+	 *
+	 * @return object Associative array containing settings values.
+	 */
+	public static function get_settings() {
+		$list   = self::get_settings_list();
+		$values = [];
+		foreach ( $list as $setting ) {
+			if ( ! isset( $values[ $setting['section'] ] ) ) {
+				$values[ $setting['section'] ] = [];
+			}
+			settype( $setting['value'], $setting['type'] );
+			$values[ $setting['section'] ][ $setting['key'] ] = $setting['value'];
+		}
+		return $values;
+	}
+
+}

--- a/includes/class-newspack-ads-settings.php
+++ b/includes/class-newspack-ads-settings.php
@@ -19,7 +19,7 @@ class Newspack_Ads_Settings {
 	 *
 	 * @param object $setting The setting to retrieve the key from.
 	 *
-	 * @return string Setting key. 
+	 * @return string Option key. 
 	 */
 	private static function get_setting_option_key( $setting ) {
 		return self::OPTION_KEY_PREFIX . $setting['section'] . '_' . $setting['key'];
@@ -75,7 +75,7 @@ class Newspack_Ads_Settings {
 			$settings_list
 		);
 
-		return $settings_list;
+		return apply_filters( 'newspack_ads_settings_list', $settings_list );
 	}
 
 	/**

--- a/includes/class-newspack-ads-settings.php
+++ b/includes/class-newspack-ads-settings.php
@@ -219,10 +219,13 @@ class Newspack_Ads_Settings {
 
 		$settings_list = array_map(
 			function ( $item ) {
-				$default       = isset( $item['default'] ) ? $item['default'] : false;
-				$item['type']  = isset( $item['type'] ) ? $item['type'] : 'string';
-				$item['value'] = get_option( self::get_setting_option_name( $item ), $default );
-				settype( $item['value'], $item['type'] );
+				$item['type'] = isset( $item['type'] ) ? $item['type'] : 'string';
+				$default      = isset( $item['default'] ) ? $item['default'] : false;
+				$value        = get_option( self::get_setting_option_name( $item ), $default );
+				if ( false !== $value ) {
+					settype( $value, $item['type'] );
+					$item['value'] = $value;
+				}
 				return $item;
 			},
 			$settings_list

--- a/includes/class-newspack-ads-settings.php
+++ b/includes/class-newspack-ads-settings.php
@@ -101,12 +101,18 @@ class Newspack_Ads_Settings {
 				} 
 			)
 		);
-		if ( $config ) {
-			settype( $value, $config['type'] );
-			return update_option( self::get_setting_option_name( $config ), $value );
-		} else {
+		// Don't update a setting that don't exist.
+		if ( ! $config ) {
 			return new WP_Error( 'newspack_ads_invalid_setting_update', __( 'Invalid setting.', 'newspack-ads' ) );
 		}
+		// Don't update a value that change on typecast.
+		$value_with_type = $value;
+		settype( $value_with_type, $config['type'] );
+		if ( $value_with_type != $value ) {
+			return new WP_Error( 'newspack_ads_invalid_setting_update', __( 'Invalid value type.', 'newspack-ads' ) );
+		}
+		settype( $value, $config['type'] );
+		return update_option( self::get_setting_option_name( $config ), $value );
 	}
 
 	/**

--- a/includes/class-newspack-ads-settings.php
+++ b/includes/class-newspack-ads-settings.php
@@ -72,8 +72,9 @@ class Newspack_Ads_Settings {
 
 		$settings_list = array_map(
 			function ( $item ) {
-				$default       = ! empty( $item['default'] ) ? $item['default'] : false;
+				$default       = isset( $item['default'] ) ? $item['default'] : false;
 				$item['value'] = get_option( self::get_setting_option_name( $item ), $default );
+				settype( $item['value'], $item['type'] );
 				return $item;
 			},
 			$settings_list
@@ -97,7 +98,7 @@ class Newspack_Ads_Settings {
 			array_filter(
 				$settings_list,
 				function( $setting ) use ( $section, $key ) {
-					return $key === $setting['key'] && $section === $setting['section'];
+					return isset( $setting['key'] ) && $key === $setting['key'] && isset( $setting['section'] ) && $section === $setting['section'];
 				} 
 			)
 		);
@@ -150,7 +151,6 @@ class Newspack_Ads_Settings {
 			if ( ! isset( $setting['key'] ) || ! isset( $setting['value'] ) ) {
 				continue;
 			}
-			settype( $setting['value'], $setting['type'] );
 			$values[ $setting['section'] ][ $setting['key'] ] = $setting['value'];
 		}
 		if ( $section ) {

--- a/includes/class-newspack-ads-settings.php
+++ b/includes/class-newspack-ads-settings.php
@@ -95,16 +95,14 @@ class Newspack_Ads_Settings {
 	 * @return bool|WP_Error Whether the value was updated or error if key does not match settings configuration.
 	 */
 	private static function update_setting( $section, $key, $value ) {
-		$settings_list = self::get_settings_list();
-		$config        = array_shift(
-			array_filter(
-				$settings_list,
-				function( $setting ) use ( $section, $key ) {
-					return isset( $setting['key'] ) && $key === $setting['key'] && isset( $setting['section'] ) && $section === $setting['section'];
-				} 
-			)
+		$settings_list    = self::get_settings_list();
+		$filtered_configs = array_filter(
+			$settings_list,
+			function( $setting ) use ( $section, $key ) {
+				return isset( $setting['key'] ) && $key === $setting['key'] && isset( $setting['section'] ) && $section === $setting['section'];
+			}
 		);
-		// Don't update a setting that don't exist.
+		$config           = array_shift( $filtered_configs );
 		if ( ! $config ) {
 			return new WP_Error( 'newspack_ads_invalid_setting_update', __( 'Invalid setting.', 'newspack-ads' ) );
 		}

--- a/includes/class-newspack-ads-settings.php
+++ b/includes/class-newspack-ads-settings.php
@@ -79,6 +79,51 @@ class Newspack_Ads_Settings {
 	}
 
 	/**
+	 * Update a setting from a provided section.
+	 *
+	 * @param string $section The section to update.
+	 * @param string $key     The key to update.
+	 * @param mixed  $value   The value to update.
+	 *
+	 * @return bool|WP_Error Whether the value was updated or error if key does not match settings configuration.
+	 */
+	private static function update_setting( $section, $key, $value ) {
+		$settings_list = self::get_settings_list();
+		$config        = array_shift(
+			array_filter(
+				$settings_list,
+				function( $setting ) use ( $section, $key ) {
+					return $key === $setting['key'] && $section === $setting['section'];
+				} 
+			)
+		);
+		if ( $config ) {
+			settype( $value, $config['type'] );
+			return update_option( self::get_setting_option_key( $config ), $value );
+		} else {
+			return new WP_Error( 'newspack_ads_invalid_setting_update', __( 'Invalid setting.', 'newspack-ads' ) );
+		}
+	}
+
+	/**
+	 * Update settings from a specific section.
+	 *
+	 * @param string $section  The key for the section to update.
+	 * @param object $settings The new settings to update.
+	 *
+	 * @return object All settings.
+	 */
+	public static function update_section( $section, $settings ) {
+		foreach ( $settings as $key => $value ) {
+			$updated = self::update_setting( $section, $key, $value );
+			if ( is_wp_error( $updated ) ) {
+				return $updated;
+			}
+		}
+		return self::get_settings_list();
+	}
+
+	/**
 	 * Get settings values organized by sections.
 	 *
 	 * @return object Associative array containing settings values.

--- a/includes/class-newspack-ads-settings.php
+++ b/includes/class-newspack-ads-settings.php
@@ -250,6 +250,29 @@ class Newspack_Ads_Settings {
 	}
 
 	/**
+	 * Retrieves a sanitized setting value to be stored as wp_option.
+	 *
+	 * @param string $type The type of the setting.
+	 * @param mixed  $value The value to sanitize.
+	 * 
+	 * @return mixed The sanitized value.
+	 */
+	private static function sanitize_setting_option( $type, $value ) {
+		switch ( $type ) {
+			case 'int':
+			case 'integer':
+			case 'boolean':
+				return (int) $value;
+			case 'float':
+				return (float) $value;
+			case 'string':
+				return sanitize_text_field( $value );
+			default:
+				return '';
+		}
+	}
+
+	/**
 	 * Update a setting from a provided section.
 	 *
 	 * @param string $section The section to update.
@@ -263,11 +286,10 @@ class Newspack_Ads_Settings {
 		if ( ! $config ) {
 			return new WP_Error( 'newspack_ads_invalid_setting_update', __( 'Invalid setting.', 'newspack-ads' ) );
 		}
-		settype( $value, $config['type'] );
 		if ( isset( $config['options'] ) && is_array( $config['options'] ) && ! in_array( $value, $config['options'] ) ) {
 			return new WP_Error( 'newspack_ads_invalid_setting_update', __( 'Invalid setting value.', 'newspack-ads' ) );
 		}
-		return update_option( self::get_setting_option_name( $config ), $value );
+		return update_option( self::get_setting_option_name( $config ), self::sanitize_setting_option( $config['type'], $value ) );
 	}
 
 	/**

--- a/includes/class-newspack-ads-settings.php
+++ b/includes/class-newspack-ads-settings.php
@@ -107,6 +107,9 @@ class Newspack_Ads_Settings {
 			return new WP_Error( 'newspack_ads_invalid_setting_update', __( 'Invalid setting.', 'newspack-ads' ) );
 		}
 		settype( $value, $config['type'] );
+		if ( isset( $config['options'] ) && is_array( $config['options'] ) && ! in_array( $value, $config['options'] ) ) {
+			return new WP_Error( 'newspack_ads_invalid_setting_update', __( 'Invalid setting value.', 'newspack-ads' ) );
+		}
 		return update_option( self::get_setting_option_name( $config ), $value );
 	}
 

--- a/includes/class-newspack-ads-settings.php
+++ b/includes/class-newspack-ads-settings.php
@@ -39,6 +39,7 @@ class Newspack_Ads_Settings {
 				'key'         => 'active',
 				'type'        => 'boolean',
 				'default'     => true,
+				'public'      => true,
 			),
 			array(
 				'description' => __( 'Fetch margin percent', 'newspack-ads' ),
@@ -47,6 +48,7 @@ class Newspack_Ads_Settings {
 				'key'         => 'fetch_margin_percent',
 				'type'        => 'int',
 				'default'     => 100,
+				'public'      => true,
 			),
 			array(
 				'description' => __( 'Render margin percent', 'newspack-ads' ),
@@ -55,6 +57,7 @@ class Newspack_Ads_Settings {
 				'key'         => 'render_margin_percent',
 				'type'        => 'int',
 				'default'     => 0,
+				'public'      => true,
 			),
 			array(
 				'description' => __( 'Mobile scaling', 'newspack-ads' ),
@@ -63,6 +66,7 @@ class Newspack_Ads_Settings {
 				'key'         => 'mobile_scaling',
 				'type'        => 'float',
 				'default'     => 2,
+				'public'      => true,
 			),
 		);
 
@@ -126,14 +130,19 @@ class Newspack_Ads_Settings {
 	/**
 	 * Get settings values organized by sections.
 	 *
+	 * @param boolean $is_public Whether to return only public settings.
+	 *
 	 * @return object Associative array containing settings values.
 	 */
-	public static function get_settings() {
+	public static function get_settings( $is_public = false ) {
 		$list   = self::get_settings_list();
 		$values = [];
 		foreach ( $list as $setting ) {
 			if ( ! isset( $values[ $setting['section'] ] ) ) {
 				$values[ $setting['section'] ] = [];
+			}
+			if ( true === $is_public && true !== $setting['public'] ) {
+				continue;
 			}
 			settype( $setting['value'], $setting['type'] );
 			$values[ $setting['section'] ][ $setting['key'] ] = $setting['value'];

--- a/includes/class-newspack-ads-settings.php
+++ b/includes/class-newspack-ads-settings.php
@@ -70,6 +70,8 @@ class Newspack_Ads_Settings {
 			),
 		);
 
+		$settings_list = apply_filters( 'newspack_ads_settings_list', $settings_list );
+
 		$settings_list = array_map(
 			function ( $item ) {
 				$default       = isset( $item['default'] ) ? $item['default'] : false;
@@ -80,7 +82,7 @@ class Newspack_Ads_Settings {
 			$settings_list
 		);
 
-		return apply_filters( 'newspack_ads_settings_list', $settings_list );
+		return $settings_list;
 	}
 
 	/**

--- a/includes/class-newspack-ads-settings.php
+++ b/includes/class-newspack-ads-settings.php
@@ -276,7 +276,7 @@ class Newspack_Ads_Settings {
 	 * @param string $section  The key for the section to update.
 	 * @param object $settings The new settings to update.
 	 *
-	 * @return object|WP_Error The settings list or error if a setting update fails.
+	 * @return array|WP_Error The settings list or error if a setting update fails.
 	 */
 	public static function update_section( $section, $settings ) {
 		foreach ( $settings as $key => $value ) {

--- a/includes/class-newspack-ads-settings.php
+++ b/includes/class-newspack-ads-settings.php
@@ -105,12 +105,6 @@ class Newspack_Ads_Settings {
 		if ( ! $config ) {
 			return new WP_Error( 'newspack_ads_invalid_setting_update', __( 'Invalid setting.', 'newspack-ads' ) );
 		}
-		// Don't update a value that change on typecast.
-		$value_with_type = $value;
-		settype( $value_with_type, $config['type'] );
-		if ( $value_with_type != $value ) {
-			return new WP_Error( 'newspack_ads_invalid_setting_update', __( 'Invalid value type.', 'newspack-ads' ) );
-		}
 		settype( $value, $config['type'] );
 		return update_option( self::get_setting_option_name( $config ), $value );
 	}

--- a/includes/class-newspack-ads.php
+++ b/includes/class-newspack-ads.php
@@ -69,6 +69,7 @@ final class Newspack_Ads {
 	 * e.g. include_once NEWSPACK_ADS_ABSPATH . 'includes/foo.php';
 	 */
 	private function includes() {
+		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-newspack-ads-settings.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-newspack-ads-blocks.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-newspack-ads-gam.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-newspack-ads-model.php';

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -68,6 +68,12 @@ class SettingsTest extends WP_UnitTestCase {
 				],
 			],
 		],
+		[
+			'description' => 'A field without type',
+			'help'        => 'Help text',
+			'section'     => 'test_section',
+			'key'         => 'typeless_field',
+		],
 	];
 
 	/**
@@ -134,6 +140,23 @@ class SettingsTest extends WP_UnitTestCase {
 		self::assertTrue(
 			is_wp_error( $result ),
 			'Should not update a value outside of existing options.'
+		);
+	}
+
+	/**
+	 * Test that a setting should always have a default type.
+	 */
+	public function test_setting_default_type() {
+		add_filter( 'newspack_ads_settings_list', [ __CLASS__, 'set_settings_list' ] );
+		$config = Newspack_Ads_Settings::get_setting_config( 'test_section', 'typeless_field' );
+		self::assertTrue(
+			isset( $config['type'] ),
+			'Should have a default type'
+		);
+		self::assertSame(
+			$config['type'],
+			'string',
+			'Should have a default type of string'
 		);
 	}
 }

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Tests the ads settings functionality.
+ *
+ * @package Newspack\Tests
+ */
+
+/**
+ * Test ads settings functionality.
+ */
+class SettingsTest extends WP_UnitTestCase {
+	/**
+	 * Sample settings list for tests
+	 *
+	 * @var array
+	 */
+	private static $settings_list = [
+		[
+			'description' => 'A setting section',
+			'help'        => 'A setting section description or help text',
+			'section'     => 'test_section',
+			'key'         => 'active',
+			'type'        => 'boolean',
+			'default'     => false,
+			'public'      => true,
+		],
+		[
+			'description' => 'My first field',
+			'help'        => 'Help text',
+			'section'     => 'test_section',
+			'key'         => 'first_field',
+			'type'        => 'boolean',
+			'default'     => true,
+			'public'      => true,
+		],
+		[
+			'description' => 'My number field',
+			'help'        => 'Help text',
+			'section'     => 'test_section',
+			'key'         => 'number_field',
+			'type'        => 'integer',
+			'default'     => true,
+			'public'      => true,
+		],
+		[
+			'description' => 'A private field',
+			'help'        => 'Help text',
+			'section'     => 'test_section',
+			'key'         => 'private_field',
+			'type'        => 'string',
+			'default'     => '',
+			'public'      => false,
+		],
+	];
+
+	/**
+	 * Set up stuff for testing.
+	 */
+	public function setUp() {
+		parent::setUp();
+		add_filter( 'newspack_ads_settings_list', [ __CLASS__, 'set_settings_list' ] );
+	}
+
+	/**
+	 * Add sample settings list.
+	 * 
+	 * @param array $settings_list List of settings.
+	 * 
+	 * @return array Updated settings list.
+	 */
+	public static function set_settings_list( $settings_list ) {
+		return $settings_list + self::$settings_list;
+	}
+  
+	/**
+	 * Test that the returned settings values does not contain non-public values.
+	 */
+	public function test_get_public_settings() {
+		$settings = Newspack_Ads_Settings::get_settings( 'test_section', true );
+		self::assertFalse(
+			isset( $settings['private_field'] ),
+			'Private settings should not be returned'
+		);
+	}
+
+	/**
+	 * Test that the values are properly updated with configured type.
+	 */
+	public function test_update_value() {
+		Newspack_Ads_Settings::update_section(
+			'test_section',
+			[
+				'active'        => '1',
+				'first_field'   => '0',
+				'number_field'  => '200',
+				'private_field' => true,
+			]
+		);
+		$settings = Newspack_Ads_Settings::get_settings( 'test_section' );
+		self::assertSame(
+			$settings['active'],
+			true,
+			'Boolean value should be updated with proper type'
+		);
+		self::assertSame(
+			$settings['first_field'],
+			false,
+			'Boolean value should be updated with proper type'
+		);
+		self::assertSame(
+			$settings['number_field'],
+			200,
+			'Integer value should be updated with proper type'
+		);
+		self::assertSame(
+			$settings['private_field'],
+			'1',
+			'String value should be updated with proper type'
+		);
+	}
+}

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -83,7 +83,6 @@ class SettingsTest extends WP_UnitTestCase {
 		add_filter( 'newspack_ads_settings_list', [ __CLASS__, 'set_settings_list' ] );
 		$values = [
 			'active'        => '1',
-			'first_field'   => '0',
 			'number_field'  => '200',
 			'private_field' => true,
 		];
@@ -92,11 +91,6 @@ class SettingsTest extends WP_UnitTestCase {
 		self::assertSame(
 			$settings['active'],
 			true,
-			'Boolean value should be updated with proper type'
-		);
-		self::assertSame(
-			$settings['first_field'],
-			false,
 			'Boolean value should be updated with proper type'
 		);
 		self::assertSame(

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -81,15 +81,13 @@ class SettingsTest extends WP_UnitTestCase {
 	 */
 	public function test_update_value() {
 		add_filter( 'newspack_ads_settings_list', [ __CLASS__, 'set_settings_list' ] );
-		Newspack_Ads_Settings::update_section(
-			'test_section',
-			[
-				'active'        => '1',
-				'first_field'   => '0',
-				'number_field'  => '200',
-				'private_field' => true,
-			]
-		);
+		$values = [
+			'active'        => '1',
+			'first_field'   => '0',
+			'number_field'  => '200',
+			'private_field' => true,
+		];
+		Newspack_Ads_Settings::update_section( 'test_section', $values );
 		$settings = Newspack_Ads_Settings::get_settings( 'test_section' );
 		self::assertSame(
 			$settings['active'],

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -51,6 +51,23 @@ class SettingsTest extends WP_UnitTestCase {
 			'default'     => '',
 			'public'      => false,
 		],
+		[
+			'description' => 'A select field',
+			'help'        => 'Help text',
+			'section'     => 'test_section',
+			'key'         => 'select_field',
+			'type'        => 'string',
+			'options'     => [
+				[
+					'value' => 'option1',
+					'name'  => 'Option 1',
+				],
+				[
+					'value' => 'option2',
+					'name'  => 'Option 2',
+				],
+			],
+		],
 	];
 
 	/**
@@ -102,6 +119,21 @@ class SettingsTest extends WP_UnitTestCase {
 			$settings['private_field'],
 			'1',
 			'String value should be updated with proper type'
+		);
+	}
+
+	/**
+	 * Test that a value update should be restricted to available options.
+	 */
+	public function test_update_value_within_options() {
+		add_filter( 'newspack_ads_settings_list', [ __CLASS__, 'set_settings_list' ] );
+		$values = [
+			'select_field' => 'not_an_option',
+		];
+		$result = Newspack_Ads_Settings::update_section( 'test_section', $values );
+		self::assertTrue(
+			is_wp_error( $result ),
+			'Should not update a value outside of existing options.'
 		);
 	}
 }

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -61,7 +61,7 @@ class SettingsTest extends WP_UnitTestCase {
 	 * @return array Updated settings list.
 	 */
 	public static function set_settings_list( $settings_list ) {
-		return $settings_list + self::$settings_list;
+		return array_merge( $settings_list, self::$settings_list );
 	}
   
 	/**

--- a/tests/test-settings.php
+++ b/tests/test-settings.php
@@ -54,18 +54,10 @@ class SettingsTest extends WP_UnitTestCase {
 	];
 
 	/**
-	 * Set up stuff for testing.
-	 */
-	public function setUp() {
-		parent::setUp();
-		add_filter( 'newspack_ads_settings_list', [ __CLASS__, 'set_settings_list' ] );
-	}
-
-	/**
 	 * Add sample settings list.
-	 * 
+	 *
 	 * @param array $settings_list List of settings.
-	 * 
+	 *
 	 * @return array Updated settings list.
 	 */
 	public static function set_settings_list( $settings_list ) {
@@ -76,6 +68,7 @@ class SettingsTest extends WP_UnitTestCase {
 	 * Test that the returned settings values does not contain non-public values.
 	 */
 	public function test_get_public_settings() {
+		add_filter( 'newspack_ads_settings_list', [ __CLASS__, 'set_settings_list' ] );
 		$settings = Newspack_Ads_Settings::get_settings( 'test_section', true );
 		self::assertFalse(
 			isset( $settings['private_field'] ),
@@ -87,6 +80,7 @@ class SettingsTest extends WP_UnitTestCase {
 	 * Test that the values are properly updated with configured type.
 	 */
 	public function test_update_value() {
+		add_filter( 'newspack_ads_settings_list', [ __CLASS__, 'set_settings_list' ] );
 		Newspack_Ads_Settings::update_section(
 			'test_section',
 			[


### PR DESCRIPTION
Implements configurable settings for the Ads plugin. Initially set up to modify lazy load settings, but with support for multiple cases.

The default values for lazy load settings also changed and are as suggested by @kmwilkerson. It should produce the following immediate change on GPT configuration script:

```diff
googletag.pubads().enableLazyLoad( {
-  fetchMarginPercent: 500,   // Fetch slots within 5 viewports.
+  fetchMarginPercent: 100,   // Fetch slots within 1 viewport.
-  renderMarginPercent: 200,  // Render slots within 2 viewports.
+  renderMarginPercent: 0,  // Render slots upon view.
  mobileScaling: 2.0         // Double the above values on mobile.
} );
```

A setting is an array with the following keys:
- description: The description of the setting.
- help: The help text for the setting.
- section: The section the setting is in.
- key: The key of the setting. Should be used along with the section name.
- type: The type of the setting. Used to typecast the value.
- default: The default value of the setting.
- options: Options to be used for a select field. Values outside of this array will not update.
  - name: The name of the option.
  - value: The value of the option.
- public: Whether the setting value is allowed to be displayed publicly on the frontend.

Settings without `key` or with the `key` of value `active` should be interpreted as section headers on the UI. In the case of `active`, it is a module that can be activated or deactivated.

It also implements API endpoints for:
 - fetching settings list
 - fetching and updating settings values
 
## How to test

 1. Written tests should pass
 2. Test API at https://github.com/Automattic/newspack-plugin/pull/1208