### PR TITLE
Fix/circleci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ commands:
       - run:
           name: Install PHP extensions
           command: |
-            sudo apt-get update && sudo apt-get install -y libxml2-dev
+            sudo apt-get update && sudo apt-get install -y libxml2-dev php-soap
       - attach_workspace:
           at: ~/
 
@@ -60,8 +60,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            sudo apt-get update && sudo apt-get install subversion
-            sudo apt-get update && sudo apt-get install default-mysql-client
+            sudo apt-get update && sudo apt-get install -y subversion default-mysql-client
       - run:
           name: Run Tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,6 @@ jobs:
           name: Install Dependencies
           command: |
             sudo apt-get update && sudo apt-get install subversion
-            sudo -E docker-php-ext-install mysqli
             sudo apt-get update && sudo apt-get install default-mysql-client
       - run:
           name: Run Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ commands:
       - run:
           name: Install PHP extensions
           command: |
-            sudo apt-get update && sudo apt-get install -y libxml2-dev php-soap
+            sudo apt-get update && sudo apt-get install -y libxml2-dev php7.4-soap
       - attach_workspace:
           at: ~/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,14 +8,13 @@ commands:
           name: Install PHP extensions
           command: |
             sudo apt-get update && sudo apt-get install -y libxml2-dev
-            sudo -E docker-php-ext-install soap
       - attach_workspace:
           at: ~/
 
 jobs:
   build:
     docker:
-      - image: circleci/php:7.4-node-browsers
+      - image: cimg/php:7.4-browsers
     steps:
       - checkout_with_workspace
       - run:
@@ -29,7 +28,7 @@ jobs:
   # Linting
   lint:
     docker:
-      - image: circleci/php:7.4-node-browsers
+      - image: cimg/php:7.4-browsers
     steps:
       - checkout_with_workspace
       - run:
@@ -46,7 +45,7 @@ jobs:
 
   test-php:
     docker:
-      - image: circleci/php:7.3
+      - image: cimg/php:7.4
       - image: circleci/mysql:5.6
     environment:
       - WP_TESTS_DIR: '/tmp/wordpress-tests-lib'
@@ -76,7 +75,7 @@ jobs:
   # Release job
   release:
     docker:
-      - image: circleci/php:7.4-node-browsers
+      - image: cimg/php:7.4-browsers
     steps:
       - checkout_with_workspace
       - run:
@@ -92,7 +91,7 @@ jobs:
   # Reset alpha branch after a release
   post_release:
     docker:
-      - image: circleci/php:7.4-node-browsers
+      - image: cimg/php:7.4-browsers
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ commands:
 jobs:
   build:
     docker:
-      - image: circleci/php:7.3-node-browsers
+      - image: circleci/php:7.4-node-browsers
     steps:
       - checkout_with_workspace
       - run:
@@ -29,7 +29,7 @@ jobs:
   # Linting
   lint:
     docker:
-      - image: circleci/php:7.3-node-browsers
+      - image: circleci/php:7.4-node-browsers
     steps:
       - checkout_with_workspace
       - run:
@@ -76,7 +76,7 @@ jobs:
   # Release job
   release:
     docker:
-      - image: circleci/php:7.3-node-browsers
+      - image: circleci/php:7.4-node-browsers
     steps:
       - checkout_with_workspace
       - run:
@@ -92,7 +92,7 @@ jobs:
   # Reset alpha branch after a release
   post_release:
     docker:
-      - image: circleci/php:7.3-node-browsers
+      - image: circleci/php:7.4-node-browsers
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Recent changes made to `circleci/php:7.3-node-browsers` resulted in our builds fail due to an incompatibility with our `node-sass` dependency.

[`circleci/` images are being deprecated and will lose support starting December 2021](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034). We should start moving towards maintained images.

This PR implements the use of `cimg/` images and changes the PHP extension install method from the `docker-php-ext-install` command to `apt` since the command is not supported on `cimg/php:7.4`.