### PR TITLE
feat: integrate SCAIP settings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
             composer install
             composer require "phpunit/phpunit=5.7.*"
             rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
+            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 5.8.1
             ./vendor/bin/phpunit
 
   # Release job

--- a/includes/class-newspack-ads-scaip.php
+++ b/includes/class-newspack-ads-scaip.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Newspack Ads SCAIP Hooks
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Newspack Ads SCAIP Class.
+ */
+class Newspack_Ads_SCAIP {
+
+	// Map of SCAIP option names.
+	const OPTIONS_MAP = array(
+		'start'          => 'scaip_settings_start',
+		'period'         => 'scaip_settings_period',
+		'repetitions'    => 'scaip_settings_repetitions',
+		'min_paragraphs' => 'scaip_settings_min_paragraphs',
+	);
+
+	/**
+	 * Initialize SCAIP Hooks.
+	 */
+	public static function init() {
+		add_filter( 'newspack_ads_settings_list', array( __CLASS__, 'add_settings' ) );
+		add_filter( 'newspack_ads_setting_option_name', array( __CLASS__, 'map_option_name' ), 10, 2 );
+	}
+
+	/**
+	 * Add SCAIP settings to the list of settings.
+	 *
+	 * @param array $settings_list List of settings.
+	 *
+	 * @return array Updated list of settings.
+	 */
+	public static function add_settings( $settings_list ) {
+
+		if ( ! defined( 'SCAIP_PLUGIN_FILE' ) ) {
+			return $settings_list;
+		}
+
+		$scaip_settings = array(
+			array(
+				'description' => __( 'Post ad inserter settings', 'newspack-ads' ),
+				'help'        => __( 'Super Cool Ad Inserter plugin options', 'newspack-ads' ),
+				'section'     => 'scaip',
+			),
+			array(
+				'description' => __( 'Number of blocks before first insertion', 'newspack-ads' ),
+				'section'     => 'scaip',
+				'key'         => 'start',
+				'type'        => 'int',
+				'default'     => 3,
+			),
+			array(
+				'description' => __( 'Number of blocks between insertions', 'newspack-ads' ),
+				'section'     => 'scaip',
+				'key'         => 'period',
+				'type'        => 'int',
+				'default'     => 3,
+			),
+			array(
+				'description' => __( 'Number of times an ad widget area should be inserted in a post', 'newspack-ads' ),
+				'section'     => 'scaip',
+				'key'         => 'repetitions',
+				'type'        => 'int',
+				'default'     => 2,
+			),
+			array(
+				'description' => __( 'Minimum number of blocks needed in a post to insert ads', 'newspack-ads' ),
+				'section'     => 'scaip',
+				'key'         => 'min_paragraphs',
+				'type'        => 'int',
+				'default'     => 6,
+			),
+		);
+		return array_merge( $settings_list, $scaip_settings );
+	}
+
+	/**
+	 * Map the option name to the one set on the SCAIP plugin.
+	 *
+	 * @param string $option_name The option name.
+	 * @param array  $setting     The setting configuration array.
+	 *
+	 * @return string Updated option name.
+	 */
+	public static function map_option_name( $option_name, $setting ) {
+		if ( 'scaip' === $setting['section'] && isset( self::OPTIONS_MAP[ $setting['key'] ] ) ) {
+			return self::OPTIONS_MAP[ $setting['key'] ];
+		}
+		return $option_name;
+	}
+}
+Newspack_Ads_SCAIP::init();

--- a/includes/class-newspack-ads-scaip.php
+++ b/includes/class-newspack-ads-scaip.php
@@ -88,7 +88,7 @@ class Newspack_Ads_SCAIP {
 	 * @return string Updated option name.
 	 */
 	public static function map_option_name( $option_name, $setting ) {
-		if ( 'scaip' === $setting['section'] && isset( self::OPTIONS_MAP[ $setting['key'] ] ) ) {
+		if ( 'scaip' === $setting['section'] && isset( $setting['key'] ) && isset( self::OPTIONS_MAP[ $setting['key'] ] ) ) {
 			return self::OPTIONS_MAP[ $setting['key'] ];
 		}
 		return $option_name;

--- a/includes/class-newspack-ads-settings.php
+++ b/includes/class-newspack-ads-settings.php
@@ -128,7 +128,8 @@ class Newspack_Ads_Settings {
 	 * @return string Option name. 
 	 */
 	private static function get_setting_option_name( $setting ) {
-		return apply_filters( 'newspack_ads_setting_option_name', self::OPTION_NAME_PREFIX . $setting['section'] . '_' . $setting['key'], $setting );
+		$option_name = isset( $setting['key'] ) ? $setting['section'] . '_' . $setting['key'] : $setting['section'];
+		return apply_filters( 'newspack_ads_setting_option_name', self::OPTION_NAME_PREFIX . $option_name, $setting );
 	}
 
 	/**

--- a/includes/class-newspack-ads-settings.php
+++ b/includes/class-newspack-ads-settings.php
@@ -128,7 +128,7 @@ class Newspack_Ads_Settings {
 	 * @return string Option name. 
 	 */
 	private static function get_setting_option_name( $setting ) {
-		return self::OPTION_NAME_PREFIX . $setting['section'] . '_' . $setting['key'];
+		return apply_filters( 'newspack_ads_setting_option_name', self::OPTION_NAME_PREFIX . $setting['section'] . '_' . $setting['key'], $setting );
 	}
 
 	/**

--- a/includes/class-newspack-ads.php
+++ b/includes/class-newspack-ads.php
@@ -70,6 +70,7 @@ final class Newspack_Ads {
 	 */
 	private function includes() {
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-newspack-ads-settings.php';
+		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-newspack-ads-scaip.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-newspack-ads-blocks.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-newspack-ads-gam.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-newspack-ads-model.php';


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/820752/141485382-261e50c4-3900-4d5c-a315-734c8fb97112.png)

This PR adds SCAIP settings as a section on Ads settings.

I'd appreciate a second opinion from the reviewer if we should also remove the original SCAIP settings page. This is not implemented here and I'm not sure if we should.

Closes #177.

### How to test

1. Check out this branch and https://github.com/Automattic/newspack-plugin/pull/1248 for a section layout fix
2. Make sure you have SCAIP installed and have tweaked its default settings
3. Visit the Advertising -> Global Settings wizard
4. Observe your settings are being shown at the "Post ad inserter settings"
5. Update the settings, visit the SCAIP settings page and confirm the results match