### PR TITLE
feat: handle missing API access error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
             composer install
             composer require "phpunit/phpunit=5.7.*"
             rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
+            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 5.8.1
             ./vendor/bin/phpunit
 
   # Release job

--- a/includes/class-newspack-ads-gam.php
+++ b/includes/class-newspack-ads-gam.php
@@ -283,7 +283,17 @@ class Newspack_Ads_GAM {
 			}
 			return $ad_units_serialised;
 		} catch ( \Exception $e ) {
-			return [];
+			$error_message = $e->getMessage();
+			if ( 0 < strpos( $error_message, 'NETWORK_API_ACCESS_DISABLED' ) ) {
+				$network_code  = self::get_gam_network_code();
+				$settings_link = "https://admanager.google.com/${network_code}#admin/settings/network";
+				$error_message = __( 'API access for this GAM intance is disabled.', 'newspack-ads' ) .
+				" <a href=\"${settings_link}\">" . __( 'Enable API access in your GAM settings.', 'newspack' ) . '</a>';
+			}
+			return new WP_Error(
+				'newspack_ads_gam_get_ad_units',
+				$error_message
+			);
 		}
 	}
 

--- a/includes/class-newspack-ads-gam.php
+++ b/includes/class-newspack-ads-gam.php
@@ -284,7 +284,7 @@ class Newspack_Ads_GAM {
 			return $ad_units_serialised;
 		} catch ( \Exception $e ) {
 			$error_message = $e->getMessage();
-			if ( 0 < strpos( $error_message, 'NETWORK_API_ACCESS_DISABLED' ) ) {
+			if ( 0 <= strpos( $error_message, 'NETWORK_API_ACCESS_DISABLED' ) ) {
 				$network_code  = self::get_gam_network_code();
 				$settings_link = "https://admanager.google.com/${network_code}#admin/settings/network";
 				$error_message = __( 'API access for this GAM intance is disabled.', 'newspack-ads' ) .

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -204,7 +204,10 @@ class Newspack_Ads_Model {
 		$ad_units = self::get_legacy_ad_units();
 		if ( self::is_gam_connected() ) {
 			$gam_ad_units = Newspack_Ads_GAM::get_serialised_gam_ad_units();
-			$sync_result  = self::sync_gam_settings( $gam_ad_units );
+			if ( \is_wp_error( $gam_ad_units ) ) {
+				return $gam_ad_units;
+			}
+			$sync_result = self::sync_gam_settings( $gam_ad_units );
 			if ( \is_wp_error( $sync_result ) ) {
 				return $sync_result;
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

A pesky GAM issue.

### How to test the changes in this Pull Request:

1. Visit your GAM instance and uncheck "API access" (`https://admanager.google.com/<network-code>#admin/settings/network`)
2. On `master`, observe that no GAM ad units are loaded
3. Switch to this branch, observe an error displayed with the link to the settings

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->