### PR TITLE
feat: disable ads on 404

### DIFF
--- a/includes/suppress-ads.php
+++ b/includes/suppress-ads.php
@@ -42,6 +42,10 @@ add_action( 'enqueue_block_editor_assets', 'newspack_ads_enqueue_suppress_ad_ass
 function newspack_ads_should_show_ads( $post_id = null ) {
 	$should_show = true;
 
+	if ( is_404() ) {
+		$should_show = false;
+	}
+
 	if ( is_singular() ) {
 		if ( null === $post_id ) {
 			$post_id = get_the_ID();


### PR DESCRIPTION
Disable ads on 404 pages by default.

Closes #238.

### How to test

1. Make sure you have a valid ad unit placed on "Above Header" or any global placement that would be visible on a 404 page.
2. On the master branch, visit a 404 page and see your ads being displayed
3. Check out this branch and make sure no ads are visible
4. Navigate through your home page and a single post page and ensure that the ads are visible

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201434638758913