### PR TITLE
fix: connection mode

### DIFF
--- a/includes/class-newspack-ads-gam.php
+++ b/includes/class-newspack-ads-gam.php
@@ -595,7 +595,7 @@ class Newspack_Ads_GAM {
 		$can_use_service_account = self::can_use_service_account();
 		$response                = [
 			'connected'               => false,
-			'connection_details'      => $connection_details['mode'],
+			'connection_mode'         => $connection_details['mode'],
 			'can_use_oauth'           => $can_use_oauth,
 			'can_use_service_account' => $can_use_service_account,
 		];


### PR DESCRIPTION
Fixes a bug:

1. On `master`, visit the Advertising wizard on a site in legacy mode (without GAM connection)
2. Observe there's not notice about legacy mode and no GAM network input
3. Switch to this branch, observe there are the notice and input 