### PR TITLE
feat: handle multiple gam accounts

### DIFF
--- a/includes/class-newspack-ads-gam.php
+++ b/includes/class-newspack-ads-gam.php
@@ -130,6 +130,7 @@ class Newspack_Ads_GAM {
 	 * Get GAM networks the authenticated user has access to.
 	 *
 	 * @return Network[] Array of networks.
+	 * @throws \Exception If not able to fetch networks.
 	 */
 	private static function get_gam_networks() {
 		if ( empty( self::$networks ) ) {
@@ -155,6 +156,7 @@ class Newspack_Ads_GAM {
 	 * Get serialized GAM networks the authenticated user has access to.
 	 *
 	 * @return array[] Array of serialized networks.
+	 * @throws \Exception If not able to fetch networks.
 	 */
 	public static function get_serialized_gam_networks() {
 		$networks = self::get_gam_networks();

--- a/includes/class-newspack-ads-gam.php
+++ b/includes/class-newspack-ads-gam.php
@@ -18,6 +18,7 @@ use Google\AdsApi\AdManager\v202102\ServiceFactory;
 use Google\AdsApi\AdManager\v202102\ArchiveAdUnits as ArchiveAdUnitsAction;
 use Google\AdsApi\AdManager\v202102\ActivateAdUnits as ActivateAdUnitsAction;
 use Google\AdsApi\AdManager\v202102\DeactivateAdUnits as DeactivateAdUnitsAction;
+use Google\AdsApi\AdManager\v202102\Network;
 use Google\AdsApi\AdManager\v202102\AdUnit;
 use Google\AdsApi\AdManager\v202102\AdUnitSize;
 use Google\AdsApi\AdManager\v202102\AdUnitTargetWindow;
@@ -50,6 +51,13 @@ class Newspack_Ads_GAM {
 	private static $session = null;
 
 	/**
+	 * GAM Network Code in use.
+	 *
+	 * @var string
+	 */
+	private static $network_code = null;
+
+	/**
 	 * Custom targeting keys.
 	 *
 	 * @var string[]
@@ -60,6 +68,15 @@ class Newspack_Ads_GAM {
 		'category',
 		'post_type',
 	];
+
+	/**
+	 * Set the network code to be used.
+	 *
+	 * @param string $network_code Network code.
+	 */
+	public static function set_network_code( $network_code ) {
+		self::$network_code = $network_code;
+	}
 
 	/**
 	 * Get credentials for connecting to GAM.
@@ -135,15 +152,42 @@ class Newspack_Ads_GAM {
 	}
 
 	/**
-	 * Get user's GAM network. Assumes the user has access to just one.
+	 * Get serialized GAM networks the authenticated user has access to.
+	 *
+	 * @return array[] Array of serialized networks.
+	 */
+	public static function get_serialized_gam_networks() {
+		$networks = self::get_gam_networks();
+		return array_map(
+			function( $network ) {
+				return [
+					'id'   => $network->getId(),
+					'name' => $network->getDisplayName(),
+					'code' => $network->getNetworkCode(),
+				];
+			},
+			$networks
+		);
+	}
+
+	/**
+	 * Get user's GAM network. Defaults to the first found network if not found or empty.
 	 *
 	 * @return Network GAM network.
 	 * @throws \Exception If there is no GAM network to use.
 	 */
 	private static function get_gam_network() {
-		$networks = self::get_gam_networks();
+		$networks     = self::get_gam_networks();
+		$network_code = self::$network_code;
 		if ( empty( $networks ) ) {
 			throw new \Exception( __( 'Missing GAM Ad network.', 'newspack-ads' ) );
+		}
+		if ( $network_code ) {
+			foreach ( $networks as $network ) {
+				if ( $network_code === $network->getNetworkCode() ) {
+					return $network;
+				}
+			}
 		}
 		return $networks[0];
 	}
@@ -292,7 +336,11 @@ class Newspack_Ads_GAM {
 			}
 			return new WP_Error(
 				'newspack_ads_gam_get_ad_units',
-				$error_message
+				$error_message,
+				array(
+					'status' => '400',
+					'level'  => 'warning',
+				)
 			);
 		}
 	}
@@ -485,7 +533,12 @@ class Newspack_Ads_GAM {
 		try {
 			$keys = $service->getCustomTargetingKeysByStatement( $statement );
 		} catch ( \Exception $e ) {
-			throw new \Exception( __( 'Unable to find existing targeting keys', 'newspack-ads' ) );
+			$error_message = $e->getMessage();
+			if ( 0 <= strpos( $error_message, 'NETWORK_API_ACCESS_DISABLED' ) ) {
+				throw new \Exception( __( 'API access for this GAM intance is disabled.', 'newspack-ads' ) );
+			} else {
+				throw new \Exception( __( 'Unable to find existing targeting keys.', 'newspack-ads' ) );
+			}
 		}
 
 		$keys_to_create = array_values(

--- a/includes/class-newspack-ads-gam.php
+++ b/includes/class-newspack-ads-gam.php
@@ -331,7 +331,7 @@ class Newspack_Ads_GAM {
 			if ( 0 <= strpos( $error_message, 'NETWORK_API_ACCESS_DISABLED' ) ) {
 				$network_code  = self::get_gam_network_code();
 				$settings_link = "https://admanager.google.com/${network_code}#admin/settings/network";
-				$error_message = __( 'API access for this GAM intance is disabled.', 'newspack-ads' ) .
+				$error_message = __( 'API access for this GAM account is disabled.', 'newspack-ads' ) .
 				" <a href=\"${settings_link}\">" . __( 'Enable API access in your GAM settings.', 'newspack' ) . '</a>';
 			}
 			return new WP_Error(
@@ -535,7 +535,7 @@ class Newspack_Ads_GAM {
 		} catch ( \Exception $e ) {
 			$error_message = $e->getMessage();
 			if ( 0 <= strpos( $error_message, 'NETWORK_API_ACCESS_DISABLED' ) ) {
-				throw new \Exception( __( 'API access for this GAM intance is disabled.', 'newspack-ads' ) );
+				throw new \Exception( __( 'API access for this GAM account is disabled.', 'newspack-ads' ) );
 			} else {
 				throw new \Exception( __( 'Unable to find existing targeting keys.', 'newspack-ads' ) );
 			}

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -51,6 +51,7 @@ class Newspack_Ads_Model {
 	 */
 	public static function init() {
 		add_action( 'init', array( __CLASS__, 'register_ad_post_type' ) );
+		Newspack_Ads_GAM::set_network_code( get_option( self::OPTION_NAME_GAM_NETWORK_CODE, null ) );
 	}
 
 	/**
@@ -833,6 +834,15 @@ class Newspack_Ads_Model {
 			$status['is_network_code_matched'] = self::is_network_code_matched();
 		}
 		return $status;
+	}
+
+	/**
+	 * Get GAM available networks.
+	 *
+	 * @return array[] Array of available networks.
+	 */
+	public static function get_gam_available_networks() {
+		return Newspack_Ads_GAM::get_serialized_gam_networks();
 	}
 
 	/**

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -839,10 +839,15 @@ class Newspack_Ads_Model {
 	/**
 	 * Get GAM available networks.
 	 *
-	 * @return array[] Array of available networks.
+	 * @return array[] Array of available networks. Empty array if no networks found or unable to fetch.
 	 */
 	public static function get_gam_available_networks() {
-		return Newspack_Ads_GAM::get_serialized_gam_networks();
+		try {
+			$networks = Newspack_Ads_GAM::get_serialized_gam_networks();
+		} catch ( Exception $e ) {
+			$networks = [];
+		}
+		return $networks;
 	}
 
 	/**


### PR DESCRIPTION
Handles a user connection that has multiple GAM accounts and the ability to choose which should be used by Newspack Ads.

Closes #225 

### How to test

1. Check out this branch and https://github.com/Automattic/newspack-plugin/pull/1334
2. Make sure you are authenticated with Google OAuth (Connections wizard) and your account has at least 2 connected GAM networks.
3. Visit the Advertising wizard and click "Configure" on the Google Ad Manager card.
4. Confirm the new dropdown selector to choose between the available networks
5. Select a different network and make sure the ad units are updated accordingly
6. Refresh the page and confirm your selection persisted
7. Visit the Placements area and confirm you are able to use the ad units for the selected network