### PR TITLE
fix: allow prebid.js to load async

### DIFF
--- a/includes/class-newspack-ads-bidding.php
+++ b/includes/class-newspack-ads-bidding.php
@@ -92,7 +92,7 @@ class Newspack_Ads_Bidding {
 			'script_loader_tag',
 			function( $tag, $handle, $src ) {
 				if ( self::PREBID_SCRIPT_HANDLE === $handle ) {
-					return '<script data-amp-plus-allowed src="' . $src . '"></script>';
+					return '<script data-amp-plus-allowed async src="' . $src . '"></script>';
 				}
 				return $tag;
 			},
@@ -277,15 +277,13 @@ class Newspack_Ads_Bidding {
 		?>
 		<script data-amp-plus-allowed>
 			( function() {
-				if ( 'undefined' === typeof window.pbjs || 'undefined' === typeof window.googletag ) {
-					return;
-				}
+				window.pbjs = window.pbjs || { que: [] };
 				var config = <?php echo wp_json_encode( $prebid_config ); ?>;
 				var adUnits = <?php echo wp_json_encode( $ad_units ); ?>;
-				window.pbjs.que.push( function() {
-					window.pbjs.setConfig( config );
-					window.pbjs.addAdUnits( adUnits );
-					window.pbjs.requestBids( {
+				pbjs.que.push( function() {
+					pbjs.setConfig( config );
+					pbjs.addAdUnits( adUnits );
+					pbjs.requestBids( {
 						timeout: config.bidderTimeout,
 						bidsBackHandler: initAdserver,
 					} );
@@ -299,11 +297,12 @@ class Newspack_Ads_Bidding {
 					?>
 				} );
 				function initAdserver() {
-					if ( window.pbjs.initAdserverSet ) return;
-					window.pbjs.initAdserverSet = true;
-					window.googletag.cmd.push( function() {
-						window.pbjs.setTargetingForGPTAsync && window.pbjs.setTargetingForGPTAsync();
-						window.googletag.pubads().refresh();
+					if ( pbjs.initAdserverSet ) return;
+					pbjs.initAdserverSet = true;
+					window.googletag = window.googletag || { cmd: [] };
+					googletag.cmd.push( function() {
+						pbjs.setTargetingForGPTAsync && pbjs.setTargetingForGPTAsync();
+						googletag.pubads().refresh();
 					} );
 				}
 				// In case pbjs doesnt load, try again after the failsafe timeout of 3000ms.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@wordpress/edit-post": "^3.13.6",
         "@wordpress/i18n": "^3.9.0",
         "@wordpress/plugins": "^2.12.0",
-        "prebid.js": "^6.2.0"
+        "prebid.js": "^6.4.0"
       },
       "devDependencies": {
         "@automattic/calypso-build": "^10.0.0",
@@ -30762,9 +30762,9 @@
       }
     },
     "node_modules/prebid.js": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/prebid.js/-/prebid.js-6.2.0.tgz",
-      "integrity": "sha512-46B1H5Jbzr8Jhm86mhHTMMQLzBpCBXHkroZY/J3p8ZMBQtenR+C2PCmyjGpVdS7ITiiYZwDjvttI02xW3hhvIg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/prebid.js/-/prebid.js-6.4.0.tgz",
+      "integrity": "sha512-Oi3Vb5Ax6c6c4jNCV01KWl5NfsNX/m3XGyUQYiPcKdl3uJGCcFpbex/xAQ+sjWRyK1LbFr91z4pnYfLDdHAkrA==",
       "dependencies": {
         "babel-plugin-transform-object-assign": "^6.22.0",
         "core-js": "^3.13.0",
@@ -61278,9 +61278,9 @@
       }
     },
     "prebid.js": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/prebid.js/-/prebid.js-6.2.0.tgz",
-      "integrity": "sha512-46B1H5Jbzr8Jhm86mhHTMMQLzBpCBXHkroZY/J3p8ZMBQtenR+C2PCmyjGpVdS7ITiiYZwDjvttI02xW3hhvIg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/prebid.js/-/prebid.js-6.4.0.tgz",
+      "integrity": "sha512-Oi3Vb5Ax6c6c4jNCV01KWl5NfsNX/m3XGyUQYiPcKdl3uJGCcFpbex/xAQ+sjWRyK1LbFr91z4pnYfLDdHAkrA==",
       "requires": {
         "babel-plugin-transform-object-assign": "^6.22.0",
         "core-js": "^3.13.0",

--- a/package.json
+++ b/package.json
@@ -135,6 +135,6 @@
     "@wordpress/edit-post": "^3.13.6",
     "@wordpress/i18n": "^3.9.0",
     "@wordpress/plugins": "^2.12.0",
-    "prebid.js": "^6.2.0"
+    "prebid.js": "^6.4.0"
   }
 }

--- a/src/prebid/index.js
+++ b/src/prebid/index.js
@@ -8,7 +8,5 @@ import 'prebid.js/modules/express';
 import 'prebid.js/modules/medianetBidAdapter';
 import 'prebid.js/modules/medianetRtdProvider';
 
-window.pbjs = window.pbjs || pbjs;
-
 // Required to process existing pbjs.queue blocks and setup any further pbjs.queue execution.
 pbjs.processQueue();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,4 +60,15 @@ const webpackConfig = getBaseWebpackConfig(
 	}
 );
 
+webpackConfig.module.rules.push( {
+	test: /.js$/,
+	include: new RegExp( `\\${ path.sep }prebid\.js` ),
+	use: {
+		loader: 'babel-loader',
+		// presets and plugins for Prebid.js must be manually specified separate from your other babel rule.
+		// this can be accomplished by requiring prebid's .babelrc.js file (requires Babel 7 and Node v8.9.0+)
+		options: require( 'prebid.js/.babelrc.js' ),
+	},
+} );
+
 module.exports = webpackConfig;


### PR DESCRIPTION
The current implementation of the `prebid.js` script does not allow it to be loaded asynchronously. It requires an [extra webpack plugin](https://github.com/prebid/Prebid.js/blob/master/plugins/pbjsGlobals.js) on its build so it can correctly pull previously queued commands and inject itself to the window.

This PR implements the plugin, add the `async` attribute to the script and updates the prebid.js version

## How to test

Run `npm ci && npm run build` and make sure `DevTools` continue to display the logs as specified at #231.