### PR TITLE
fix: hide header bidding if using AMP

### DIFF
--- a/includes/class-newspack-ads-bidding.php
+++ b/includes/class-newspack-ads-bidding.php
@@ -483,6 +483,12 @@ class Newspack_Ads_Bidding {
 	 */
 	public function register_settings( $settings_list ) {
 
+		// Skip if using AMP.
+		if ( Newspack_Ads::is_amp() ) {
+			return $settings_list;
+		}
+
+		// Skip if no bidders are registered.
 		if ( false === $this->has_registered_bidders() ) {
 			return $settings_list;
 		}


### PR DESCRIPTION
Hide header bidding settings if using AMP.

### How to test

1. Remove `NEWSPACK_AMP_PLUS_ENABLED` if you have it and make sure AMP is enabled
2. Make sure you have `NEWSPACK_ADS_EXPERIMENTAL_MEDIANET` set to true
3. On the master branch, visit Newsletters -> Settings
4. Observe the header bidding settings are visible, although it wouldn't work because of JS requirements
5. Switch to this branch and refresh the page
6. Confirm header bidding settings are no longer visible
7. Visit the Placements, edit a placement and confirm the bidder placement ID is also not displayed
