### PR TITLE
feat(placements): stick to top support

### DIFF
--- a/includes/class-newspack-ads-placements.php
+++ b/includes/class-newspack-ads-placements.php
@@ -268,7 +268,8 @@ class Newspack_Ads_Placements {
 	 * - hooks: An array of action hooks to inject an ad unit into.
 	 *   - name: The friendly name of the hook.
 	 *   - hook_name: The name of the WordPress action hook to inject the ad unit into.
-	 * - supports: An array of supported placement features. Supported features are: 'stick_to_top'.
+	 * - supports: An array of supported placement features. Available features are:
+	 *   - `stick_to_top`: Whether the placement should be sticky to the top of the page.
 	 *
 	 * @return array Placement objects.
 	 */

--- a/includes/class-newspack-ads-placements.php
+++ b/includes/class-newspack-ads-placements.php
@@ -499,7 +499,7 @@ class Newspack_Ads_Placements {
 			[
 				'newspack_global_ad'             => true,
 				$placement_key                   => true,
-				$placement_key . '-' . $hook_key => true,
+				$placement_key . '-' . $hook_key => ! empty( $hook_key ),
 				'stick-to-top'                   => $stick_to_top,
 			],
 			$placement_key,

--- a/includes/class-newspack-ads-placements.php
+++ b/includes/class-newspack-ads-placements.php
@@ -41,17 +41,20 @@ class Newspack_Ads_Placements {
 				'callback'            => [ __CLASS__, 'api_update_placement' ],
 				'permission_callback' => [ 'Newspack_Ads_Settings', 'api_permissions_check' ],
 				'args'                => [
-					'placement'   => [
+					'placement'    => [
 						'sanitize_callback' => 'sanitize_title',
 					],
-					'ad_unit'     => [
+					'ad_unit'      => [
 						'sanitize_callback' => 'sanitize_text_field',
 					],
-					'bidders_ids' => [
+					'bidders_ids'  => [
 						'sanitize_callback' => [ __CLASS__, 'sanitize_bidders_ids' ],
 					],
-					'hooks'       => [
+					'hooks'        => [
 						'sanitize_callback' => [ __CLASS__, 'sanitize_hooks_data' ],
+					],
+					'stick_to_top' => [
+						'sanitize_callback' => 'rest_sanitize_boolean',
 					],
 				],
 			]
@@ -135,11 +138,12 @@ class Newspack_Ads_Placements {
 	 * @return WP_REST_Response containing the configured placements.
 	 */
 	public static function api_update_placement( $request ) {
-		$data   = array(
-			'ad_unit'     => $request['ad_unit'],
-			'bidders_ids' => $request['bidders_ids'],
-			'hooks'       => $request['hooks'],
-		);
+		$data   = [
+			'ad_unit'      => $request['ad_unit'],
+			'bidders_ids'  => $request['bidders_ids'],
+			'hooks'        => $request['hooks'],
+			'stick_to_top' => $request['stick_to_top'],
+		];
 		$result = self::update_placement( $request['placement'], $data );
 		if ( is_wp_error( $result ) ) {
 			return \rest_ensure_response( $result );
@@ -264,6 +268,7 @@ class Newspack_Ads_Placements {
 	 * - hooks: An array of action hooks to inject an ad unit into.
 	 *   - name: The friendly name of the hook.
 	 *   - hook_name: The name of the WordPress action hook to inject the ad unit into.
+	 * - supports: An array of supported placement features. Supported features are: 'stick_to_top'.
 	 *
 	 * @return array Placement objects.
 	 */
@@ -302,7 +307,17 @@ class Newspack_Ads_Placements {
 		$placements = apply_filters( 'newspack_ads_placements', $placements );
 
 		foreach ( $placements as $placement_key => $placement ) {
-			$placements[ $placement_key ]['data'] = self::get_placement_data( $placement_key, $placement );
+			$placements[ $placement_key ] = wp_parse_args(
+				$placement,
+				[
+					'name'            => '',
+					'description'     => '',
+					'default_enabled' => false,
+					'hook_name'       => '',
+					'supports'        => [],
+					'data'            => self::get_placement_data( $placement_key, $placement ),
+				]
+			);
 		}
 		return $placements;
 	}
@@ -365,6 +380,8 @@ class Newspack_Ads_Placements {
 			return new WP_Error( 'newspack_ads_invalid_placement', __( 'This placement does not exist.', 'newspack-ads' ) );
 		}
 
+		$placement = $placements[ $placement_key ];
+
 		// Updates always enables the placement.
 		$data['enabled'] = true;
 
@@ -378,6 +395,11 @@ class Newspack_Ads_Placements {
 					$data['hooks'][ $hook_key ]['id'] = self::get_id( [ $placement_key, $hook_key, $data['ad_unit'] ] );
 				}
 			}
+		}
+
+		// Handle "stick to top" feature update.
+		if ( in_array( 'stick_to_top', $placement['supports'], true ) ) {
+			$data['stick_to_top'] = isset( $data['stick_to_top'] ) ? (bool) $data['stick_to_top'] : false;
 		}
 
 		return update_option( self::get_option_name( $placement_key ), wp_json_encode( $data ) );
@@ -429,6 +451,8 @@ class Newspack_Ads_Placements {
 		$placement  = $placements[ $placement_key ];
 		$is_enabled = $placement['data']['enabled'];
 
+		$stick_to_top = isset( $placement['data']['stick_to_top'] ) ? (bool) $placement['data']['stick_to_top'] : false;
+
 		if ( $hook_key && isset( $placement['data']['hooks'] ) ) {
 			$placement_data = $placement['data']['hooks'][ $hook_key ];
 		} else {
@@ -462,17 +486,40 @@ class Newspack_Ads_Placements {
 
 		do_action( 'newspack_ads_before_placement_ad', $placement_key, $hook_key, $placement_data );
 
+		/**
+		 * Filters the classnames applied to the ad container.
+		 *
+		 * @param bool[] Associative array with classname as key and boolean as value.
+		 * @param string Placement key.
+		 * @param string Hook key.
+		 * @param array  Placement data.
+		 */
+		$classnames = apply_filters(
+			'newspack_ads_placement_classnames',
+			[
+				'newspack_global_ad'             => true,
+				$placement_key                   => true,
+				$placement_key . '-' . $hook_key => true,
+				'stick-to-top'                   => $stick_to_top,
+			],
+			$placement_key,
+			$hook_key,
+			$placement_data 
+		);
+
+		$classnames_str = implode( ' ', array_keys( array_filter( $classnames ) ) );
+
 		if ( 'sticky' === $placement_key && $is_amp ) :
 			?>
 			<div class="newspack_amp_sticky_ad__container">
-				<amp-sticky-ad class='newspack_amp_sticky_ad <?php echo esc_attr( $placement_key ); ?>' layout="nodisplay">
+				<amp-sticky-ad class='newspack_amp_sticky_ad <?php echo esc_attr( $classnames_str ); ?>' layout="nodisplay">
 					<?php echo $code; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				</amp-sticky-ad>
 			</div>
 			<?php
 		else :
 			?>
-			<div class='newspack_global_ad <?php echo esc_attr( $placement_key ); ?>'>
+			<div class='<?php echo esc_attr( $classnames_str ); ?>'>
 				<?php if ( 'sticky' === $placement_key ) : ?>
 					<button class='newspack_sticky_ad__close'></button>
 				<?php endif; ?>

--- a/includes/class-newspack-ads-placements.php
+++ b/includes/class-newspack-ads-placements.php
@@ -512,6 +512,7 @@ class Newspack_Ads_Placements {
 
 		do_action( 'newspack_ads_before_placement_ad', $placement_key, $hook_key, $placement_data );
 
+		$is_sticky_amp = 'sticky' === $placement_key && $is_amp;
 		/**
 		 * Filters the classnames applied to the ad container.
 		 *
@@ -523,22 +524,23 @@ class Newspack_Ads_Placements {
 		$classnames = apply_filters(
 			'newspack_ads_placement_classnames',
 			[
-				'newspack_global_ad'             => true,
+				'newspack_global_ad'             => ! $is_sticky_amp,
+				'newspack_amp_sticky_ad'         => $is_sticky_amp,
 				$placement_key                   => true,
 				$placement_key . '-' . $hook_key => ! empty( $hook_key ),
 				'stick-to-top'                   => $stick_to_top,
 			],
 			$placement_key,
 			$hook_key,
-			$placement_data 
+			$placement_data
 		);
 
 		$classnames_str = implode( ' ', array_keys( array_filter( $classnames ) ) );
 
-		if ( 'sticky' === $placement_key && $is_amp ) :
+		if ( $is_sticky_amp ) :
 			?>
 			<div class="newspack_amp_sticky_ad__container">
-				<amp-sticky-ad class='newspack_amp_sticky_ad <?php echo esc_attr( $classnames_str ); ?>' layout="nodisplay">
+				<amp-sticky-ad class='<?php echo esc_attr( $classnames_str ); ?>' layout="nodisplay">
 					<?php echo $code; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				</amp-sticky-ad>
 			</div>

--- a/includes/class-newspack-ads-sidebar-placements.php
+++ b/includes/class-newspack-ads-sidebar-placements.php
@@ -26,6 +26,11 @@ class Newspack_Ads_Sidebar_Placements {
 		'footer-3',
 	];
 
+	// Sidebars that allow sticky positioning.
+	const STICK_TO_TOP_SIDEBARS = [
+		'sidebar-1',
+	];
+
 	/**
 	 * Initialize settings.
 	 */
@@ -46,7 +51,7 @@ class Newspack_Ads_Sidebar_Placements {
 			do_action( sprintf( self::SIDEBAR_BEFORE_HOOK_NAME, $index ) );
 		}
 	}
-	
+
 	/**
 	 * Create a dynamic sidebar after action appropriate for ad unit insertion.
 	 *
@@ -89,12 +94,19 @@ class Newspack_Ads_Sidebar_Placements {
 					continue;
 				}
 
+				$supports = [];
+
+				if ( in_array( $sidebar['id'], self::STICK_TO_TOP_SIDEBARS, true ) ) {
+					$supports[] = 'stick_to_top';
+				}
+
 				$placement_config = [
 					'name'        => $sidebar['name'],
 					// Translators: %s: The name of the sidebar.
 					'description' => sprintf( __( 'Choose an ad unit to display in the "%s" widget area.', 'newspack-ads' ), $sidebar['name'] ),
+					'supports'    => $supports,
 				];
-				
+
 				if ( in_array( $sidebar['id'], $single_unit_sidebars, true ) ) {
 					$placement_config['hook_name'] = sprintf( self::SIDEBAR_BEFORE_HOOK_NAME, $sidebar['id'] );
 				} else {
@@ -109,7 +121,7 @@ class Newspack_Ads_Sidebar_Placements {
 						],
 					];
 				}
-				
+
 				$sidebar_placements[ $placement_key ] = $placement_config;
 			}
 		}


### PR DESCRIPTION
Implements "stick to top" support for any registered placement configured with `'supports' => [ 'stick_to_top' ]`. Enables support for the "Sidebar 1" placement.

Closes #244 

## How to test

 - Check out this branch and https://github.com/Automattic/newspack-plugin/pull/1365
 - Confirm you have AMP Plus enabled
 - Visit **Advertising -> Placements** wizard, enable and edit the **Sidebar** placement
 - Select a viable ad unit as "after widget area", check the "Stick to top" checkbox and save
 - Visit a page/post with the sidebar and confirm the ad sticks to the top on scroll
 - Disable AMP Plus, refresh the page and confirm the ad is **no longer sticking**
 - Visit the wizard page again, edit the previous placement and confirm the "Stick to top" option is no longer available