### PR TITLE
fix(header-bidding): disable initial load for gtag

### DIFF
--- a/includes/class-newspack-ads-bidding.php
+++ b/includes/class-newspack-ads-bidding.php
@@ -64,7 +64,6 @@ class Newspack_Ads_Bidding {
 
 		// Scripts setup.
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
-		add_filter( 'newspack_ads_disable_gtag_initial_load', [ __CLASS__, 'gtag_disable_initial_load' ], 100 );
 		add_filter( 'newspack_ads_gtag_ads_data', [ $this, 'add_gtag_ads_data' ] );
 		add_action( 'newspack_ads_gtag_before_script', [ $this, 'prebid_script' ], 10, 2 );
 	}
@@ -100,20 +99,6 @@ class Newspack_Ads_Bidding {
 			10,
 			3
 		);
-	}
-
-	/**
-	 * Disable GTag initial load if header bidding is enabled.
-	 *
-	 * @param bool $disable_initial_load Whether to disable initial load.
-	 *
-	 * @return bool Whether to disable initial load.
-	 */
-	public static function gtag_disable_initial_load( $disable_initial_load ) {
-		if ( ! self::is_enabled() ) {
-			return $disable_initial_load;
-		}
-		return true;
 	}
 
 	/**
@@ -293,6 +278,10 @@ class Newspack_Ads_Bidding {
 		<script data-amp-plus-allowed>
 			( function() {
 				window.pbjs = window.pbjs || { que: [] };
+				window.googletag = window.googletag || { cmd: [] };
+				googletag.cmd.push( function() {
+					googletag.pubads().disableInitialLoad();
+				} );
 				var config = <?php echo wp_json_encode( $prebid_config ); ?>;
 				var adUnits = <?php echo wp_json_encode( $ad_units ); ?>;
 				pbjs.que.push( function() {
@@ -314,7 +303,6 @@ class Newspack_Ads_Bidding {
 				function initAdserver() {
 					if ( pbjs.initAdserverSet ) return;
 					pbjs.initAdserverSet = true;
-					window.googletag = window.googletag || { cmd: [] };
 					googletag.cmd.push( function() {
 						pbjs.setTargetingForGPTAsync && pbjs.setTargetingForGPTAsync();
 						googletag.pubads().refresh();

--- a/includes/class-newspack-ads-bidding.php
+++ b/includes/class-newspack-ads-bidding.php
@@ -64,6 +64,7 @@ class Newspack_Ads_Bidding {
 
 		// Scripts setup.
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
+		add_filter( 'newspack_ads_disable_gtag_initial_load', [ __CLASS__, 'gtag_disable_initial_load' ], 100 );
 		add_filter( 'newspack_ads_gtag_ads_data', [ $this, 'add_gtag_ads_data' ] );
 		add_action( 'newspack_ads_gtag_before_script', [ $this, 'prebid_script' ], 10, 2 );
 	}
@@ -99,6 +100,20 @@ class Newspack_Ads_Bidding {
 			10,
 			3
 		);
+	}
+
+	/**
+	 * Disable GTag initial load if header bidding is enabled.
+	 *
+	 * @param bool $disable_initial_load Whether to disable initial load.
+	 *
+	 * @return bool Whether to disable initial load.
+	 */
+	public static function gtag_disable_initial_load( $disable_initial_load ) {
+		if ( ! self::is_enabled() ) {
+			return $disable_initial_load;
+		}
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
Avoid double fetching when using header bidding by disabling initial load for GTag.

### Update

c21f1a2298c68e3a14fd07c88841a81a4c79c0fb initially proposed the use of the `newspack_ads_disable_gtag_initial_load` filter to determine the use of `disableInitialLoad()`. This is problematic because our `prebid_script()` method have particular variables that prevents it from being unnecessarily printed on the page. Not printing it means ads wouldn't load (unless a third-party calls for the `refresh()` method).

82ebc8718903856d2ac344d2cb10c763702c8b96 updates to call `disableInitialLoad()` directly on the `prebid_script()` method, which is a better practice in regard to how GPT and Prebid configuration scripts should interact.

### How to test

 - While on the master branch ensure you have experimental header bidding configured as described on #231 
 - Confirm you have a random Customer ID and a valid ad unit with a random Placement ID for header bidding
 - Visit the page where the ad unit is displayed with an additional `?googfc` parameter
 - Expand the displayed logs and notice the `Ad fetch count` is **2**
 - Check out this branch, refresh the page and confirm the count is **1**