### PR TITLE
chore: update post-release job to pull changelog and semver changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,14 +87,12 @@ jobs:
     docker:
       - image: cimg/php:7.4-browsers
     steps:
-      - checkout
+      - checkout_with_workspace
       - run:
-          name: Set tip of alpha branch on top of release and force-push it to remote
+          name: Perform post-release chores
           command: |
-            git pull origin release
-            git checkout alpha
-            git reset --hard release --
-            git push "https://$GITHUB_TOKEN@github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git" --force
+            wget -O post-release.sh https://raw.githubusercontent.com/Automattic/newspack-scripts/master/post-release.sh
+            chmod 755 ./post-release.sh && ./post-release.sh
 
 workflows:
   version: 2


### PR DESCRIPTION
Updates `post_release` job to match the latest Git workflow changes.