### PR TITLE
fix(placements): ensure active placement have ID

### DIFF
--- a/includes/class-newspack-ads-placements.php
+++ b/includes/class-newspack-ads-placements.php
@@ -347,6 +347,11 @@ class Newspack_Ads_Placements {
 				continue;
 			}
 
+			// Skip placements without ID.
+			if ( ! isset( $placement['data']['id'] ) ) {
+				continue;
+			}
+
 			// Add placement and its hooks data to array.
 			if ( isset( $placement['data']['ad_unit'] ) && $placement['data']['ad_unit'] ) {
 				$placements_by_id[ $placement['data']['id'] ] = $placement['data'];

--- a/includes/class-newspack-ads-placements.php
+++ b/includes/class-newspack-ads-placements.php
@@ -347,11 +347,6 @@ class Newspack_Ads_Placements {
 				continue;
 			}
 
-			// Skip placements without ID.
-			if ( ! isset( $placement['data']['id'] ) ) {
-				continue;
-			}
-
 			// Add placement and its hooks data to array.
 			if ( isset( $placement['data']['ad_unit'] ) && $placement['data']['ad_unit'] ) {
 				$placements_by_id[ $placement['data']['id'] ] = $placement['data'];
@@ -361,14 +356,14 @@ class Newspack_Ads_Placements {
 
 			if ( isset( $placement['data']['hooks'] ) ) {
 				foreach ( $placement['data']['hooks'] as $hook ) {
-					if ( isset( $hook['ad_unit'] ) && $hook['ad_unit'] ) {
+					if ( isset( $hook['id'] ) && isset( $hook['ad_unit'] ) && $hook['ad_unit'] ) {
 						$placements_by_id[ $hook['id'] ] = $hook;
 					}
 				}
 			}
 
 			// Remove hook data from root placement.
-			if ( isset( $placements_by_id[ $placement['data']['id'] ]['hooks'] ) ) {
+			if ( isset( $placement['data']['id'] ) && isset( $placements_by_id[ $placement['data']['id'] ]['hooks'] ) ) {
 				unset( $placements_by_id[ $placement['data']['id'] ]['hooks'] );
 			}
 		}


### PR DESCRIPTION
Ensure the active placement have ID for the `get_placements_data_by_id()` method. The odd case of a placement ad unit being left blank after being filled can cause inconsistent placement data.

### How to test the PR

1. On the master branch select an ad unit for a global placement and save
2. Select blank (Select an Ad Unit) for the same placement
3. Visit a page where this placement should be displayed
4. Debug logs should display: `Notice: Undefined index: id in newspack-ads/includes/class-newspack-ads-placements.php on line 366`
5. Check out this branch, refresh the page and no notices should be thrown.
