### PR TITLE
feat: custom ad label

### DIFF
--- a/includes/class-newspack-ads-custom-label.php
+++ b/includes/class-newspack-ads-custom-label.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Newspack Ads Custom Ad Label
+ *
+ * @package Newspack
+ */
+
+/**
+ * Newspack Ads Custom Ad Label Class.
+ */
+class Newspack_Ads_Custom_Label {
+
+	/**
+	 * Initialize settings.
+	 */
+	public static function init() {
+		add_action( 'newspack_ads_settings_list', [ __CLASS__, 'settings_list' ] );
+		add_action( 'wp_head', [ __CLASS__, 'render_label' ] );
+	}
+
+	/**
+	 * Register Custom Ad Placement Label settings.
+	 *
+	 * @param array $settings_list List of settings.
+	 *
+	 * @return array Updated list of settings.
+	 */
+	public static function settings_list( $settings_list ) {
+		return array_merge(
+			[
+				[
+					'description' => __( 'Custom ad label', 'newspack-ads' ),
+					'help'        => __( 'Add a custom text to be displayed right before your rendered ads.' ),
+					'section'     => 'custom_label',
+					'key'         => 'active',
+					'type'        => 'boolean',
+					'default'     => false,
+				],
+				[
+					'description' => __( 'Label text', 'newspack-ads' ),
+					'help'        => __( 'The custom text to be displayed right before your rendered ads.', 'newspack-ads' ),
+					'section'     => 'custom_label',
+					'key'         => 'label_text',
+					'type'        => 'string',
+					'default'     => __( 'Advertising', 'newspack-ads' ),
+				],
+			],
+			$settings_list
+		);
+	}
+
+	/**
+	 * Render custom label.
+	 */
+	public static function render_label() {
+		$enabled    = Newspack_Ads_Settings::get_setting( 'custom_label', 'active' );
+		$label_text = Newspack_Ads_Settings::get_setting( 'custom_label', 'label_text' );
+		if ( true !== $enabled || empty( $label_text ) ) {
+			return;
+		}
+		?>
+		<style>
+			.newspack_global_ad > div::before {
+				content: '<?php echo esc_html( $label_text ); ?>';
+				text-align: center;
+				margin-bottom: 10px;
+				display: block;
+				font-size: 10px;
+				text-transform: uppercase;
+				letter-spacing: 1.5px;
+				color: #777;
+			}
+		</style>
+		<?php
+	}
+
+}
+Newspack_Ads_Custom_Label::init();

--- a/includes/class-newspack-ads-custom-label.php
+++ b/includes/class-newspack-ads-custom-label.php
@@ -29,20 +29,19 @@ class Newspack_Ads_Custom_Label {
 		return array_merge(
 			[
 				[
-					'description' => __( 'Custom ad label', 'newspack-ads' ),
-					'help'        => __( 'Add a custom text to be displayed right before your rendered ads.' ),
+					'description' => esc_html__( 'Custom ad label', 'newspack-ads' ),
+					'help'        => esc_html__( 'Add a custom text to be displayed right before your rendered ads.' ),
 					'section'     => 'custom_label',
 					'key'         => 'active',
 					'type'        => 'boolean',
 					'default'     => false,
 				],
 				[
-					'description' => __( 'Label text', 'newspack-ads' ),
-					'help'        => __( 'The custom text to be displayed right before your rendered ads.', 'newspack-ads' ),
+					'description' => esc_html__( 'Label', 'newspack-ads' ),
 					'section'     => 'custom_label',
 					'key'         => 'label_text',
 					'type'        => 'string',
-					'default'     => __( 'Advertising', 'newspack-ads' ),
+					'default'     => esc_html__( 'Advertising', 'newspack-ads' ),
 				],
 			],
 			$settings_list
@@ -62,13 +61,13 @@ class Newspack_Ads_Custom_Label {
 		<style>
 			.newspack_global_ad > div::before {
 				content: '<?php echo esc_html( $label_text ); ?>';
-				text-align: center;
-				margin-bottom: 10px;
 				display: block;
+				font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 				font-size: 10px;
-				text-transform: uppercase;
-				letter-spacing: 1.5px;
-				color: #777;
+				line-height: 1.6;
+				margin-bottom: 0.4em;
+				opacity: 0.75;
+				text-align: center;
 			}
 		</style>
 		<?php

--- a/includes/class-newspack-ads-settings.php
+++ b/includes/class-newspack-ads-settings.php
@@ -353,5 +353,18 @@ class Newspack_Ads_Settings {
 		}
 	}
 
+	/**
+	 * Get a setting value.
+	 *
+	 * @param string $section       The section to retrieve settings from.
+	 * @param string $key           The key of the setting to retrieve.
+	 * @param mixed  $default_value The default value to return if the setting is not found.
+	 *
+	 * @return mixed The setting value or null if not found.
+	 */
+	public static function get_setting( $section, $key, $default_value = null ) {
+		$settings = self::get_settings( $section );
+		return isset( $settings[ $key ] ) ? $settings[ $key ] : $default_value;
+	}
 }
 Newspack_Ads_Settings::init();

--- a/includes/class-newspack-ads.php
+++ b/includes/class-newspack-ads.php
@@ -70,6 +70,7 @@ final class Newspack_Ads {
 	 */
 	private function includes() {
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-newspack-ads-settings.php';
+		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-newspack-ads-custom-label.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-newspack-ads-bidding.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/bidders/class-newspack-ads-bidder-medianet.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-newspack-ads-placements.php';


### PR DESCRIPTION
Adds support for a custom label to be displayed right before a placement ad renders.

![image](https://user-images.githubusercontent.com/820752/151225366-91709888-dfc3-4381-8c06-8c8bd4804c85.png)

![image](https://user-images.githubusercontent.com/820752/151225523-cc8dd32a-f9b0-4cec-a883-a3fd92817dc5.png)

Closes #193 

## How to test

1. Check out this branch and make sure you have global placements configured with valid ad units
2. Navigate on the site and confirm nothing changes with the ad rendering
3. Visit **Advertising -> Settings** and enable the **Custom ad label** setting
4. Visit your website and confirm the default label is being applied to rendered ads
5. Change the default label to something else and confirm the label changes on the frontend as well
6. Modify a placement to an ad unit without a valid creative and confirm the ad and label are not rendered
7. Test the label visibility with and without AMP
8. Change your website's primary body font to any other to confirm the style is appropriate