### PR TITLE
fix: ad label default value

### DIFF
--- a/includes/class-newspack-ads-custom-label.php
+++ b/includes/class-newspack-ads-custom-label.php
@@ -41,7 +41,7 @@ class Newspack_Ads_Custom_Label {
 					'section'     => 'custom_label',
 					'key'         => 'label_text',
 					'type'        => 'string',
-					'default'     => esc_html__( 'Advertising', 'newspack-ads' ),
+					'default'     => esc_html__( 'Advertisement', 'newspack-ads' ),
 				],
 			],
 			$settings_list


### PR DESCRIPTION
Changes the custom ad label default value from "Advertising" to "Advertisement".