### PR TITLE
fix: dont query inactive ad units

### DIFF
--- a/includes/class-newspack-ads-gam.php
+++ b/includes/class-newspack-ads-gam.php
@@ -365,7 +365,7 @@ class Newspack_Ads_GAM {
 		// Get all non-archived ad units, unless ids are specified.
 		$statement_builder = new StatementBuilder();
 		if ( empty( $ids ) ) {
-			$statement_builder = $statement_builder->where( "Status IN('ACTIVE', 'INACTIVE')" );
+			$statement_builder = $statement_builder->where( "Status IN('ACTIVE')" );
 		} else {
 			$statement_builder = $statement_builder->where( 'ID IN(' . implode( ', ', $ids ) . ')' );
 		}


### PR DESCRIPTION
Closes #250 

## How to test

1. Make sure you are connected with a GAM network
2. Visit the **Advertising -> Google Ad Manager -> Configure** page and your Ad Units dashboard at GAM
3. Make sure you have `inactive` ad units on your GAM dashboard
4. Confirm that on this branch they are no longer visible