### PR TITLE
feat: add template targeting key

### DIFF
--- a/includes/class-newspack-ads-gam.php
+++ b/includes/class-newspack-ads-gam.php
@@ -91,6 +91,7 @@ class Newspack_Ads_GAM {
 		'slug',
 		'category',
 		'post_type',
+		'template',
 	];
 
 	/**

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -787,6 +787,11 @@ class Newspack_Ads_Model {
 				$targeting['slug'] = sanitize_text_field( $slug );
 			}
 
+			$template_slug = get_page_template_slug();
+			if ( ! empty( $template_slug ) ) {
+				$targeting['template'] = sanitize_title( $template_slug );
+			}
+
 			// Add the category slugs to targeting.
 			$categories = wp_get_post_categories( get_the_ID(), [ 'fields' => 'slugs' ] );
 			if ( ! empty( $categories ) ) {


### PR DESCRIPTION
Add the `template` targeting key using [`get_page_template_slug()`](https://developer.wordpress.org/reference/functions/get_page_template_slug/) for more targeting coverage.

It should cover the targeting of wider creatives for #295 (https://github.com/Automattic/newspack-theme/pull/1699).

![image](https://user-images.githubusercontent.com/820752/151819952-bcb2f815-47dd-46ce-8c49-36766096227a.png)

## How to test

1. Check out this branch and visit Advertising wizard
2. Notice the success message inside the GAM card confirming the creation of the new targeting key. (The wizard will always look for missing useful targeting keys on load and create them)
3. Create a post using the One-column template, visit the page and confirm the targeting is being configured by inspecting the searching for : `"template":`. You should find the `gpt` config like this:
![image](https://user-images.githubusercontent.com/820752/151821060-02b47956-6e00-44fc-81d9-2d73961822c2.png)
