### PR TITLE
hotfix: gam serialised method arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.26.1-hotfix.1](https://github.com/Automattic/newspack-ads/compare/v1.26.0...v1.26.1-hotfix.1) (2022-01-31)
+
+
+### Bug Fixes
+
+* default arg for serialise gam methods ([94a8675](https://github.com/Automattic/newspack-ads/commit/94a8675e2394230d7cd2f6d5e64bad6391f0fb5c))
+
 # [1.26.0](https://github.com/Automattic/newspack-ads/compare/v1.25.0...v1.26.0) (2022-01-31)
 
 

--- a/includes/class-newspack-ads-gam.php
+++ b/includes/class-newspack-ads-gam.php
@@ -405,7 +405,7 @@ class Newspack_Ads_GAM {
 	 * 
 	 * @return array[] Array of serialised companies.
 	 */
-	public static function get_serialised_advertisers( $companies = [] ) {
+	public static function get_serialised_advertisers( $companies = null ) {
 		return array_map(
 			function( $item ) {
 				return [
@@ -413,7 +413,7 @@ class Newspack_Ads_GAM {
 					'name' => $item->getName(),
 				];
 			},
-			count( $companies ) ? $companies : self::get_advertisers()
+			null !== $companies ? $companies : self::get_advertisers()
 		);
 	}
 
@@ -499,7 +499,7 @@ class Newspack_Ads_GAM {
 	 *
 	 * @return object[] Array of serialised orders.
 	 */
-	public static function get_serialised_orders( $orders = [] ) {
+	public static function get_serialised_orders( $orders = null ) {
 		return array_map(
 			function( $order ) {
 				return [
@@ -512,7 +512,7 @@ class Newspack_Ads_GAM {
 					'creator_id'    => $order->getCreatorId(),
 				];
 			},
-			! empty( $orders ) ? $orders : self::get_orders()
+			null !== $orders ? $orders : self::get_orders()
 		);
 	}
 
@@ -562,7 +562,7 @@ class Newspack_Ads_GAM {
 	 *
 	 * @return array[] Array of serialised creatives.
 	 */
-	public static function get_serialised_creatives( $creatives = [] ) {
+	public static function get_serialised_creatives( $creatives = null ) {
 		return array_map(
 			function( $creatives ) {
 				return [
@@ -571,7 +571,7 @@ class Newspack_Ads_GAM {
 					'advertiserId' => $creatives->getAdvertiserId(),
 				];
 			},
-			! empty( $creatives ) ? $creatives : self::get_creatives()
+			null !== $creatives ? $creatives : self::get_creatives()
 		);
 	}
 
@@ -617,7 +617,7 @@ class Newspack_Ads_GAM {
 	 *
 	 * @return object[] Array of serialised orders.
 	 */
-	public static function get_serialised_line_items( $line_items = [] ) {
+	public static function get_serialised_line_items( $line_items = null ) {
 		return array_map(
 			function( $item ) {
 				return [
@@ -629,7 +629,7 @@ class Newspack_Ads_GAM {
 					'type'        => $item->getLineItemType(),
 				];
 			},
-			! empty( $line_items ) ? $line_items : self::get_line_items()
+			null !== $line_items ? $line_items : self::get_line_items()
 		);
 	}
 

--- a/newspack-ads.php
+++ b/newspack-ads.php
@@ -5,7 +5,7 @@
  * Description:     Ad services integration.
  * Author:          Automattic
  * License:         GPL2
- * Version:         1.26.0
+ * Version:         1.26.1-hotfix.1
  *
  * @package         Newspack
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack-ads",
-  "version": "1.26.0",
+  "version": "1.26.1-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack-ads",
-      "version": "1.26.0",
+      "version": "1.26.1-hotfix.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "newspack-components": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack-ads",
-  "version": "1.26.0",
+  "version": "1.26.1-hotfix.1",
   "author": "Automattic",
   "private": true,
   "scripts": {


### PR DESCRIPTION
There is a logic error on how some of the `get_serialised_*` methods work. If the result of the query returns empty, it will always fall to return all of the entities.

This hotfix changes the default argument value to `null` so it returns an empty array as expected for empty results.