### PR TITLE
hotfix: reindex filtered sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.26.2-hotfix.1](https://github.com/Automattic/newspack-ads/compare/v1.26.1...v1.26.2-hotfix.1) (2022-02-01)
+
+
+### Bug Fixes
+
+* reindex filtered sizes ([39a411e](https://github.com/Automattic/newspack-ads/commit/39a411ec8f5e69a1a9f140f4b8270e9dc4aaae60))
+
 ## [1.26.1](https://github.com/Automattic/newspack-ads/compare/v1.26.0...v1.26.1) (2022-01-31)
 
 

--- a/includes/class-newspack-ads-bidding.php
+++ b/includes/class-newspack-ads-bidding.php
@@ -320,6 +320,8 @@ class Newspack_Ads_Bidding {
 					array_map( [ __CLASS__, 'get_size_string' ], $ad_data['sizes'] ),
 					array_map( [ __CLASS__, 'get_size_string' ], $this->get_all_sizes() )
 				);
+				// Reindex filtered array.
+				$sizes = array_values( $sizes );
 				if ( ! count( $sizes ) ) {
 					continue;
 				}

--- a/newspack-ads.php
+++ b/newspack-ads.php
@@ -5,7 +5,7 @@
  * Description:     Ad services integration.
  * Author:          Automattic
  * License:         GPL2
- * Version:         1.26.1
+ * Version:         1.26.2-hotfix.1
  *
  * @package         Newspack
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack-ads",
-  "version": "1.26.1",
+  "version": "1.26.2-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack-ads",
-      "version": "1.26.1",
+      "version": "1.26.2-hotfix.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "newspack-components": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack-ads",
-  "version": "1.26.1",
+  "version": "1.26.2-hotfix.1",
   "author": "Automattic",
   "private": true,
   "scripts": {


### PR DESCRIPTION
The header bidding ad unit sizes should be reindexed after being filtered by `array_intersect()`. Otherwise, `wp_json_encode()` will generate an object keyed by the existing indexes instead of an array.

## How to test

1. On the master branch, create an ad unit with a couple of standard sizes and a non-standard one: `100x50`, `728x90`, `970x250`
2. Place this ad unit on a placement with a random Media.net placement ID
3. Visit the page, open DevTools and with the element inspector, search for: "mediaTypes"
4. Observe the `sizes` are an object keyed by its indexes
5. Switch to this branch, refresh the page and confirm the value of `sizes` is an array.
  