### PR TITLE
hotfix: gam targeting keys names are case-insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.26.4-hotfix.1](https://github.com/Automattic/newspack-ads/compare/v1.26.3...v1.26.4-hotfix.1) (2022-02-08)
+
+
+### Bug Fixes
+
+* **gam:** targeting keys names are case insensitive ([da31c69](https://github.com/Automattic/newspack-ads/commit/da31c69d36b61bd555fe70b3b7e7ca10410078bd))
+
 ## [1.26.3](https://github.com/Automattic/newspack-ads/compare/v1.26.2...v1.26.3) (2022-02-03)
 
 

--- a/newspack-ads.php
+++ b/newspack-ads.php
@@ -5,7 +5,7 @@
  * Description:     Ad services integration.
  * Author:          Automattic
  * License:         GPL2
- * Version:         1.26.3
+ * Version:         1.26.4-hotfix.1
  *
  * @package         Newspack
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack-ads",
-  "version": "1.26.3",
+  "version": "1.26.4-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack-ads",
-      "version": "1.26.3",
+      "version": "1.26.4-hotfix.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "newspack-components": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack-ads",
-  "version": "1.26.3",
+  "version": "1.26.4-hotfix.1",
   "author": "Automattic",
   "private": true,
   "scripts": {


### PR DESCRIPTION
GAM targeting key names are case-insensitive and should be treated as such. The current query uses a case-sensitive operator which fails to find existing different-case keys and causes a creation error by attempting to create duplicates.

This PR changes the query to search using the [case-insensitive `LIKE` operator](https://developers.google.com/google-ads/api/docs/query/case-sensitivity). It also fixes a logic error on the usage of `strpos()`, which returns `false` if the needle is not found, not an `int`.

### How to test

Since GAM doesn't delete entities, if you click to "delete" any of the default targeting keys and recreate with uppercase characters, it will actually re-enable the archived key with the previous lowercase characters.

To test with a new key, create a key called `Uppercasetest` on your GAM dashboard and add `uppercasetest` to the `$custom_targeting_keys` on line `89`:

1. While on the master branch, visit the Newspack Ads wizard homepage and observe the error
2. Switch to this branch and the error should not be visible