### PR TITLE
chore: DOM nesting in a React component

### DIFF
--- a/src/wizard-settings/header-bidding-gam/index.js
+++ b/src/wizard-settings/header-bidding-gam/index.js
@@ -223,7 +223,7 @@ const HeaderBiddingGAM = () => {
 						{ error ? (
 							error.message
 						) : (
-							<div className="newspack-ads__header-bidding-gam__order-description">
+							<span className="newspack-ads__header-bidding-gam__order-description">
 								{ order?.order_id ? (
 									<span>
 										{ __( 'Order:', 'newspack-ads' ) }{ ' ' }
@@ -252,7 +252,7 @@ const HeaderBiddingGAM = () => {
 								) : (
 									getMissingOrderMessage()
 								) }
-							</div>
+							</span>
 						) }
 					</Fragment>
 				) }


### PR DESCRIPTION
React does not like having `div`s in `p`s:

<img width="732" alt="image" src="https://user-images.githubusercontent.com/7383192/153240219-a0a0d9e8-39c5-474a-aa86-d7972bb9a047.png">
