### PR TITLE
feat(header-bidding): enable user syncing through iframes for OpenX

### DIFF
--- a/includes/bidders/class-newspack-ads-bidder-openx.php
+++ b/includes/bidders/class-newspack-ads-bidder-openx.php
@@ -46,7 +46,30 @@ class Newspack_Ads_Bidder_OpenX {
 				],
 			]
 		);
+		add_filter( 'newspack_ads_prebid_config', [ __CLASS__, 'add_user_sync_iframe' ] );
 		add_filter( 'newspack_ads_openx_ad_unit_bid', [ __CLASS__, 'set_openx_ad_unit_bid' ], 10, 4 );
+	}
+
+	/**
+	 * Enable user syncing through iframes.
+	 *
+	 * OpenX strongly recommends enabling user syncing through iframes. This
+	 * functionality improves DSP user match rates and increases the OpenX bid
+	 * rate and bid price.
+	 *
+	 * @link https://docs.prebid.org/dev-docs/bidders/openx.html
+	 *
+	 * @param array $config Prebid.js config.
+	 *
+	 * @return array Prebid.js config.
+	 */
+	public static function add_user_sync_iframe( $config ) {
+		$bidder_config = newspack_get_ads_bidder( 'openx' );
+		if ( ! $bidder_config || ! isset( $bidder_config['data']['openx_platform'] ) || empty( $bidder_config['data']['openx_platform'] ) ) {
+			return $config;
+		}
+		$config['userSync']['iframeEnabled'] = true;
+		return $config;
 	}
 
 	/**


### PR DESCRIPTION
Enables user syncing through iframes when OpenX is active.

According to [Prebid.js documentation](https://docs.prebid.org/dev-docs/bidders/openx.html):

> By default, Prebid.js version 0.34.0+ turns off user syncing through iframes. OpenX strongly recommends enabling user syncing through iframes. This functionality improves DSP user match rates and increases the OpenX bid rate and bid price. Be sure to call pbjs.setConfig() only once.

### How to test

1. Make sure you have:
   1. AMP Plus on
   2. GAM successfully connected
   3. Header bidding enabled through: `define( 'NEWSPACK_ADS_EXPERIMENTAL_BIDDERS', true );`
2. Check out this branch and at Newspack Ads -> Settings, make sure you have OpenX as an active bidder and a random OpenX Platform ID
3. Visit a page with ads placed and using DevTools search the DOM for `iframeEnabled`
4. Confirm it's set to true at the `pbjs.setConfig()`