### PR TITLE
fix: use ad unit size count for determining responsive amp ads strategy

### DIFF
--- a/includes/class-newspack-ads-blocks.php
+++ b/includes/class-newspack-ads-blocks.php
@@ -18,8 +18,8 @@ class Newspack_Ads_Blocks {
 	public static function init() {
 		require_once NEWSPACK_ADS_ABSPATH . 'src/blocks/ad-unit/view.php';
 		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_block_editor_assets' ) );
-		add_action( 'wp_head', array( __CLASS__, 'insert_google_ad_manager_header_code' ), 30 );
-		add_action( 'wp_footer', array( __CLASS__, 'insert_google_ad_manager_footer_code' ), 30 );
+		add_action( 'wp_head', array( __CLASS__, 'insert_gpt_header_script' ) );
+		add_action( 'wp_footer', array( __CLASS__, 'insert_gpt_footer_script' ) );
 	}
 
 	/**
@@ -114,31 +114,24 @@ class Newspack_Ads_Blocks {
 	}
 
 	/**
-	 * Google Ad Manager header code
+	 * Google Publisher Tag header script.
 	 */
-	public static function insert_google_ad_manager_header_code() {
+	public static function insert_gpt_header_script() {
 		if ( ! newspack_ads_should_show_ads() ) {
 			return;
 		}
-
 		if ( Newspack_Ads::is_amp() ) {
 			return;
 		}
-		ob_start();
 		?>
 		<script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js" data-amp-plus-allowed></script>
-		<script data-amp-plus-allowed>
-			window.googletag = window.googletag || {cmd: []};
-		</script>
 		<?php
-		$code = ob_get_clean();
-		echo $code; //phpcs:ignore
 	}
 
 	/**
-	 * Google Ad Manager footer code
+	 * Google Publisher Tag configuration script.
 	 */
-	public static function insert_google_ad_manager_footer_code() {
+	public static function insert_gpt_footer_script() {
 		if ( ! newspack_ads_should_show_ads() ) {
 			return;
 		}
@@ -204,10 +197,9 @@ class Newspack_Ads_Blocks {
 		$prepared_unit_data = apply_filters( 'newspack_ads_gtag_ads_data', $prepared_unit_data );
 
 		do_action( 'newspack_ads_gtag_before_script', $ad_config, $prepared_unit_data );
-
-		ob_start();
 		?>
 		<script data-amp-plus-allowed>
+			window.googletag = window.googletag || { cmd: [] };
 			googletag.cmd.push(function() {
 				var ad_config        = <?php echo wp_json_encode( $ad_config ); ?>;
 				var all_ad_units     = <?php echo wp_json_encode( $prepared_unit_data ); ?>;
@@ -350,9 +342,7 @@ class Newspack_Ads_Blocks {
 			} );
 		</script>
 		<?php
-		$code = ob_get_clean();
-		echo $code; // phpcs:ignore
-		do_action( 'newspack_ads_after_gpt_script', $ad_config, $prepared_unit_data );
+		do_action( 'newspack_ads_gtag_after_script', $ad_config, $prepared_unit_data );
 	}
 }
 Newspack_Ads_Blocks::init();

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -613,10 +613,10 @@ class Newspack_Ads_Model {
 		$styles = [];
 
 		// Gather up all of the ad sizes which should be displayed on the same viewports.
-		// As a heuristic, each ad slot can safely display ads with a 20% difference from slot's width.
+		// As a heuristic, each ad slot can safely display ads with a 30% difference from slot's width.
 		// e.g. for the following setup: [[900,200], [750,200]],
 		// We can display [[900,200], [750,200]] on viewports >= 900px and [[750,200]] on viewports < 900px.
-		$width_ratio_min = apply_filters( 'newspack_ads_multisize_size_ratio_max', 0.8, $ad_unit );
+		$width_ratio_min = apply_filters( 'newspack_ads_multisize_size_ratio_max', 0.7, $ad_unit );
 		$all_ad_sizes    = [];
 		foreach ( $widths as $ad_width ) {
 			$valid_ad_sizes = [];

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -613,16 +613,17 @@ class Newspack_Ads_Model {
 		$styles = [];
 
 		// Gather up all of the ad sizes which should be displayed on the same viewports.
-		// As a heuristic, each ad slot can safely display ads 200px narrower or less than the slot's width.
+		// As a heuristic, each ad slot can safely display ads with a 20% difference from slot's width.
 		// e.g. for the following setup: [[900,200], [750,200]],
 		// We can display [[900,200], [750,200]] on viewports >= 900px and [[750,200]] on viewports < 900px.
-		$width_difference_max = apply_filters( 'newspack_ads_multisize_size_difference_max', 200, $ad_unit );
-		$all_ad_sizes         = [];
+		$width_ratio_min = apply_filters( 'newspack_ads_multisize_size_ratio_max', 0.8, $ad_unit );
+		$all_ad_sizes    = [];
 		foreach ( $widths as $ad_width ) {
 			$valid_ad_sizes = [];
 
 			foreach ( $sizes as $size ) {
-				if ( $size[0] <= $ad_width && $ad_width - $width_difference_max <= $size[0] ) {
+				$width_ratio = min( $ad_width, $size[0] ) / max( $ad_width, $size[0] );
+				if ( $size[0] <= $ad_width && $width_ratio_min < $width_ratio ) {
 					$valid_ad_sizes[] = $size;
 				}
 			}

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -675,9 +675,9 @@ class Newspack_Ads_Model {
 
 			// If there is a multisize that's equal to the width and height of the container, remove it from the multisizes.
 			// The container size is included by default, and should not also be included in the multisize.
-			$container_multisize          = $width . 'x' . $height;
-			$container_multisize_location = array_search( $container_multisize, $multisizes );
-			if ( false !== $container_multisize_location ) {
+			$container_multisize           = $width . 'x' . $height;
+			$container_multisize_locations = array_keys( $multisizes, $container_multisize );
+			foreach ( $container_multisize_locations as $container_multisize_location ) {
 				unset( $multisizes[ $container_multisize_location ] );
 			}
 

--- a/includes/class-newspack-ads-scaip.php
+++ b/includes/class-newspack-ads-scaip.php
@@ -40,7 +40,6 @@ class Newspack_Ads_SCAIP {
 		// Placements hooks.
 		add_action( 'scaip_shortcode', [ __CLASS__, 'create_placement_action' ] );
 		add_filter( 'newspack_ads_placements', [ __CLASS__, 'add_placements' ] );
-		add_filter( 'newspack_ads_maybe_use_responsive_placement', [ __CLASS__, 'use_responsive_placement' ], 10, 2 );
 
 		// Deprecate sidebar.
 		if ( ! self::is_legacy_widgets() ) {
@@ -206,21 +205,6 @@ class Newspack_Ads_SCAIP {
 			}
 		}
 		return $placement_data;
-	}
-
-	/**
-	 * Use responsive placement for SCAIP placements.
-	 *
-	 * @param boolean $responsive Default value of whether to use responsive placement.
-	 * @param string  $placement  ID of the ad placement.
-	 *
-	 * @return boolean Whether to use responsive placement.
-	 */
-	public static function use_responsive_placement( $responsive, $placement ) {
-		if ( 0 === strpos( $placement, self::PLACEMENT_PREFIX ) ) {
-			return true;
-		}
-		return $responsive;
 	}
 }
 Newspack_Ads_SCAIP::init();

--- a/includes/class-newspack-ads-sidebar-placements.php
+++ b/includes/class-newspack-ads-sidebar-placements.php
@@ -48,7 +48,6 @@ class Newspack_Ads_Sidebar_Placements {
 		add_action( 'dynamic_sidebar_after', [ __CLASS__, 'create_sidebar_after_action' ], 10, 2 );
 		add_filter( 'is_active_sidebar', [ __CLASS__, 'allow_empty_sidebars' ], 10, 2 );
 		add_filter( 'newspack_ads_placements', [ __CLASS__, 'add_sidebar_placements' ], 5, 1 );
-		add_filter( 'newspack_ads_maybe_use_responsive_placement', [ __CLASS__, 'use_responsive_placement' ], 10, 2 );
 	}
 
 	/**
@@ -165,22 +164,5 @@ class Newspack_Ads_Sidebar_Placements {
 		}
 		return array_merge( $placements, $sidebar_placements );
 	}
-
-	/**
-	 * Use responsive placement for sidebar placements.
-	 *
-	 * @param boolean $responsive Default value of whether to use responsive placement.
-	 * @param string  $placement  ID of the ad placement.
-	 *
-	 * @return boolean Whether to use responsive placement.
-	 */
-	public static function use_responsive_placement( $responsive, $placement ) {
-		$sidebar_placements = array_map( [ __CLASS__, 'get_placement_key' ], array_column( $GLOBALS['wp_registered_sidebars'], 'id' ) );
-		if ( in_array( $placement, $sidebar_placements, true ) ) {
-			return true;
-		}
-		return $responsive;
-	}
-
 }
 Newspack_Ads_Sidebar_Placements::init();


### PR DESCRIPTION
Removes the use of a custom filter to determine if the ad unit should be rendered using the responsive strategy for AMP ads. Instead, use the number of sizes and if it's a fluid ad unit.

Also refactors how the GPT script is rendered, some method names for improved readability, and bug fixes for the AMP responsive strategy.

## How to test

1. Check out this branch and make sure you have AMP active and AMP Plus **disabled**
2. Place ad units with a singular size in a global placement, a block, and a widget
3. Confirm the ads renders as expected
4. Place multi-sized ad units in a global placement, a block, and a widget
5. Change your viewport to confirm it's using the responsive strategy