### PR TITLE
fix(header-bidding): ensure sizes for creative placeholders

### DIFF
--- a/includes/class-newspack-ads-bidding.php
+++ b/includes/class-newspack-ads-bidding.php
@@ -288,6 +288,9 @@ class Newspack_Ads_Bidding {
 			),
 			SORT_REGULAR
 		);
+		if ( empty( $bidders_sizes ) ) {
+			return self::ACCEPTED_AD_SIZES;
+		}
 		return $bidders_sizes;
 	}
 

--- a/includes/providers/gam/class-newspack-ads-gam.php
+++ b/includes/providers/gam/class-newspack-ads-gam.php
@@ -878,7 +878,7 @@ class Newspack_Ads_GAM {
 			$line_item->setPrimaryGoal( new Goal( $config['primary_goal']['goal_type'] ) );
 
 			// Creative placeholders (or expected creatives).
-			if ( isset( $config['creative_placeholders'] ) ) {
+			if ( isset( $config['creative_placeholders'] ) && ! empty( $config['creative_placeholders'] ) ) {
 				$creative_placeholders = array_map(
 					function ( $size ) {
 						return new CreativePlaceholder( new Size( $size[0], $size[1] ) );


### PR DESCRIPTION
While attempting to create a header bidding GAM order without having any enabled bidder, it attempts to create without creative placeholders. This is because the creative placeholders are generated combining the accepted ad sizes from enabled bidders. This PR modifies the `get_all_sizes()` method to always return the default accepted ad sizes if no bidder sizes are found.

### How to test this PR

1. On a fresh instance, connect to GAM and enable header bidding through `define( 'NEWSPACK_ADS_EXPERIMENTAL_BIDDERS', true );`
2. While on master attempt to create a GAM order without having any bidder selected as enabled
3. Confirm the "required creative placeholder" error
4. Install this branch and confirm you are able to create the order without selecting a bidder