### PR TITLE
fix: bad post-release merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+# [1.28.0](https://github.com/Automattic/newspack-ads/compare/v1.27.0...v1.28.0) (2022-03-08)
+
+
+### Bug Fixes
+
+* **header-bidding:** ensure sizes for creative placeholders ([#325](https://github.com/Automattic/newspack-ads/issues/325)) ([fc7adc9](https://github.com/Automattic/newspack-ads/commit/fc7adc9ca77b2494aedc1e23d6ee0c6db703de39))
+
+
+### Features
+
+* capitalise labels ([#318](https://github.com/Automattic/newspack-ads/issues/318)) ([c6d348b](https://github.com/Automattic/newspack-ads/commit/c6d348b13d3bf007de6ad86246b768798a0d427b))
+* **header-bidding:** enable user syncing through iframes for OpenX ([#317](https://github.com/Automattic/newspack-ads/issues/317)) ([a704b55](https://github.com/Automattic/newspack-ads/commit/a704b55da94dd9a69906b38adeafe2b699b1daf0))
+* **header-bidding:** multiple gam orders ([#310](https://github.com/Automattic/newspack-ads/issues/310)) ([8e4f123](https://github.com/Automattic/newspack-ads/commit/8e4f123e0119bb45e4112d82f8b6387925c9228c))
+
+# [1.28.0-alpha.2](https://github.com/Automattic/newspack-ads/compare/v1.28.0-alpha.1...v1.28.0-alpha.2) (2022-03-08)
+
+
+### Bug Fixes
+
+* **header-bidding:** ensure sizes for creative placeholders ([#325](https://github.com/Automattic/newspack-ads/issues/325)) ([fc7adc9](https://github.com/Automattic/newspack-ads/commit/fc7adc9ca77b2494aedc1e23d6ee0c6db703de39))
+
+# [1.28.0-alpha.1](https://github.com/Automattic/newspack-ads/compare/v1.27.0...v1.28.0-alpha.1) (2022-02-24)
+
+
+### Features
+
+* capitalise labels ([#318](https://github.com/Automattic/newspack-ads/issues/318)) ([c6d348b](https://github.com/Automattic/newspack-ads/commit/c6d348b13d3bf007de6ad86246b768798a0d427b))
+* **header-bidding:** enable user syncing through iframes for OpenX ([#317](https://github.com/Automattic/newspack-ads/issues/317)) ([a704b55](https://github.com/Automattic/newspack-ads/commit/a704b55da94dd9a69906b38adeafe2b699b1daf0))
+* **header-bidding:** multiple gam orders ([#310](https://github.com/Automattic/newspack-ads/issues/310)) ([8e4f123](https://github.com/Automattic/newspack-ads/commit/8e4f123e0119bb45e4112d82f8b6387925c9228c))
+
 # [1.27.0](https://github.com/Automattic/newspack-ads/compare/v1.26.4...v1.27.0) (2022-02-22)
 
 

--- a/newspack-ads.php
+++ b/newspack-ads.php
@@ -5,7 +5,7 @@
  * Description:     Ad services integration.
  * Author:          Automattic
  * License:         GPL2
- * Version:         1.27.0
+ * Version:         1.28.0
  *
  * @package         Newspack
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack-ads",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack-ads",
-      "version": "1.27.0",
+      "version": "1.28.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "newspack-components": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack-ads",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "author": "Automattic",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Pulls changes in from `release` after the [last post-release job failed](https://app.circleci.com/pipelines/github/Automattic/newspack-ads/938/workflows/5f33484f-34b3-49cd-acec-8c3553f22dd0/jobs/2626).