### PR TITLE
fix: prevent empty bidder unit id

### DIFF
--- a/includes/class-newspack-ads-bidding.php
+++ b/includes/class-newspack-ads-bidding.php
@@ -340,7 +340,7 @@ class Newspack_Ads_Bidding {
 
 				foreach ( $bidders as $bidder_id => $bidder ) {
 
-					if ( isset( $ad_data['bidders'][ $bidder_id ] ) ) {
+					if ( isset( $ad_data['bidders'][ $bidder_id ] ) && ! empty( $ad_data['bidders'][ $bidder_id ] ) ) {
 
 						$bidder_placement_id = $ad_data['bidders'][ $bidder_id ];
 


### PR DESCRIPTION
By clearing a placement of its bidder unit IDs, the stored value is an empty string. This empty string should be checked before creating the Prebid script configuration

### How to test

1. Make sure you have AMP off (or AMP Plus on), GAM connected and header bidding configured through `define( 'NEWSPACK_ADS_EXPERIMENTAL_BIDDERS', true );`
2. While on master, make sure you have enabled bidders and debug mode on Newspack Ads -> Settings
3. Edit a placement with a random ID for the bidder, then edit again to clear the ID
4. Visit the page where the ad is rendered and confirm on the page logs that there's a bid attempt
5. Check out this branch, refresh the page and confirm there's no bid attempt
6. Add a random bidder ID for the placement again, visit the page to confirm that the bid continues to work as expected