### PR TITLE
refactor: unify responsive size map

### DIFF
--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -622,8 +622,6 @@ class Newspack_Ads_Model {
 				}
 			}
 		}
-		$size_map = apply_filters( 'newspack_ads_multisize_ad_sizes', $size_map );
-
 		return $size_map;
 	}
 

--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -617,7 +617,7 @@ class Newspack_Ads_Model {
 		foreach ( $widths as $ad_width ) {
 			foreach ( $sizes as $size ) {
 				$diff = min( $ad_width, $size[0] ) / max( $ad_width, $size[0] );
-				if ( $size[0] <= $ad_width && ( 1 - $width_diff_ratio ) < $diff ) {
+				if ( $size[0] <= $ad_width && ( 1 - $width_diff_ratio ) <= $diff ) {
 					$size_map[ $ad_width ][] = $size;
 				}
 			}

--- a/tests/test-model.php
+++ b/tests/test-model.php
@@ -185,4 +185,38 @@ class ModelTest extends WP_UnitTestCase {
 		$sizes = 'notanarray';
 		$this->assertNotEquals( $sizes, Newspack_Ads_Model::sanitize_sizes( $sizes ) );
 	}
+
+	/**
+	 * Test size map rules.
+	 */
+	public function test_responsive_size_map() {
+
+		self::assertEquals(
+			[
+				'10'  => [ [ 10, 10 ] ],
+				'100' => [ [ 100, 100 ] ],
+			],
+			Newspack_Ads_Model::get_responsive_size_map( [ [ 10, 10 ], [ 100, 100 ] ] )
+		);
+
+		self::assertEquals(
+			[
+				'10'  => [ [ 10, 10 ] ],
+				'60'  => [ [ 60, 60 ] ],
+				'90'  => [ [ 90, 90 ] ],
+				'100' => [ [ 90, 90 ], [ 100, 100 ] ],
+			],
+			Newspack_Ads_Model::get_responsive_size_map( [ [ 10, 10 ], [ 100, 100 ], [ 90, 90 ], [ 60, 60 ] ] )
+		);
+
+		self::assertEquals(
+			[
+				'10'  => [ [ 10, 10 ] ],
+				'60'  => [ [ 60, 60 ] ],
+				'90'  => [ [ 60, 60 ], [ 90, 90 ] ],
+				'100' => [ [ 60, 60 ], [ 90, 90 ], [ 100, 100 ] ],
+			],
+			Newspack_Ads_Model::get_responsive_size_map( [ [ 10, 10 ], [ 100, 100 ], [ 90, 90 ], [ 60, 60 ] ], 0.5 )
+		);
+	}
 }


### PR DESCRIPTION
There currently are 2 different strategies to handle size mapping and responsive ads. Although we need both strategies to meet AMP and GPT requirements, the applied rules should be the same to avoid unexpected behavior.

This PR unifies the size mapping logic by implementing the `get_responsive_size_map()` method and simplifies how it's applied to both GPT and AMP.

### How to test this PR

There shouldn't be any noticeable change:

1. Check out this branch and make sure ad units with multiple sizes are displayed as expected for different viewports with AMP and AMP Plus
3. Written test should pass