### PR TITLE
fix: template targeting basename

### DIFF
--- a/includes/class-newspack-ads-model.php
+++ b/includes/class-newspack-ads-model.php
@@ -789,7 +789,7 @@ class Newspack_Ads_Model {
 
 			$template_slug = get_page_template_slug();
 			if ( ! empty( $template_slug ) ) {
-				$targeting['template'] = sanitize_title( $template_slug );
+				$targeting['template'] = sanitize_title( basename( $template_slug, '.php' ) );
 			}
 
 			// Add the category slugs to targeting.


### PR DESCRIPTION
Removes the trailing `-php` from the template name for GPT targeting by using its `basename()`. `single-feature-php` should now be `single-feature`.

### How to test

Create a post using the One-column template, visit the page and confirm the targeting is being configured by inspecting the HTML and searching for: `"template":`. You should find the GPT config like this:

<img width="200" alt="image" src="https://user-images.githubusercontent.com/820752/158215004-7bd14ee1-b808-45fc-8734-7329df2f68f1.png">
