### PR TITLE
fix(gam): consider size map viewport count for responsive strategy

### DIFF
--- a/includes/providers/gam/class-gam-provider.php
+++ b/includes/providers/gam/class-gam-provider.php
@@ -88,7 +88,24 @@ final class GAM_Provider extends Provider {
 			return '';
 		}
 		if ( 'sticky' === $placement_key && true === $is_amp ) {
-			$code = '<amp-sticky-ad class="newspack_amp_sticky_ad" layout="nodisplay">' . $code . '</amp-sticky-ad>';
+			$sticky_attrs = [
+				'class'  => 'newspack_amp_sticky_ad',
+				'layout' => 'nodisplay',
+			];
+			$code         = sprintf(
+				'<amp-sticky-ad %s>%s</amp-sticky-ad>',
+				implode(
+					' ',
+					array_map(
+						function( $key, $value ) {
+							return sprintf( "%s='%s'", $key, $value );
+						},
+						array_keys( $sticky_attrs ),
+						array_values( $sticky_attrs )
+					)
+				),
+				$code
+			);
 		}
 		return $code;
 	}


### PR DESCRIPTION
The GAM ad unit code for AMP is currently verifying the size count to use the responsive strategy. This generates unnecessary calculation and additional markup for slots that only results in 1 viewport after the size map calculation.

This PR moves the size map calculation to the `get_ad_unit_amp_code()` method so it verifies the viewport count before deciding which strategy to use. It also makes the size map calculation more accurate, considering the filtered `$size` array for the sticky placement.

This change also fixes an issue where an AMP sticky ad would not properly render due to the additional markup generated by the responsive strategy, in case the ad unit is multi-sized.

It also refactors the `<amp-sticky-ad />` generation for better maintenance.

### How to test this PR

1. Make sure you have AMP Plus off, AMP plugin active, and check out this branch
2. Create an ad unit with sizes that would result in one viewport width: `300x250` and ~`290x200`~`300x200` - this should only affect multi-size sharing the same width.
3. Place this ad unit and confirm it's rendered with a singular multi-sized `<amp-ad />` tag and not contained by a `<div id="div-gpt-amp-*" />`
4. Also place an ad unit with multiple different sizes and confirm the responsive strategy continues to work as expected