### PR TITLE
fix(placements): remove default ad unit

### DIFF
--- a/includes/class-placements.php
+++ b/includes/class-placements.php
@@ -332,28 +332,24 @@ final class Placements {
 				'name'            => __( 'Global: Above Header', 'newspack-ads' ),
 				'description'     => __( 'Choose an ad unit to display above the header.', 'newspack-ads' ),
 				'default_enabled' => true,
-				'default_ad_unit' => 'newspack_above_header',
 				'hook_name'       => 'before_header',
 			),
 			'global_below_header' => array(
 				'name'            => __( 'Global: Below Header', 'newspack-ads' ),
 				'description'     => __( 'Choose an ad unit to display below the header.', 'newspack-ads' ),
 				'default_enabled' => true,
-				'default_ad_unit' => 'newspack_below_header',
 				'hook_name'       => 'after_header',
 			),
 			'global_above_footer' => array(
 				'name'            => __( 'Global: Above Footer', 'newspack-ads' ),
 				'description'     => __( 'Choose an ad unit to display above the footer.', 'newspack-ads' ),
 				'default_enabled' => true,
-				'default_ad_unit' => 'newspack_above_footer',
 				'hook_name'       => 'before_footer',
 			),
 			'sticky'              => array(
 				'name'            => __( 'Mobile Sticky Footer', 'newspack-ads' ),
 				'description'     => __( 'Choose a sticky ad unit to display at the bottom of the viewport on mobile devices (recommended sizes are 320x50, 300x50)', 'newspack-ads' ),
 				'default_enabled' => true,
-				'default_ad_unit' => 'newspack_sticky',
 				'hook_name'       => 'before_footer',
 			),
 		);


### PR DESCRIPTION
The suggested "default" ad units for the standard global placements are not being used and cause these placements to always render an empty div. This gets fixed if the user disables the placement or manually set a different value followed by an empty value.

This PR removes those default ad units since there's no current reason to keep them.

### How to test

1. While on master make sure you don't have the `_newspack_ads_placement_global_below_header` option. It will make the placements system use the `default_ad_unit`
2. Visit a page and confirm there's a `1.5rem` gap between the header and the content and there's an empty `<div class="newspack_global_ad global_below_header" />`
3. Check out this branch, refresh and confirm the gap and the `<div />` are gone