### PR TITLE
fix(gam): remove unused gpt script

### DIFF
--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -132,7 +132,9 @@ final class GAM_Scripts {
 				for ( var container_id in all_ad_units ) {
 					var ad_unit = all_ad_units[ container_id ];
 
+					<?php
 					// Only set up ad units that are present on the page.
+					?>
 					if ( ! document.querySelector( '#' + container_id ) ) {
 						continue;
 					}
@@ -152,45 +154,40 @@ final class GAM_Scripts {
 						defined_ad_units[ container_id ].setTargeting( target_key, ad_unit['targeting'][ target_key ] );
 					}
 
+					<?php
 					/**
-					 * Configure responsive ads.
-					 * Ads wider than the viewport should not show.
+					 * Build and set the responsive mapping.
+					 *
+					 * @see https://developers.google.com/doubleclick-gpt/guides/ad-sizes#responsive_ads
 					 */
-
-					// Get all of the unique ad widths.
-					var unique_widths = {};
-					ad_unit['sizes'].forEach( function( size ) {
-						unique_widths[ size[0] ] = [];
-					} );
-
-					// For each width, get all of the sizes equal-to-or-smaller than it.
-					for ( width in unique_widths ) {
-						ad_unit['sizes'].forEach( function( size ) {
-							if ( size[0] <= width ) {
-								unique_widths[ width ].push( size );
-							}
-						} );
-					}
-
-					// Build and set the responsive mapping.
-					// @see https://developers.google.com/doubleclick-gpt/guides/ad-sizes#responsive_ads
+					?>
 					var mapping = googletag.sizeMapping();
+					<?php
 					// Default base is to not show ads.
+					?>
 					var baseSizes = [];
+					<?php
 					// If the ad unit is fluid, base includes fluid.
+					?>
 					if( ad_unit['fluid'] ) {
 						baseSizes = baseSizes.concat( 'fluid' );
 					}
+					<?php
 					// Iterate through size map.
+					?>
 					for ( viewportWidth in ad_unit['size_map'] ) {
 						var mappedSizes = ad_unit['size_map'][ viewportWidth ];
 						mapping.addSize( [ parseInt( viewportWidth ), 0 ], baseSizes.concat( mappedSizes ) );
 					}
+					<?php
 					// Sticky ads should only be shown on mobile (screen width <=600px).
+					?>
 					if ( ad_unit['sticky'] ) {
 						mapping.addSize( [600, 0], baseSizes );
 					}
+					<?php
 					// On viewports smaller than the smallest ad size, don't show any ads.
+					?>
 					mapping.addSize( [0, 0], baseSizes );
 					defined_ad_units[ container_id ].defineSizeMapping( mapping.build() );
 				}
@@ -212,9 +209,14 @@ final class GAM_Scripts {
 				for ( var container_id in defined_ad_units ) {
 					googletag.display( container_id );
 				}
-				// Identify fluid rendered ad and fix iframe width.
-				// GPT currently sets the iframe with `min-width` set to 100% and property `width` set to 0.
-				// This causes the iframe to be rendered with 0 width.
+
+				<?php
+				/**
+				 * Identify fluid rendered ad and fix iframe width.
+				 * GPT currently sets the iframe with `min-width` set to 100% and property `width` set to 0.
+				 * This causes the iframe to be rendered with 0 width.
+				 */
+				?>
 				googletag.pubads().addEventListener( 'slotRenderEnded', function(event) {
 					var sizes = event.slot.getSizes();
 					if (

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -98,7 +98,14 @@ final class GAM_Scripts {
 		}
 
 		// Gather common targeting data and remove from ad unit targeting.
-		$common_targeting = array_intersect( ...array_values( array_column( $prepared_unit_data, 'targeting' ) ) );
+		$common_targeting = array_uintersect_assoc(
+			...array_values( array_column( $prepared_unit_data, 'targeting' ) ),
+			...[
+				function( $a, $b ) {
+						return $a === $b ? 0 : 1;
+				},
+			]
+		);
 		foreach ( $prepared_unit_data as $container_id => $ad_unit ) {
 			$prepared_unit_data[ $container_id ]['targeting'] = array_diff_key( $ad_unit['targeting'], $common_targeting );
 		}

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -143,7 +143,7 @@ final class GAM_Scripts {
 				var ad_config        = <?php echo wp_json_encode( $ad_config ); ?>;
 				var all_ad_units     = <?php echo wp_json_encode( $prepared_unit_data ); ?>;
 				var lazy_load        = <?php echo wp_json_encode( Settings::get_settings( 'lazy_load', true ), JSON_FORCE_OBJECT ); ?>;
-				var common_targeting = <?php echo wp_json_encode( $common_targeting ); ?>;
+				var common_targeting = <?php echo wp_json_encode( $common_targeting, JSON_FORCE_OBJECT ); ?>;
 				var defined_ad_units = {};
 
 				for ( var container_id in all_ad_units ) {

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -98,16 +98,19 @@ final class GAM_Scripts {
 		}
 
 		// Gather common targeting data and remove from ad unit targeting.
-		$common_targeting = array_uintersect_assoc(
-			...array_values( array_column( $prepared_unit_data, 'targeting' ) ),
-			...[
-				function( $a, $b ) {
-						return $a === $b ? 0 : 1;
-				},
-			]
-		);
-		foreach ( $prepared_unit_data as $container_id => $ad_unit ) {
-			$prepared_unit_data[ $container_id ]['targeting'] = array_diff_key( $ad_unit['targeting'], $common_targeting );
+		$common_targeting = [];
+		if ( 1 < count( $prepared_unit_data ) ) {
+			$common_targeting = array_uintersect_assoc(
+				...array_values( array_column( $prepared_unit_data, 'targeting' ) ),
+				...[
+					function( $a, $b ) {
+							return $a === $b ? 0 : 1;
+					},
+				]
+			);
+			foreach ( $prepared_unit_data as $container_id => $ad_unit ) {
+				$prepared_unit_data[ $container_id ]['targeting'] = array_diff_key( $ad_unit['targeting'], $common_targeting );
+			}
 		}
 
 		$ad_config = [


### PR DESCRIPTION
After #329 the size mapping part of the GPT script was simplified but some code from the previous approach remained. This PR removes the unused code and moves the comments to PHP to reduce printed bytes.

No changes should take place, AMP Plus and off-AMP ads should continue to render without errors.

c61185245ce40b57e0bb4b68ebeea66235b696cd (with improvements on 8ab8e5333f77753b5cc54c5d84f56e830b8c17cc) also isolates the common targeting key-val across ad units, which should, for most cases, be the entire targeting. This also aims to reduce printed bytes by not repeating the same targeting parameters for every ad unit on the page.