### PR TITLE
fix(integrations): ad refresh control sanitized settings

### DIFF
--- a/includes/integrations/class-ad-refresh-control.php
+++ b/includes/integrations/class-ad-refresh-control.php
@@ -178,7 +178,8 @@ class Ad_Refresh_Control {
 			$settings['disable_refresh'] = ! (bool) $settings['active'];
 			unset( $settings['active'] );
 		}
-		\update_option( self::SETTINGS_KEY, \AdRefreshControl\Settings\sanitize_settings( $settings ) );
+		$settings = \AdRefreshControl\Settings\sanitize_settings( $settings );
+		\update_option( self::SETTINGS_KEY, $settings );
 		return \rest_ensure_response( $settings );
 	}
 }


### PR DESCRIPTION
Ensure returned values from the Ad Refresh Control integration API are the same as stored.

### How to test

1. While on master and https://github.com/Automattic/newspack-plugin/pull/1587, visit the Add-Ons page on the Ads wizard and make sure you have Ad Refresh Control toggled on
2. Visit the Settings wizard and enter non-numeric values to the "Excluded Advertiser IDs" input
3. Save and confirm the values persisted
4. Refresh and confirm the invalid values were not stored
5. Check out this branch, repeat step 2 and confirm the values were cleared on save

Although I believe this is not a user-friendly way of handling invalid user input, it is the same way the plugin currently handles it on its own Settings page. I don't think we should implement this type of enhancement for this integration but am open to suggestions.