### PR TITLE
fix(blocks): ensure id uniqueness

### DIFF
--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -16,6 +16,13 @@ use Newspack_Ads\Placements;
 final class Blocks {
 
 	/**
+	 * Amount of blocks rendered in the page.
+	 *
+	 * @var int
+	 */
+	private static $block_count = 0;
+
+	/**
 	 * Initialize blocks
 	 *
 	 * @return void
@@ -71,7 +78,7 @@ final class Blocks {
 		if ( isset( $data['id'] ) && ! empty( $data['id'] ) ) {
 			return $data['id'];
 		}
-		return sprintf( '%1$s_%2$s', get_the_ID(), $data['ad_unit'] );
+		return sprintf( '%1$s_%2$s_%3$s', get_the_ID(), $data['ad_unit'], self::$block_count );
 	}
 
 	/**
@@ -153,6 +160,7 @@ final class Blocks {
 		if ( empty( $content ) ) {
 			return '';
 		}
+		self::$block_count++;
 		return sprintf( '<div class="%1$s" style="text-align:%2$s">%3$s</div>', $classes, $align, $content );
 	}
 


### PR DESCRIPTION
If the ID doesn't exist, the generated ID, formed by the page ID + the ad unit name, is not guaranteed to be unique. This hotfix ensures that the generated IDs are unique by including an index of block count.

This fixes issues for publishers that have been using multiple ad blocks on the same page using the same ad unit. Until the ad unit block is not manually edited, it won't have a random ID attached to it and the generated ID will take place.

### How to test

1. Create a new page with multiple Ad Unit blocks
2. Make sure the blocks have the same ad unit
3. Edit the page code to remove the `id` attribute of every ad unit block, so it forces the use of generated ID
4. While on the release branch, visit the page and confirm only the first ad renders
5. Check out this branch and confirm all ad units are rendering

Note: Being a single ad unit rendering multiple times, it must have multiple creatives attached to it.