### PR TITLE
feat(gam): size map filters and width threshold

### DIFF
--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -621,9 +621,9 @@ final class GAM_Model {
 	 * we can display [[640,320], [960,540]] on viewports >= 960px even though
 	 * the ratio difference is higher than the default 30%.
 	 *
-	 * @param array[] $sizes            Array of sizes.
-	 * @param float   $width_diff_ratio Minimum width ratio difference for sizes to share same viewport.
-	 * @param int     $width_threshold  Width threshold to ignore ratio difference.
+	 * @param array[]   $sizes            Array of sizes.
+	 * @param float     $width_diff_ratio Minimum width ratio difference for sizes to share same viewport.
+	 * @param int|false $width_threshold  Width threshold to ignore ratio difference. False disables threshold.
 	 *
 	 * @return array[] Size map keyed by the viewport width.
 	 */
@@ -638,7 +638,7 @@ final class GAM_Model {
 		foreach ( $viewports as $viewport_width ) {
 			foreach ( $sizes as $size ) {
 				$is_in_viewport     = $size[0] <= $viewport_width;
-				$is_above_threshold = $width_threshold <= $size[0];
+				$is_above_threshold = false !== $width_threshold && $width_threshold <= $size[0];
 				$diff               = min( $viewport_width, $size[0] ) / max( $viewport_width, $size[0] );
 				$is_within_ratio    = ( 1 - $width_diff_ratio ) <= $diff;
 				if ( $is_in_viewport && ( $is_within_ratio || $is_above_threshold ) ) {

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -93,7 +93,7 @@ final class GAM_Scripts {
 				'fluid'     => (bool) $ad_unit['fluid'],
 				'targeting' => $ad_targeting,
 				'sticky'    => GAM_Model::is_sticky( $ad_unit ),
-				'size_map'  => GAM_Model::get_responsive_size_map( $sizes ),
+				'size_map'  => GAM_Model::get_ad_unit_size_map( $ad_unit, $sizes ),
 			];
 		}
 

--- a/tests/test-model.php
+++ b/tests/test-model.php
@@ -218,7 +218,19 @@ class ModelTest extends WP_UnitTestCase {
 				'90'  => [ [ 60, 60 ], [ 90, 90 ] ],
 				'100' => [ [ 60, 60 ], [ 90, 90 ], [ 100, 100 ] ],
 			],
-			GAM_Model::get_responsive_size_map( [ [ 10, 10 ], [ 100, 100 ], [ 90, 90 ], [ 60, 60 ] ], 0.5 )
+			GAM_Model::get_responsive_size_map( [ [ 10, 10 ], [ 100, 100 ], [ 90, 90 ], [ 60, 60 ] ], 0.5 ),
+			'The size map groups sizes with a custom difference ratio.'
+		);
+
+		self::assertEquals(
+			[
+				'300' => [ [ 300, 200 ], [ 300, 250 ] ],
+				'350' => [ [ 350, 200 ] ],
+				'640' => [ [ 640, 360 ] ],
+				'960' => [ [ 640, 360 ], [ 960, 540 ] ],
+			],
+			GAM_Model::get_responsive_size_map( [ [ 300, 200 ], [ 300, 250 ], [ 350, 200 ], [ 640, 360 ], [ 960, 540 ] ], 0 ),
+			'The size map groups sizes above the default width threshold of 600 regardless of their ratio difference.'
 		);
 	}
 }

--- a/tests/test-model.php
+++ b/tests/test-model.php
@@ -219,7 +219,7 @@ class ModelTest extends WP_UnitTestCase {
 				'100' => [ [ 60, 60 ], [ 90, 90 ], [ 100, 100 ] ],
 			],
 			GAM_Model::get_responsive_size_map( [ [ 10, 10 ], [ 100, 100 ], [ 90, 90 ], [ 60, 60 ] ], 0.5 ),
-			'The size map groups sizes with a custom difference ratio.'
+			'Groups sizes with a custom difference ratio.'
 		);
 
 		self::assertEquals(
@@ -230,7 +230,18 @@ class ModelTest extends WP_UnitTestCase {
 				'960' => [ [ 640, 360 ], [ 960, 540 ] ],
 			],
 			GAM_Model::get_responsive_size_map( [ [ 300, 200 ], [ 300, 250 ], [ 350, 200 ], [ 640, 360 ], [ 960, 540 ] ], 0 ),
-			'The size map groups sizes above the default width threshold of 600 regardless of their ratio difference.'
+			'Groups sizes above the default width threshold of 600 regardless of their ratio difference.'
+		);
+
+		self::assertEquals(
+			[
+				'300' => [ [ 300, 200 ], [ 300, 250 ] ],
+				'350' => [ [ 350, 200 ] ],
+				'640' => [ [ 640, 360 ] ],
+				'960' => [ [ 960, 540 ] ],
+			],
+			GAM_Model::get_responsive_size_map( [ [ 300, 200 ], [ 300, 250 ], [ 350, 200 ], [ 640, 360 ], [ 960, 540 ] ], 0, false ),
+			'Groups sizes without ratio difference and threshold disabled.'
 		);
 	}
 }


### PR DESCRIPTION
Implements size map filters and a width threshold to allow tablet ads to share rotation with desktop ads regardless of their width ratio difference.

Closes #364 

### How to test

1. Create an ad unit with the following sizes: `320x180`, `320x480`, `640x360`, `960x540` and apply this ad unit to a global placement
2. With AMP Plus on, visit the page and inspect the generated GPT script (search for `all_ad_units`)
3. Confirm that the script contains the following `size_map` config parameter formed for the created ad unit:

```json
{
  320: [
    [320, 180],
    [320, 480],
  ],
  640: [
    [640, 360],
  ],
  960: [
    [640, 360],
    [960, 540],
  ],
}
```

On master, the viewport `960` doesn't include the `640x360` size.

4. Toggle AMP Plus off and refresh the page
5. Inspect the `<amp-ad />` element and confirm the grouping of tags also match the above, with a tag that looks like this: `<amp-ad width="960px" height="540px" data-multi-size="640x360" />`

You can also test disabling the threshold by adding the following filter:

```php
add_filter( 'newspack_ads_gam_size_map_width_threshold', '__return_false' );
```

Written tests should also pass.