### PR TITLE
feat(placements): ad unit preview

### DIFF
--- a/includes/class-bidding.php
+++ b/includes/class-bidding.php
@@ -333,15 +333,15 @@ final class Bidding {
 
 				// Detect sizes supported by available bidders.
 				$sizes = array_intersect(
-					array_map( [ __CLASS__, 'get_size_string' ], $ad_data['sizes'] ),
-					array_map( [ __CLASS__, 'get_size_string' ], $this->get_all_sizes() )
+					array_map( 'Newspack_Ads\get_size_string', $ad_data['sizes'] ),
+					array_map( 'Newspack_Ads\get_size_string', $this->get_all_sizes() )
 				);
 				// Reindex filtered array.
 				$sizes = array_values( $sizes );
 				if ( ! count( $sizes ) ) {
 					continue;
 				}
-				$sizes = array_map( [ __CLASS__, 'get_size_array' ], $sizes );
+				$sizes = array_map( 'Newspack_Ads\get_size_array', $sizes );
 
 				$bids = [];
 

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -71,6 +71,7 @@ final class Core {
 	 * e.g. include_once NEWSPACK_ADS_ABSPATH . 'includes/foo.php';
 	 */
 	private function includes() {
+		include_once NEWSPACK_ADS_ABSPATH . '/includes/utils.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/providers/interface-provider.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/providers/class-provider.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/providers/gam/class-gam-api.php';

--- a/includes/class-placements.php
+++ b/includes/class-placements.php
@@ -261,7 +261,7 @@ final class Placements {
 				$data['hooks'][ $hook_key ] = wp_parse_args(
 					$hook,
 					[
-						'provider' => 'gam',
+						'provider' => Providers::DEFAULT_PROVIDER,
 					]
 				);
 				if ( isset( $hook['ad_unit'] ) && $hook['ad_unit'] && ! isset( $hook['id'] ) ) {

--- a/includes/class-placements.php
+++ b/includes/class-placements.php
@@ -608,6 +608,9 @@ final class Placements {
 	public static function render_ad_unit_mock( $provider_id, $ad_unit, $classes = [] ) {
 		$provider     = Providers::get_provider( $provider_id );
 		$ad_unit_data = Providers::get_provider_unit_data( $provider_id, $ad_unit );
+		if ( ! $ad_unit_data ) {
+			return;
+		}
 		/**
 		 * Default to a 300x200 size if no sizes are provided.
 		 */

--- a/includes/class-placements.php
+++ b/includes/class-placements.php
@@ -628,7 +628,6 @@ final class Placements {
 					width="<?php echo esc_attr( $width ); ?>"
 					height="<?php echo esc_attr( $height ); ?>"
 					strokeDasharray="2"
-					fill="transparent"
 				/>
 				<line x1="0" y1="0" x2="100%" y2="100%" strokeDasharray="2" />
 			</svg>

--- a/includes/class-providers.php
+++ b/includes/class-providers.php
@@ -90,7 +90,7 @@ final class Providers {
 	/**
 	 * Get registered providers.
 	 *
-	 * @return Newspack_Ads_Provider[] Associative array of registered providers keyed by their ID.
+	 * @return Provider[] Associative array of registered providers keyed by their ID.
 	 */
 	public static function get_providers() {
 		return self::$providers;
@@ -99,7 +99,7 @@ final class Providers {
 	/**
 	 * Get a serialised provider data.
 	 *
-	 * @param Newspack_Ads_Provider $provider The provider to serialise.
+	 * @param Provider $provider The provider to serialise.
 	 *
 	 * @return array Associative array with provider data.
 	 */
@@ -114,7 +114,7 @@ final class Providers {
 	/**
 	 * Get active providers.
 	 *
-	 * @return Newspack_Ads_Provider[] Associative array of active providers keyed by their ID.
+	 * @return Provider[] Associative array of active providers keyed by their ID.
 	 */
 	public static function get_active_providers() {
 		$active_providers = [];
@@ -127,11 +127,64 @@ final class Providers {
 	}
 
 	/**
+	 * Get active providers with their units.
+	 *
+	 * @return array[] Serialised providers with their units.
+	 */
+	public static function get_active_providers_data() {
+		if ( empty( self::$active_providers_data ) ) {
+			$active_providers            = self::get_active_providers();
+			self::$active_providers_data = array_map(
+				function( Provider $provider ) {
+					return self::get_provider_data( $provider->get_provider_id() );
+				},
+				array_values( $active_providers )
+			);
+		}
+		return self::$active_providers_data;
+	}
+
+	/**
+	 * Get provider data by its ID.
+	 *
+	 * @param string $provider_id The provider ID.
+	 *
+	 * @return array|null Associative array of provider data or null if not found.
+	 */
+	public static function get_provider_data( $provider_id ) {
+		$provider = self::get_provider( $provider_id );
+		if ( ! $provider ) {
+			return null;
+		}
+		return array_merge( self::get_serialised_provider( $provider ), [ 'units' => $provider->get_units() ] );  
+	}
+
+	/**
+	 * Get a provider unit data.
+	 *
+	 * @param string $provider_id The provider ID.
+	 * @param string $unit_value The unit value.
+	 *
+	 * @return array|null Unit data or null if not found.
+	 */
+	public static function get_provider_unit_data( $provider_id, $unit_value ) {
+		$provider = self::get_provider_data( $provider_id );
+		if ( empty( $provider ) ) {
+			return null;
+		}
+		$ad_unit_idx = array_search( $unit_value, array_column( $provider['units'], 'value' ) );
+		if ( false === $unit_value ) {
+			return null;
+		}
+		return $provider['units'][ $ad_unit_idx ];
+	}
+
+	/**
 	 * Get a provider given its ID.
 	 *
 	 * @param string $provider_id The provider ID.
 	 *
-	 * @return Newspack_Ads_Provider|false The provider or false if not found.
+	 * @return Provider|false The provider or false if not found.
 	 */
 	public static function get_provider( $provider_id ) {
 		$providers = self::get_providers();

--- a/includes/class-providers.php
+++ b/includes/class-providers.php
@@ -180,7 +180,7 @@ final class Providers {
 			return null;
 		}
 		$ad_unit_idx = array_search( $unit_value, array_column( $provider['units'], 'value' ) );
-		if ( false === $unit_value ) {
+		if ( false === $ad_unit_idx ) {
 			return null;
 		}
 		return $provider['units'][ $ad_unit_idx ];

--- a/includes/class-providers.php
+++ b/includes/class-providers.php
@@ -33,6 +33,13 @@ final class Providers {
 	protected static $providers = [];
 
 	/**
+	 * Cache of active providers data.
+	 *
+	 * @var array[] Serialised providers with their units.
+	 */
+	protected static $active_providers_data = null;
+
+	/**
 	 * Initialize providers.
 	 */
 	public static function init() {

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Newspack Ads Utility Functions.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Ads;
+
+/**
+ * Return a string from a size array.
+ *
+ * @param array $size Size array.
+ *
+ * @return string Size string.
+ */
+function get_size_string( $size ) {
+	return $size[0] . 'x' . $size[1];
+}
+
+/**
+ * Return an array from a size string.
+ *
+ * @param string $size Size string.
+ *
+ * @return array Size array.
+ */
+function get_size_array( $size ) {
+	return array_map( 'intval', explode( 'x', $size ) );
+}

--- a/src/frontend/style.scss
+++ b/src/frontend/style.scss
@@ -1,3 +1,5 @@
+@import '~@wordpress/base-styles/colors';
+
 .stick-to-top:last-child {
 	position: sticky;
 	top: 1rem;
@@ -10,4 +12,43 @@
 // TMP: the overflow: hidden should be removed in the theme.
 #page {
 	overflow: initial !important;
+}
+
+/**
+ * Placement mock
+ */
+.newspack-ads {
+	&__ad-placement-mock {
+		position: relative;
+		align-items: center;
+		display: flex;
+		font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu,
+			Cantarell, 'Helvetica Neue', sans-serif;
+		justify-content: center;
+		&__svg {
+			display: block;
+			pointer-events: none;
+			position: absolute;
+			rect {
+				fill: white;
+				stroke: rgba( $gray-900, 0.4 );
+				stroke-width: 1px;
+			}
+			line {
+				stroke: rgba( $gray-900, 0.4 );
+				stroke-width: 1px;
+			}
+		}
+		&__label {
+			background: white;
+			border: 1px dashed rgba( $gray-900, 0.4 );
+			color: $gray-900;
+			font-size: 10px;
+			line-height: 1.6;
+			padding: 4px 8px;
+			pointer-events: none;
+			position: absolute;
+			text-align: center;
+		}
+	}
 }

--- a/tests/class-newspack-ads-test-provider.php
+++ b/tests/class-newspack-ads-test-provider.php
@@ -35,10 +35,7 @@ class Newspack_Ads_Test_Provider extends Provider {
 				'name'  => 'Test Ad Unit',
 				'value' => 'test_ad_unit',
 				'sizes' => [
-					[
-						'width'  => 300,
-						'height' => 250,
-					],
+					[ 300, 250 ],
 				],
 			],
 		];

--- a/tests/test-providers.php
+++ b/tests/test-providers.php
@@ -115,9 +115,6 @@ class ProvidersTest extends WP_UnitTestCase {
 			],
 			Providers::get_provider_unit_data( 'test_provider', 'test_ad_unit' )
 		);
-		self::assertEquals(
-			null,
-			Providers::get_provider_unit_data( 'test_provider', 'not_an_ad_unit' )
-		);
+		self::assertNull( Providers::get_provider_unit_data( 'test_provider', 'not_an_ad_unit' ) );
 	}
 }

--- a/tests/test-providers.php
+++ b/tests/test-providers.php
@@ -36,12 +36,12 @@ class ProvidersTest extends WP_UnitTestCase {
 	public function test_serialised_provider() {
 		$serialised_provider = Providers::get_serialised_provider( self::$provider );
 		self::assertEquals(
-			$serialised_provider,
 			[
 				'id'     => self::$provider->get_provider_id(),
 				'name'   => self::$provider->get_provider_name(),
 				'active' => self::$provider->is_active(),
-			]
+			],
+			$serialised_provider
 		);
 	}
 
@@ -54,8 +54,8 @@ class ProvidersTest extends WP_UnitTestCase {
 			$provider instanceof Provider
 		);
 		self::assertEquals(
-			$provider->get_provider_id(),
-			self::$provider->get_provider_id()
+			self::$provider->get_provider_id(),
+			$provider->get_provider_id()
 		);
 	}
 
@@ -73,8 +73,51 @@ class ProvidersTest extends WP_UnitTestCase {
 		);
 		$code = ob_get_clean();
 		self::assertEquals(
-			$code,
-			'test_ad_unit test_placement_id test_hook_key'
+			'test_ad_unit test_placement_id test_hook_key',
+			$code
+		);
+	}
+
+	/**
+	 * Test method to get a provider data.
+	 */
+	public function test_provider_data() {
+		self::assertEquals(
+			[
+				'id'     => 'test_provider',
+				'name'   => 'Test Provider',
+				'active' => true,
+				'units'  => [
+					[
+						'name'  => 'Test Ad Unit',
+						'value' => 'test_ad_unit',
+						'sizes' => [
+							[ 300, 250 ],
+						],
+					],
+				],
+			],
+			Providers::get_provider_data( 'test_provider' )
+		);
+	}
+
+	/**
+	 * Test method to get a provider unit data.
+	 */
+	public function test_provider_unit_data() {
+		self::assertEquals(
+			[
+				'name'  => 'Test Ad Unit',
+				'value' => 'test_ad_unit',
+				'sizes' => [
+					[ 300, 250 ],
+				],
+			],
+			Providers::get_provider_unit_data( 'test_provider', 'test_ad_unit' )
+		);
+		self::assertEquals(
+			null,
+			Providers::get_provider_unit_data( 'test_provider', 'not_an_ad_unit' )
 		);
 	}
 }


### PR DESCRIPTION
Implements the ad unit mock preview when viewing ad units through the customizer.  It also:

 - [Fix placement hook data to use the default provider if not yet stored](https://github.com/Automattic/newspack-ads/pull/367/files#diff-fb1912afb032a05d595f377bddbe82f63efb460f9df64caee448b35835d07b8aR261-R266)
 - Extends the Providers class API
 - Inaugurates `utils.php` for shared utility across the plugin

Closes #334 and is also an important part of the work in progress at #287.

### How to test this PR

1. Check out this branch, run `npm run build` and confirm you have ad units applied to placements
2. Visit a page with ads and enter the Customizer
3. Confirm you see the same ad unit mock preview like the one displayed in the block editor

Updated test for the extended Providers class API should also pass.