### PR TITLE
feat(integrations): disable refresh control for adsense

### DIFF
--- a/includes/integrations/class-ad-refresh-control.php
+++ b/includes/integrations/class-ad-refresh-control.php
@@ -32,6 +32,7 @@ class Ad_Refresh_Control {
 	 */
 	public static function init() {
 		\add_filter( 'newspack_amp_plus_sanitized', [ __CLASS__, 'allow_amp_plus' ], 10, 2 );
+		\add_filter( 'avc_advertiser_ids', [ __CLASS__, 'default_advertiser_ids' ] );
 		\add_action( 'rest_api_init', [ __CLASS__, 'register_api_endpoints' ] );
 	}
 
@@ -51,6 +52,21 @@ class Ad_Refresh_Control {
 			}
 		}
 		return $is_sanitized;
+	}
+
+	/**
+	 * Default advertisers IDs to exclude.
+	 *
+	 * Excludes when the advertiser ID is 0, representing AdSense, which does not
+	 * allow refreshing.
+	 *
+	 * @param array $advertiser_ids Advertiser IDs to exclude.
+	 *
+	 * @return array Advertiser IDs to exclude.
+	 */
+	public static function default_advertiser_ids( $advertiser_ids ) {
+		$advertiser_ids[] = 0;
+		return $advertiser_ids;
 	}
 
 	/**

--- a/includes/integrations/class-ad-refresh-control.php
+++ b/includes/integrations/class-ad-refresh-control.php
@@ -28,7 +28,7 @@ class Ad_Refresh_Control {
 	];
 
 	/**
-	 * Initialize SCAIP Hooks.
+	 * Initialize hooks.
 	 */
 	public static function init() {
 		\add_filter( 'newspack_amp_plus_sanitized', [ __CLASS__, 'allow_amp_plus' ], 10, 2 );


### PR DESCRIPTION
Add `0` to the list of disabled advertisers for refresh control.

Closes #370

### How to test

1. Check out this branch, visit the Add-Ons page and make sure you have Ad Refresh Control enabled
2. Visit the Settings wizard and confirm you have no **Excluded Advertiser IDs**
3. Visit the front page, inspect the HTML and search for `advertiserIds`
4. Confirm the value is `[1]`. The values are sent as a PHP to JSON encoded map, so index `0` being of value `1` means disable `0`
5. Fill `1234` to the **Excluded Advertiser IDs** field and save
6. Confirm the value printed on the page is now `{ "1234": 1, "0": 1 }`