### PR TITLE
feat(gam): strict container bounds for ad slot

### DIFF
--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -268,7 +268,7 @@ final class GAM_Scripts {
 					var availableWidth = Math.max( boundWidth, containerWidth ) + parseInt( ad_unit['container_bleed'] );
 					for ( viewportWidth in ad_unit['size_map'] ) {
 						var width = parseInt( viewportWidth );
-						if ( shouldUseBounds && width <= availableWidth ) {
+						if ( ! shouldUseBounds || width <= availableWidth ) {
 							var mappedSizes = ad_unit['size_map'][ viewportWidth ];
 							mapping.addSize( [ width, 0 ], baseSizes.concat( mappedSizes ) );
 						}

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -234,7 +234,8 @@ final class GAM_Scripts {
 					 */
 					?>
 					var boundWidth = 0;
-					for ( var selector of ad_unit['bounds_selectors'] ) {
+					for ( var i = 0; i < ad_unit['bounds_selectors'].length; i++ ) {
+						var selector = ad_unit['bounds_selectors'][ i ];
 						if ( boundWidth ) {
 							break;
 						}
@@ -242,8 +243,8 @@ final class GAM_Scripts {
 							boundsContainers[ selector ] = document.querySelectorAll( selector );
 						}
 						if ( boundsContainers[ selector ].length ) {
-							for( var i = 0; i < boundsContainers[ selector ].length; i++ ) {
-								var boundContainer = boundsContainers[ selector ][ i ];
+							for( var j = 0; j < boundsContainers[ selector ].length; j++ ) {
+								var boundContainer = boundsContainers[ selector ][ j ];
 								if ( boundContainer.contains( container ) ) {
 									boundWidth = boundContainer.offsetWidth;
 									break;

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -89,9 +89,10 @@ final class GAM_Scripts {
 			}
 
 			/**
-			 * Filters which container elements should restrict the bounds of the ad.
+			 * Filters which container elements should restrict the bounds of its
+			 * inner ads.
 			 *
-			 * @param string[] $bounds_selectors The selectors to restrict the bounds of the ad.
+			 * @param string[] $bounds_selectors The selectors to restrict bounds.
 			 * @param array    $ad_unit          Ad unit data.
 			 * @param array    $sizes            Ad unit sizes.
 			 */
@@ -230,11 +231,11 @@ final class GAM_Scripts {
 
 					<?php
 					/**
-					 * Identify the bound container for this slot and use its offset
-					 * width as bound width.
+					 * Identify the bounds container for this slot and use its offset
+					 * width as bounds width.
 					 */
 					?>
-					var boundWidth = 0;
+					var boundsWidth = 0;
 					findContainer:
 					for ( var i = 0; i < ad_unit['bounds_selectors'].length; i++ ) {
 						var selector = ad_unit['bounds_selectors'][ i ];
@@ -243,9 +244,9 @@ final class GAM_Scripts {
 						}
 						if ( boundsContainers[ selector ].length ) {
 							for( var j = 0; j < boundsContainers[ selector ].length; j++ ) {
-								var boundContainer = boundsContainers[ selector ][ j ];
-								if ( boundContainer.contains( container ) ) {
-									boundWidth = boundContainer.offsetWidth;
+								var boundsContainer = boundsContainers[ selector ][ j ];
+								if ( boundsContainer.contains( container ) ) {
+									boundsWidth = boundsContainer.offsetWidth;
 									break findContainer;
 								}
 							}
@@ -254,17 +255,15 @@ final class GAM_Scripts {
 					<?php
 					/**
 					 * Iterate and apply size map skipping viewports larger than the ad
-					 * identified bound.
+					 * identified container width, if a bounds container is identified.
 					 *
-					 * It should use bounds if the ad is located inside a bound container.
-					 *
-					 * The available width is the bigger of the bound width or the direct
+					 * The available width is the bigger of the bounds width or the direct
 					 * parent offset width.
 					 */
 					?>
-					var shouldUseBounds = !! boundWidth;
+					var shouldUseBounds = !! boundsWidth;
 					var containerWidth = container.parentNode.offsetWidth;
-					var availableWidth = Math.max( boundWidth, containerWidth ) + parseInt( ad_unit['container_bleed'] );
+					var availableWidth = Math.max( boundsWidth, containerWidth ) + parseInt( ad_unit['container_bleed'] );
 					for ( viewportWidth in ad_unit['size_map'] ) {
 						var width = parseInt( viewportWidth );
 						if ( ! shouldUseBounds || width <= availableWidth ) {

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -92,22 +92,33 @@ final class GAM_Scripts {
 			 * Filters whether the script should consider the container offset width
 			 * to filter out ad sizes that are too wide for the slot.
 			 *
-			 * @param bool  $strict_container_bounds Whether to consider the container offset width.
+			 * @param bool  $strict_bounds Whether to consider the container offset width.
 			 * @param array $ad_unit                 Ad unit data.
 			 * @param array $sizes                   Ad unit sizes.
 			 */
-			$strict_container_bounds = apply_filters( 'newspack_ads_gam_strict_container_bounds', true, $ad_unit, $sizes );
+			$strict_bounds = apply_filters( 'newspack_ads_gam_strict_container_bounds', true, $ad_unit, $sizes );
+
+			/**
+			 * Filters the bleed allowed to extrapolate the ad container bounds in
+			 * case the bounds are strict.
+			 *
+			 * @param int   $container_bleed The amount of bleed allowed.
+			 * @param array $ad_unit                Ad unit data.
+			 * @param array $sizes                  Ad unit sizes.
+			 */
+			$container_bleed = apply_filters( 'newspack_ads_gam_container_bounds_bleed', 40, $ad_unit, $sizes );
 
 			$prepared_unit_data[ $container_id ] = [
-				'unique_id'               => $unique_id,
-				'name'                    => esc_attr( $ad_unit['name'] ),
-				'code'                    => esc_attr( $ad_unit['code'] ),
-				'sizes'                   => $sizes,
-				'fluid'                   => (bool) $ad_unit['fluid'],
-				'targeting'               => $ad_targeting,
-				'sticky'                  => GAM_Model::is_sticky( $ad_unit ),
-				'size_map'                => GAM_Model::get_ad_unit_size_map( $ad_unit, $sizes ),
-				'strict_container_bounds' => (bool) $strict_container_bounds,
+				'unique_id'       => $unique_id,
+				'name'            => esc_attr( $ad_unit['name'] ),
+				'code'            => esc_attr( $ad_unit['code'] ),
+				'sizes'           => $sizes,
+				'fluid'           => (bool) $ad_unit['fluid'],
+				'targeting'       => $ad_targeting,
+				'sticky'          => GAM_Model::is_sticky( $ad_unit ),
+				'size_map'        => GAM_Model::get_ad_unit_size_map( $ad_unit, $sizes ),
+				'strict_bounds'   => (bool) $strict_bounds,
+				'container_bleed' => (int) $container_bleed ?? 0,
 			];
 		}
 
@@ -212,10 +223,10 @@ final class GAM_Scripts {
 					 * container offset width.
 					 */
 					?>
-					var availableWidth = container.parentNode.offsetWidth;
+					var availableWidth = container.parentNode.offsetWidth + parseInt( ad_unit['container_bleed'] );
 					for ( viewportWidth in ad_unit['size_map'] ) {
 						var width = parseInt( viewportWidth );
-						if ( ad_unit['strict_container_bounds'] && width <= availableWidth ) {
+						if ( ad_unit['strict_bounds'] && width <= availableWidth ) {
 							var mappedSizes = ad_unit['size_map'][ viewportWidth ];
 							mapping.addSize( [ width, 0 ], baseSizes.concat( mappedSizes ) );
 						}

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -93,8 +93,8 @@ final class GAM_Scripts {
 			 * to filter out ad sizes that are too wide for the slot.
 			 *
 			 * @param bool  $strict_bounds Whether to consider the container offset width.
-			 * @param array $ad_unit                 Ad unit data.
-			 * @param array $sizes                   Ad unit sizes.
+			 * @param array $ad_unit       Ad unit data.
+			 * @param array $sizes         Ad unit sizes.
 			 */
 			$strict_bounds = apply_filters( 'newspack_ads_gam_strict_container_bounds', true, $ad_unit, $sizes );
 
@@ -103,8 +103,8 @@ final class GAM_Scripts {
 			 * case the bounds are strict.
 			 *
 			 * @param int   $container_bleed The amount of bleed allowed.
-			 * @param array $ad_unit                Ad unit data.
-			 * @param array $sizes                  Ad unit sizes.
+			 * @param array $ad_unit         Ad unit data.
+			 * @param array $sizes           Ad unit sizes.
 			 */
 			$container_bleed = apply_filters( 'newspack_ads_gam_container_bounds_bleed', 40, $ad_unit, $sizes );
 

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -254,11 +254,11 @@ final class GAM_Scripts {
 					}
 					<?php
 					/**
-					 * Iterate and apply size map skipping viewports larger than the ad
-					 * identified container width, if a bounds container is identified.
+					 * Iterate and apply size map skipping viewports larger than the
+					 * container width, if a bounds container is identified.
 					 *
-					 * The available width is the bigger of the bounds width or the direct
-					 * parent offset width.
+					 * The available width is the bigger of the bounds container width or
+					 * the direct parent offset width.
 					 */
 					?>
 					var shouldUseBounds = !! boundsWidth;

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -172,11 +172,12 @@ final class GAM_Scripts {
 		?>
 		<script data-amp-plus-allowed>
 			googletag.cmd.push(function() {
-				var ad_config         = <?php echo wp_json_encode( $ad_config ); ?>;
-				var all_ad_units      = <?php echo wp_json_encode( $prepared_unit_data ); ?>;
-				var lazy_load         = <?php echo wp_json_encode( Settings::get_settings( 'lazy_load', true ), JSON_FORCE_OBJECT ); ?>;
-				var common_targeting  = <?php echo wp_json_encode( $common_targeting, JSON_FORCE_OBJECT ); ?>;
-				var defined_ad_units  = {};
+				var ad_config        = <?php echo wp_json_encode( $ad_config ); ?>;
+				var all_ad_units     = <?php echo wp_json_encode( $prepared_unit_data ); ?>;
+				var lazy_load        = <?php echo wp_json_encode( Settings::get_settings( 'lazy_load', true ), JSON_FORCE_OBJECT ); ?>;
+				var common_targeting = <?php echo wp_json_encode( $common_targeting, JSON_FORCE_OBJECT ); ?>;
+				var defined_ad_units = {};
+
 				var boundsContainers = {};
 
 				for ( var container_id in all_ad_units ) {

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -111,11 +111,11 @@ final class GAM_Scripts {
 			 * Filters the bleed allowed to extrapolate the ad container bounds in
 			 * case the bounds are strict.
 			 *
-			 * @param int   $container_bleed The amount of bleed allowed.
-			 * @param array $ad_unit         Ad unit data.
-			 * @param array $sizes           Ad unit sizes.
+			 * @param int   $bounds_bleed The amount of bleed allowed.
+			 * @param array $ad_unit      Ad unit data.
+			 * @param array $sizes        Ad unit sizes.
 			 */
-			$container_bleed = apply_filters( 'newspack_ads_gam_container_bounds_bleed', 40, $ad_unit, $sizes );
+			$bounds_bleed = apply_filters( 'newspack_ads_gam_bounds_bleed', 40, $ad_unit, $sizes );
 
 			$prepared_unit_data[ $container_id ] = [
 				'unique_id'        => $unique_id,
@@ -127,7 +127,7 @@ final class GAM_Scripts {
 				'sticky'           => GAM_Model::is_sticky( $ad_unit ),
 				'size_map'         => GAM_Model::get_ad_unit_size_map( $ad_unit, $sizes ),
 				'bounds_selectors' => $bounds_selectors,
-				'container_bleed'  => (int) $container_bleed ?? 0,
+				'bounds_bleed'     => (int) $bounds_bleed ?? 0,
 			];
 		}
 
@@ -263,7 +263,7 @@ final class GAM_Scripts {
 					?>
 					var shouldUseBounds = !! boundsWidth;
 					var containerWidth = container.parentNode.offsetWidth;
-					var availableWidth = Math.max( boundsWidth, containerWidth ) + parseInt( ad_unit['container_bleed'] );
+					var availableWidth = Math.max( boundsWidth, containerWidth ) + parseInt( ad_unit['bounds_bleed'] );
 					for ( viewportWidth in ad_unit['size_map'] ) {
 						var width = parseInt( viewportWidth );
 						if ( ! shouldUseBounds || width <= availableWidth ) {

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -95,7 +95,6 @@ final class GAM_Scripts {
 			 * @param array    $ad_unit          Ad unit data.
 			 * @param array    $sizes            Ad unit sizes.
 			 */
-
 			$bounds_selectors = apply_filters(
 				'newspack_ads_gam_bounds_selectors',
 				[

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -235,11 +235,9 @@ final class GAM_Scripts {
 					 */
 					?>
 					var boundWidth = 0;
+					findContainer:
 					for ( var i = 0; i < ad_unit['bounds_selectors'].length; i++ ) {
 						var selector = ad_unit['bounds_selectors'][ i ];
-						if ( boundWidth ) {
-							break;
-						}
 						if ( typeof boundsContainers[ selector ] === 'undefined' ) {
 							boundsContainers[ selector ] = document.querySelectorAll( selector );
 						}
@@ -248,7 +246,7 @@ final class GAM_Scripts {
 								var boundContainer = boundsContainers[ selector ][ j ];
 								if ( boundContainer.contains( container ) ) {
 									boundWidth = boundContainer.offsetWidth;
-									break;
+									break findContainer;
 								}
 							}
 						}

--- a/src/frontend/style.scss
+++ b/src/frontend/style.scss
@@ -1,9 +1,5 @@
 @import '~@wordpress/base-styles/colors';
 
-.newspack_global_ad {
-	width: 100%;
-}
-
 .stick-to-top:last-child {
 	position: sticky;
 	top: 1rem;

--- a/src/frontend/style.scss
+++ b/src/frontend/style.scss
@@ -1,5 +1,9 @@
 @import '~@wordpress/base-styles/colors';
 
+.newspack_global_ad {
+	width: 100%;
+}
+
 .stick-to-top:last-child {
 	position: sticky;
 	top: 1rem;
@@ -12,10 +16,6 @@
 // TMP: the overflow: hidden should be removed in the theme.
 #page {
 	overflow: initial !important;
-}
-
-.newspack_global_ad {
-	width: 100%;
 }
 
 /**

--- a/src/frontend/style.scss
+++ b/src/frontend/style.scss
@@ -14,6 +14,10 @@
 	overflow: initial !important;
 }
 
+.newspack_global_ad {
+	width: 100%;
+}
+
 /**
  * Placement mock
  */


### PR DESCRIPTION
Prevents the rendering of slot creatives larger than the container offset width. Also puts it behind a filter so publishers can modify its behavior per ad unit.

It also proposes a bleed of 40px by default, so the centered creative can extrapolate at most 20 pixels on each side.

~~The `newspack_ad_global` was added a default `width: 100%;` to ensure that the container fills the available space. This shouldn't be an issue for regular units, only for the full-width template, which requires this PR: https://github.com/Automattic/newspack-theme/pull/1766~~

~~I'd also appreciate a confidence check on the use of the direct parent `offsetWidth` for this strategy. An alternative is to resolve the issue by case, for example, detect if the slot is within `entry-content`, use its width as the argument and ignore other cases.~~

Update: I've decided to tweak the approach to use declared "bounds containers" instead of the direct parent. It is a safer approach since floated blocks or other unusual approaches may get affected by the previous method, resulting in no ads being rendered.

As documented inline, the filterable list of bounds containers selectors can determine the available width for the slot. In case the slot is contained by one, the available width will be the bigger of the bounds container width or the direct parent offset width.

The proposed selectors are:

 - `.entry-content` - post content
 - `.widget-area` - sidebars
 - `.sidebar` - increase potential sidebar coverage
 
Ad slots outside of the above elements shouldn't have container bounds applied.

### How to test

Using an ad unit with 300x200, 970x90, and 728x90 sizes apply as a SCAIP position and with your browser viewport at approximately 1250px:

1. Visit a post with sidebar (default template) and confirm only the 728x90 creative is rendered
2. Visit a post with the full-width template and confirm it rotates between 728x90 and 970x90

On master, it renders the 970x90 creative on both templates because it fits on the viewport, but the container width can be smaller and extrapolates bounds:

| Master | This PR |
| --- | --- |
| <img width="1221" alt="image" src="https://user-images.githubusercontent.com/820752/163063822-f615ec3b-a2a4-449c-8520-b27749d43dd4.png"> | <img width="1214" alt="image" src="https://user-images.githubusercontent.com/820752/163063778-3c4b860a-31aa-4ef0-9640-e86ddad43072.png"> |

Change the viewport to approximately 900px and confirm the 300x200 creative is rendered for the post with the default template.

Add other units to other global placements and make sure the ads are rendering as expected.