### PR TITLE
perf(providers): optimize data cache

### DIFF
--- a/includes/class-providers.php
+++ b/includes/class-providers.php
@@ -33,11 +33,11 @@ final class Providers {
 	protected static $providers = [];
 
 	/**
-	 * Cache of active providers data.
+	 * Cache of providers data.
 	 *
-	 * @var array[] Serialised providers with their units.
+	 * @var array[] Associative array of serialised providers with their units, keyed by their ID.
 	 */
-	protected static $active_providers_data = null;
+	protected static $providers_data = [];
 
 	/**
 	 * Initialize providers.
@@ -139,16 +139,13 @@ final class Providers {
 	 * @return array[] Serialised providers with their units.
 	 */
 	public static function get_active_providers_data() {
-		if ( empty( self::$active_providers_data ) ) {
-			$active_providers            = self::get_active_providers();
-			self::$active_providers_data = array_map(
-				function( Provider $provider ) {
-					return self::get_provider_data( $provider->get_provider_id() );
-				},
-				array_values( $active_providers )
-			);
-		}
-		return self::$active_providers_data;
+		$active_providers = self::get_active_providers();
+		return array_map(
+			function( Provider $provider ) {
+				return self::get_provider_data( $provider->get_provider_id() );
+			},
+			array_values( $active_providers )
+		);
 	}
 
 	/**
@@ -159,11 +156,18 @@ final class Providers {
 	 * @return array|null Associative array of provider data or null if not found.
 	 */
 	public static function get_provider_data( $provider_id ) {
-		$provider = self::get_provider( $provider_id );
-		if ( ! $provider ) {
-			return null;
+		if ( ! isset( self::$providers_data[ $provider_id ] ) ) {
+			$provider = self::get_provider( $provider_id );
+			if ( $provider ) {
+				self::$providers_data[ $provider_id ] = array_merge(
+					self::get_serialised_provider( $provider ),
+					[ 'units' => $provider->get_units() ]
+				);
+			} else {
+				self::$providers_data[ $provider_id ] = null;
+			}
 		}
-		return array_merge( self::get_serialised_provider( $provider ), [ 'units' => $provider->get_units() ] );  
+		return self::$providers_data[ $provider_id ];
 	}
 
 	/**


### PR DESCRIPTION
A small performance tweak for fetched providers' data.

Moves the cache to the `get_provider_data()` method level in order to increase its coverage across different methods.

### How to test

No changes should take place.

With GAM connected and Broadstreet installed and connected visit the Placements editor and confirm data from both providers are available for editing.

Provider methods tests passing should also confirm the expected data is being returned.