### PR TITLE
chore: remove unused methods

### DIFF
--- a/includes/class-bidding.php
+++ b/includes/class-bidding.php
@@ -233,28 +233,6 @@ final class Bidding {
 	}
 
 	/**
-	 * Return a string from a size array.
-	 *
-	 * @param array $size Size array.
-	 *
-	 * @return string Size string.
-	 */
-	private static function get_size_string( $size ) {
-		return $size[0] . 'x' . $size[1];
-	}
-
-	/**
-	 * Return an array from a size string.
-	 *
-	 * @param string $size Size string.
-	 *
-	 * @return array Size array.
-	 */
-	private static function get_size_array( $size ) {
-		return array_map( 'intval', explode( 'x', $size ) );
-	}
-
-	/**
 	 * Sanitize an array of price buckets.
 	 *
 	 * @param array[] $price_buckets Array of price buckets.

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -721,12 +721,7 @@ final class GAM_Model {
 			$width  = $viewport_width;
 			$height = absint( max( array_column( $ad_sizes, 1 ) ) );
 
-			$multisizes = array_map(
-				function( $size ) {
-					return $size[0] . 'x' . $size[1];
-				},
-				$ad_sizes
-			);
+			$multisizes = array_map( '\Newspack_Ads\get_size_string', $ad_sizes );
 
 			// If there is a multisize that's equal to the width and height of the container, remove it from the multisizes.
 			// The container size is included by default, and should not also be included in the multisize.


### PR DESCRIPTION
As per #367, these size transformation methods are now part of the `utils.php` file and are not used.

cc92f7d5f019185eafd15716c5fbc7a987452e42 also applies the util function to the multisize attribute for GAM AMP ad code generation.