### PR TITLE
fix(blocks): simplify block placement id

### DIFF
--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -42,9 +42,6 @@ final class Blocks {
 			'newspack-ads/ad-unit',
 			[
 				'attributes'      => [
-					'id'          => [
-						'type' => 'string',
-					],
 					'provider'    => [
 						'type'    => 'string',
 						'default' => 'gam',
@@ -68,20 +65,6 @@ final class Blocks {
 	}
 
 	/**
-	 * Generate a block ID in case the block doesn't have the ID attribute.
-	 *
-	 * @param array[] $data Block placement data.
-	 *
-	 * @return string Block ID.
-	 */
-	private static function get_block_id( $data ) {
-		if ( isset( $data['id'] ) && ! empty( $data['id'] ) ) {
-			return $data['id'];
-		}
-		return sprintf( '%1$s_%2$s_%3$s', get_the_ID(), $data['ad_unit'], self::$block_count );
-	}
-
-	/**
 	 * Get block placement data.
 	 *
 	 * @param array[] $attrs Block attributes.
@@ -89,15 +72,15 @@ final class Blocks {
 	 * @return array[] Placement data.
 	 */
 	private static function get_block_placement_data( $attrs ) {
-		$data       = wp_parse_args(
+		$data = wp_parse_args(
 			$attrs,
 			[
+				'id'       => uniqid(),
 				'enabled'  => true,
 				'provider' => 'gam',
 				'ad_unit'  => isset( $attrs['activeAd'] ) ? $attrs['activeAd'] : '',
 			]
 		);
-		$data['id'] = self::get_block_id( $data );
 		return $data;
 	}
 

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -16,13 +16,6 @@ use Newspack_Ads\Placements;
 final class Blocks {
 
 	/**
-	 * Amount of blocks rendered in the page.
-	 *
-	 * @var int
-	 */
-	private static $block_count = 0;
-
-	/**
 	 * Initialize blocks
 	 *
 	 * @return void
@@ -143,7 +136,6 @@ final class Blocks {
 		if ( empty( $content ) ) {
 			return '';
 		}
-		self::$block_count++;
 		return sprintf( '<div class="%1$s" style="text-align:%2$s">%3$s</div>', $classes, $align, $content );
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
       "dependencies": {
         "lodash": "^4.17.21",
         "newspack-components": "^2.0.3",
-        "prebid.js": "^6.20.0",
-        "uuid": "^8.3.2"
+        "prebid.js": "^6.20.0"
       },
       "devDependencies": {
         "@rushstack/eslint-patch": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   "dependencies": {
     "lodash": "^4.17.21",
     "newspack-components": "^2.0.3",
-    "prebid.js": "^6.20.0",
-    "uuid": "^8.3.2"
+    "prebid.js": "^6.20.0"
   }
 }

--- a/src/blocks/ad-unit/edit.js
+++ b/src/blocks/ad-unit/edit.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { v4 as uuid } from 'uuid';
 import classNames from 'classnames';
 
 /**
@@ -128,10 +127,7 @@ function Edit( { attributes, setAttributes } ) {
 										value={ attributes }
 										onChange={ value => {
 											setIsEditing( true );
-											setAttributes( {
-												...value,
-												id: uuid(),
-											} );
+											setAttributes( value );
 										} }
 									/>
 								</div>

--- a/src/blocks/ad-unit/index.js
+++ b/src/blocks/ad-unit/index.js
@@ -32,9 +32,6 @@ export const settings = {
 	],
 	description: __( 'Render an ad unit from your inventory.', 'newspack-ads' ),
 	attributes: {
-		id: {
-			type: 'string',
-		},
 		provider: {
 			type: 'string',
 			default: 'gam',


### PR DESCRIPTION
The Ad Unit blocks require to have a placement ID that does not have to persist or be predictable due to the dynamic nature of such placements.

This PR simplifies the ID implementation by just using php's `uniqid()` on placement registration instead of the current complex ID generation on block editing.

Closes #363 

### How to test

Check out this branch, create multiple ad unit blocks on the same page and confirm they all render as expected.