### PR TITLE
feat: enable suppression for any viewable post type

### DIFF
--- a/includes/class-suppression.php
+++ b/includes/class-suppression.php
@@ -41,10 +41,12 @@ final class Suppression {
 	}
 
 	/**
-	 * Enqueue block editor ad suppression assets.
+	 * Enqueue block editor ad suppression assets for any post type considered
+	 * "viewable".
 	 */
 	public static function enqueue_block_editor_assets() {
-		if ( 'post' === get_current_screen()->post_type || 'page' === get_current_screen()->post_type ) {
+		$post_type = \get_current_screen()->post_type;
+		if ( ! empty( $post_type ) && \is_post_type_viewable( $post_type ) ) {
 			wp_enqueue_script( 'newspack-ads-suppress-ads', Core::plugin_url( 'dist/suppress-ads.js' ), [], NEWSPACK_ADS_VERSION, true );
 		}
 	}


### PR DESCRIPTION
Allow the Newspack Ads Settings block editor panel to be displayed on any post type considered "[viewable](https://developer.wordpress.org/reference/functions/is_post_type_viewable/)".

### How to test

1. On the master branch, edit a public custom post type that uses the block editor (a Newspack listing, for example)
2. Observe the "Newspack Ads Settings" is not displayed
3. Check out this branch, refresh and observe the panel
4. Toggle the Ad Suppression **on** and save
5. Visit the page and confirm no ads are displayed
