### PR TITLE
fix(gam): common targeting array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.32.1-hotfix.1](https://github.com/Automattic/newspack-ads/compare/v1.32.0...v1.32.1-hotfix.1) (2022-05-03)
+
+
+### Bug Fixes
+
+* **gam:** common targeting array ([56d028e](https://github.com/Automattic/newspack-ads/commit/56d028eab2a11792bd403dd35626604844a95991))
+
 # [1.32.0](https://github.com/Automattic/newspack-ads/compare/v1.31.0...v1.32.0) (2022-05-03)
 
 

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -176,7 +176,7 @@ final class GAM_Scripts {
 				var ad_config        = <?php echo wp_json_encode( $ad_config ); ?>;
 				var all_ad_units     = <?php echo wp_json_encode( $prepared_unit_data ); ?>;
 				var lazy_load        = <?php echo wp_json_encode( Settings::get_settings( 'lazy_load', true ), JSON_FORCE_OBJECT ); ?>;
-				var common_targeting = <?php echo wp_json_encode( $common_targeting, JSON_FORCE_OBJECT ); ?>;
+				var common_targeting = <?php echo wp_json_encode( $common_targeting ); ?>;
 				var defined_ad_units = {};
 
 				var boundsContainers = {};

--- a/newspack-ads.php
+++ b/newspack-ads.php
@@ -5,7 +5,7 @@
  * Description:     Ad services integration.
  * Author:          Automattic
  * License:         GPL2
- * Version:         1.32.0
+ * Version:         1.32.1-hotfix.1
  *
  * @package         Newspack
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack-ads",
-  "version": "1.32.0",
+  "version": "1.32.1-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack-ads",
-      "version": "1.32.0",
+      "version": "1.32.1-hotfix.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack-ads",
-  "version": "1.32.0",
+  "version": "1.32.1-hotfix.1",
   "author": "Automattic",
   "private": true,
   "scripts": {


### PR DESCRIPTION
The common targeting parameters are encoded to JSON using the `JSON_FORCE_OBJECT` flag. This was initially applied so that an empty result would still encode to `{}`. The unintended result is that it is forcing objects to every nested array, creating `{ "0": "value" }` instead of the expected `[ "value" ]`.

There's no need to ensure that an empty result renders a `{}`, just removing the flag suffices.

### How to test

1. With the latest release, apply 2 categories to a single post. Visit the page with the extra `?googfc` parameter
2. Inspect the rendered ads and confirm the targeted category is `[object Object]`
3. Check out this branch, refresh the page and confirm the categories are listed correctly
