### PR TITLE
feat(gam): targeting for tags and authors

### DIFF
--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -816,6 +816,27 @@ final class GAM_Model {
 				$targeting['category'] = array_map( 'sanitize_text_field', $categories );
 			}
 
+			// Add tags slugs to targeting.
+			$tags = wp_get_post_tags( get_the_ID(), [ 'fields' => 'slugs' ] );
+			if ( ! empty( $tags ) ) {
+				$targeting['tag'] = array_map( 'sanitize_text_field', $tags );
+			}
+
+			// Add the post authors to targeting.
+			if ( function_exists( 'get_coauthors' ) ) {
+				$authors = array_map(
+					function( $user ) {
+						return $user->user_login;
+					},
+					get_coauthors() 
+				);
+			} else {
+				$authors = [ get_the_author_meta( 'user_login' ) ];
+			}
+			if ( ! empty( $authors ) ) {
+				$targeting['author'] = array_map( 'sanitize_text_field', $authors );
+			}
+					
 			// Add post type to targeting.
 			$targeting['post_type'] = get_post_type();
 

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -176,7 +176,7 @@ final class GAM_Scripts {
 				var ad_config        = <?php echo wp_json_encode( $ad_config ); ?>;
 				var all_ad_units     = <?php echo wp_json_encode( $prepared_unit_data ); ?>;
 				var lazy_load        = <?php echo wp_json_encode( Settings::get_settings( 'lazy_load', true ), JSON_FORCE_OBJECT ); ?>;
-				var common_targeting = <?php echo wp_json_encode( $common_targeting, JSON_FORCE_OBJECT ); ?>;
+				var common_targeting = <?php echo wp_json_encode( $common_targeting ); ?>;
 				var defined_ad_units = {};
 
 				var boundsContainers = {};


### PR DESCRIPTION
Add targeting support for tags and authors over GAM.

Closes #395 

### How to test this PR

1. Check out this branch and visit a post with multiple tags using the `?googfc` parameter
2. Make sure you have Co-Author Plus **disabled**, Inspect the targeting options, and observe the author and tags targeted
3. Enable Co-Author Plus, add a co-author to the post and confirm using the inspector that the authors' slugs are targeted