### PR TITLE
fix(customizer): enqueue lodash dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.32.2-hotfix.1](https://github.com/Automattic/newspack-ads/compare/v1.32.1...v1.32.2-hotfix.1) (2022-05-04)
+
+
+### Bug Fixes
+
+* **customizer:** enqueue lodash dependency ([54b735f](https://github.com/Automattic/newspack-ads/commit/54b735f98290b411edc92a3e081ed56b9052e6ff))
+
 ## [1.32.1](https://github.com/Automattic/newspack-ads/compare/v1.32.0...v1.32.1) (2022-05-04)
 
 

--- a/includes/customizer/class-customizer.php
+++ b/includes/customizer/class-customizer.php
@@ -53,7 +53,7 @@ final class Customizer {
 		\wp_enqueue_script(
 			'newspack-ads-customizer-control',
 			\plugins_url( '../../dist/customizer-control.js', __FILE__ ),
-			[ 'customize-controls', 'jquery' ],
+			[ 'customize-controls', 'jquery', 'lodash' ],
 			filemtime( dirname( NEWSPACK_ADS_PLUGIN_FILE ) . '/dist/customizer-control.js' ),
 			true
 		);

--- a/newspack-ads.php
+++ b/newspack-ads.php
@@ -5,7 +5,7 @@
  * Description:     Ad services integration.
  * Author:          Automattic
  * License:         GPL2
- * Version:         1.32.1
+ * Version:         1.32.2-hotfix.1
  *
  * @package         Newspack
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack-ads",
-  "version": "1.32.1",
+  "version": "1.32.2-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack-ads",
-      "version": "1.32.1",
+      "version": "1.32.2-hotfix.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack-ads",
-  "version": "1.32.1",
+  "version": "1.32.2-hotfix.1",
   "author": "Automattic",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Lodash is not compiled to the final script so it must be enqueued as a dependency of the `customizer-control.js` script.

### How to test

Since the introduction of the block-based widget editor, lodash is enqueued by default to the customizer. To test this PR you must disable it by installing the [Classic Widgets](https://wordpress.org/plugins/classic-widgets/) plugin.

On the release branch, visit the customizer and confirm the `undefined` lodash error. Check out this branch, refresh and confirm the error is gone and you are able to edit and save Ad Placements.