### PR TITLE
feat: constant to opt-out of AMP Plus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.33.0-hotfix.1](https://github.com/Automattic/newspack-ads/compare/v1.32.2...v1.33.0-hotfix.1) (2022-05-05)
+
+
+### Features
+
+* constant to opt-out of AMP Plus ([162d42c](https://github.com/Automattic/newspack-ads/commit/162d42c16956f20c9e1f214f34bb0754ae4dff94))
+
 ## [1.32.2](https://github.com/Automattic/newspack-ads/compare/v1.32.1...v1.32.2) (2022-05-04)
 
 

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -119,10 +119,7 @@ final class Core {
 	 * @return bool AMP or not
 	 */
 	public static function is_amp() {
-		if (
-			! ( defined( 'NEWSPACK_AMP_PLUS_ADS_DISABLED' ) && true === NEWSPACK_AMP_PLUS_ADS_DISABLED ) && // Ensure AMP Plus for Ads is not opted-out.
-			method_exists( '\Newspack\AMP_Enhancements', 'should_use_amp_plus' ) && \Newspack\AMP_Enhancements::should_use_amp_plus()
-		) {
+		if ( self::is_amp_plus_configured() ) {
 			return false;
 		}
 		if ( function_exists( 'is_amp_endpoint' ) && \is_amp_endpoint() ) {

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -119,7 +119,10 @@ final class Core {
 	 * @return bool AMP or not
 	 */
 	public static function is_amp() {
-		if ( class_exists( '\Newspack\AMP_Enhancements' ) && method_exists( '\Newspack\AMP_Enhancements', 'should_use_amp_plus' ) && \Newspack\AMP_Enhancements::should_use_amp_plus() ) {
+		if (
+			! ( defined( 'NEWSPACK_AMP_PLUS_ADS_DISABLED' ) && true === NEWSPACK_AMP_PLUS_ADS_DISABLED ) && // Ensure AMP Plus for Ads is not opted-out.
+			method_exists( '\Newspack\AMP_Enhancements', 'should_use_amp_plus' ) && \Newspack\AMP_Enhancements::should_use_amp_plus()
+		) {
 			return false;
 		}
 		if ( function_exists( 'is_amp_endpoint' ) && \is_amp_endpoint() ) {
@@ -133,7 +136,10 @@ final class Core {
 	 * @return bool Configured or not.
 	 */
 	public static function is_amp_plus_configured() {
-		return class_exists( '\Newspack\AMP_Enhancements' ) && method_exists( '\Newspack\AMP_Enhancements', 'is_amp_plus_configured' ) && \Newspack\AMP_Enhancements::is_amp_plus_configured();
+		return (
+			! ( defined( 'NEWSPACK_AMP_PLUS_ADS_DISABLED' ) && true === NEWSPACK_AMP_PLUS_ADS_DISABLED ) && // Ensure AMP Plus for Ads is not opted-out.
+			method_exists( '\Newspack\AMP_Enhancements', 'is_amp_plus_configured' ) && \Newspack\AMP_Enhancements::is_amp_plus_configured()
+		);
 	}
 }
 Core::instance();

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -135,7 +135,7 @@ final class Core {
 	public static function is_amp_plus_configured() {
 		return (
 			! ( defined( 'NEWSPACK_AMP_PLUS_ADS_DISABLED' ) && true === NEWSPACK_AMP_PLUS_ADS_DISABLED ) && // Ensure AMP Plus for Ads is not opted-out.
-			method_exists( '\Newspack\AMP_Enhancements', 'is_amp_plus_configured' ) && \Newspack\AMP_Enhancements::is_amp_plus_configured()
+			method_exists( '\Newspack\AMP_Enhancements', 'should_use_amp_plus' ) && \Newspack\AMP_Enhancements::should_use_amp_plus()
 		);
 	}
 }

--- a/newspack-ads.php
+++ b/newspack-ads.php
@@ -5,7 +5,7 @@
  * Description:     Ad services integration.
  * Author:          Automattic
  * License:         GPL2
- * Version:         1.32.2
+ * Version:         1.33.0-hotfix.1
  *
  * @package         Newspack
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack-ads",
-  "version": "1.32.2",
+  "version": "1.33.0-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack-ads",
-      "version": "1.32.2",
+      "version": "1.33.0-hotfix.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack-ads",
-  "version": "1.32.2",
+  "version": "1.33.0-hotfix.1",
   "author": "Automattic",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Implements the `NEWSPACK_AMP_PLUS_ADS_DISABLED` flag to opt-out of AMP Plus.

Allows for AMP Plus features to be used on the Newspack ecosystem without necessarily activating it for Ads.

It also simplifies the method to remove `class_exists()` for `\Newspack\AMP_Enhancements`. The `method_exists()` function already performs the necessary checks to avoid missing class errors.

ef1441952228f763e9efe40839db62cda2514755 removes an unnecessary duplicate logic

### How to test

1. Check out this branch with AMP installed and the AMP Plus flag (`NEWSPACK_AMP_PLUS_ENABLED`) confirm you are still able to see Ads rendered through GPT (inspect the Ad element and confirm it is not a `<amp-ad />` element)
2. Add `define( 'NEWSPACK_AMP_PLUS_ADS_DISABLED', true );` to your `wp-config.php` and refresh the page
3. Confirm the Ads are now using the `<amp-ad />` tag and the GPT script is not rendered (inspect elements and search for `googletag.cmd`, it should not find results)