### PR TITLE
feat(gam): block column as a bounds container

### DIFF
--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -99,6 +99,7 @@ final class GAM_Scripts {
 			$bounds_selectors = apply_filters(
 				'newspack_ads_gam_bounds_selectors',
 				[
+					'.wp-block-column',
 					'.entry-content',
 					'.sidebar',
 					'.widget-area',
@@ -252,6 +253,7 @@ final class GAM_Scripts {
 							}
 						}
 					}
+					console.log( boundsWidth );
 					<?php
 					/**
 					 * Iterate and apply size map skipping viewports larger than the

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -253,7 +253,6 @@ final class GAM_Scripts {
 							}
 						}
 					}
-					console.log( boundsWidth );
 					<?php
 					/**
 					 * Iterate and apply size map skipping viewports larger than the


### PR DESCRIPTION
#375 introduced "bounds containers", which restricts the sizes for GPT ads inside `.entry-content` and `.widget-area`.

The elements that contain an ad unit can be expanded to also include `.wp-block-column`, which is the common class for a column inside the Columns block.

| Master | This branch |
| --- | --- |
| <img width="1304" alt="image" src="https://user-images.githubusercontent.com/820752/167480577-e4158c76-77a9-4ce1-bc30-c360da3ffb2b.png"> | <img width="1252" alt="image" src="https://user-images.githubusercontent.com/820752/167480664-98088e53-c861-4e01-a239-d1b7619c6e5a.png"> |

Closes #400

### How to test

1. In the master branch, add an ad unit with `300x250` and `728x90` sizes to a block column with a maximum width of 600.
2. Visit the page and confirm the 728x90 creative is rendered on the page
3. Check out this branch, refresh the page and confirm only the 300x250 creative is rendered.