### PR TITLE
feat(gam): default ad units

### DIFF
--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -281,7 +281,7 @@ final class GAM_Model {
 		if ( ! $synced ) {
 			self::$ad_units = $ad_units;
 		}
-		return self::$ad_units;
+		return $ad_units;
 	}
 
 	/**

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -147,7 +147,7 @@ final class GAM_Model {
 	 */
 	public static function get_default_ad_units() {
 		$ad_units = [
-			[
+			'newspack_below_header'  => [
 				'name'  => \esc_html__( 'Newspack Below Header', 'newspack' ),
 				'sizes' => [
 					[ 320, 50 ],
@@ -157,42 +157,42 @@ final class GAM_Model {
 					[ 970, 250 ],
 				],
 			],
-			[
+			'newspack_sticky_footer' => [
 				'name'  => \esc_html__( 'Newspack Sticky Footer', 'newspack' ),
 				'sizes' => [
 					[ 320, 50 ],
 					[ 320, 100 ],
 				],
 			],
-			[
+			'newspack_sidebar_1'     => [
 				'name'  => \esc_html__( 'Newspack Sidebar 1', 'newspack' ),
 				'sizes' => [
 					[ 300, 250 ],
 					[ 300, 600 ],
 				],
 			],
-			[
+			'newspack_sidebar_2'     => [
 				'name'  => \esc_html__( 'Newspack Sidebar 2', 'newspack' ),
 				'sizes' => [
 					[ 300, 250 ],
 					[ 300, 600 ],
 				],
 			],
-			[
+			'newspack_in_article_1'  => [
 				'name'  => \esc_html__( 'Newspack In-Article 1', 'newspack' ),
 				'sizes' => [
 					[ 728, 90 ],
 					[ 300, 250 ],
 				],
 			],
-			[
+			'newspack_in_article_2'  => [
 				'name'  => \esc_html__( 'Newspack In-Article 2', 'newspack' ),
 				'sizes' => [
 					[ 728, 90 ],
 					[ 300, 250 ],
 				],
 			],
-			[
+			'newspack_in_article_3'  => [
 				'name'  => \esc_html__( 'Newspack In-Article 3', 'newspack' ),
 				'sizes' => [
 					[ 728, 90 ],
@@ -207,16 +207,16 @@ final class GAM_Model {
 		 */
 		$ad_units = apply_filters( 'newspack_ads_default_ad_units', $ad_units );
 		return array_map(
-			function( $ad_unit ) {
-				$sanitized_title       = str_replace( '-', '_', \sanitize_title( $ad_unit['name'] ) );
-				$ad_unit['id']         = $sanitized_title;
-				$ad_unit['code']       = $sanitized_title;
+			function( $id, $ad_unit ) {
+				$ad_unit['id']         = $id;
+				$ad_unit['code']       = $id;
 				$ad_unit['fluid']      = false;
 				$ad_unit['status']     = 'ACTIVE';
 				$ad_unit['is_default'] = true;
 				return $ad_unit;
 			},
-			$ad_units 
+			array_keys( $ad_units ),
+			array_values( $ad_units )
 		);
 	}
 

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -208,12 +208,12 @@ final class GAM_Model {
 		$ad_units = apply_filters( 'newspack_ads_default_ad_units', $ad_units );
 		return array_map(
 			function( $ad_unit ) {
-				$sanitized_title      = \sanitize_title( $ad_unit['name'] );
-				$ad_unit['id']        = $sanitized_title;
-				$ad_unit['code']      = $sanitized_title;
-				$ad_unit['fluid']     = false;
-				$ad_unit['status']    = 'ACTIVE';
-				$ad_unit['is_legacy'] = true;
+				$sanitized_title       = str_replace( '-', '_', \sanitize_title( $ad_unit['name'] ) );
+				$ad_unit['id']         = $sanitized_title;
+				$ad_unit['code']       = $sanitized_title;
+				$ad_unit['fluid']      = false;
+				$ad_unit['status']     = 'ACTIVE';
+				$ad_unit['is_default'] = true;
 				return $ad_unit;
 			},
 			$ad_units 

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -613,7 +613,7 @@ final class GAM_Model {
 		$attrs      = [];
 		$multisizes = [];
 
-		if ( true === $ad_unit['fluid'] ) {
+		if ( isset( $ad_unit['fluid'] ) && true === $ad_unit['fluid'] ) {
 			$attrs['height'] = 'fluid';
 			$attrs['layout'] = 'fluid';
 			$multisizes[]    = 'fluid';

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -277,8 +277,10 @@ final class GAM_Model {
 		} else {
 			$ad_units = array_merge( $ad_units, self::get_synced_gam_ad_units() );
 		}
-		$ad_units       = array_merge( $ad_units, self::get_default_ad_units() );
-		self::$ad_units = $ad_units;
+		$ad_units = array_merge( $ad_units, self::get_default_ad_units() );
+		if ( ! $synced ) {
+			self::$ad_units = $ad_units;
+		}
 		return self::$ad_units;
 	}
 

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -258,7 +258,7 @@ final class GAM_Model {
 	 * @return array Array of ad units.
 	 */
 	public static function get_ad_units( $synced = false ) {
-		if ( null !== self::$ad_units ) {
+		if ( null !== self::$ad_units && ! $synced ) {
 			return self::$ad_units;
 		}
 		$ad_units = self::get_legacy_ad_units();

--- a/tests/test-model.php
+++ b/tests/test-model.php
@@ -137,7 +137,7 @@ class ModelTest extends WP_UnitTestCase {
 		self::assertEquals(
 			count( $result ),
 			count( $default_ad_units ) + 1,
-			'The defalt ad units and the single legacy ad unit are returned, as there is no GAM connection.'
+			'The default ad units and the single legacy ad unit are returned, as there is no GAM connection.'
 		);
 		self::assertTrue(
 			$result[0]['is_legacy'],

--- a/tests/test-model.php
+++ b/tests/test-model.php
@@ -132,11 +132,12 @@ class ModelTest extends WP_UnitTestCase {
 	 * Ad units getter.
 	 */
 	public function test_ad_units_getter() {
-		$result = GAM_Model::get_ad_units();
+		$default_ad_units = GAM_Model::get_default_ad_units();
+		$result           = GAM_Model::get_ad_units();
 		self::assertEquals(
 			count( $result ),
-			1,
-			'Only the single legacy ad unit is returned, as there is no GAM connection.'
+			count( $default_ad_units ) + 1,
+			'The defalt ad units and the single legacy ad unit are returned, as there is no GAM connection.'
 		);
 		self::assertTrue(
 			$result[0]['is_legacy'],


### PR DESCRIPTION
Implements permanent default ad units. #410 proposes that the default ad units can be edited and saved to be part of the publisher's inventory. This can overcomplicate how we manage the ad units, this PR proposes the default ad units are permanent and not editable.

<img width="1068" alt="image" src="https://user-images.githubusercontent.com/820752/169094401-53e043ff-ce40-4079-b8b1-64f4244a7b96.png">

<img width="766" alt="image" src="https://user-images.githubusercontent.com/820752/167493067-5b48b306-e909-4396-ab85-305cb4dc603e.png">

Closes #410 

### How to test this PR

1. Check out this branch and https://github.com/Automattic/newspack-plugin/pull/1654
2. With a fresh install, use legacy mode by just entering a GAM network code
3. Visit the GAM wizard and observe the uneditable default ad units
4. Visit the placements wizard, select edit a placement and confirm you are able to select and save a default ad unit
5. Edit a page, add an ad unit block and confirm you are able to select and save a default ad unit
6. Confirm the slot is configured on the front-end for both AMP and AMP Plus:
    1. For AMP, inspect the element and observe the default ad unit code and sizes being configured
    2. For AMP Plus, visit the front-end with the `?googfc` URL parameter and inspect the GPT configuration with the overlayed tool

