### PR TITLE
feat: activation hook defaults

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -48,7 +48,7 @@ final class Core {
 	/**
 	 * Activation Hook
 	 */
-	public function activation_hook() {
+	public static function activation_hook() {
 		do_action( 'newspack_ads_activation_hook' );
 	}
 

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -42,6 +42,14 @@ final class Core {
 		$this->includes();
 
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
+		register_activation_hook( NEWSPACK_ADS_PLUGIN_FILE, [ __CLASS__, 'activation_hook' ] );
+	}
+
+	/**
+	 * Activation Hook
+	 */
+	public function activation_hook() {
+		do_action( 'newspack_ads_activation_hook' );
 	}
 
 	/**

--- a/includes/class-placements.php
+++ b/includes/class-placements.php
@@ -383,28 +383,24 @@ final class Placements {
 	private static function register_default_placements() {
 		$placements = array(
 			'global_above_header' => array(
-				'name'            => __( 'Global: Above Header', 'newspack-ads' ),
-				'description'     => __( 'Choose an ad unit to display above the header.', 'newspack-ads' ),
-				'default_enabled' => true,
-				'hook_name'       => 'before_header',
+				'name'        => __( 'Global: Above Header', 'newspack-ads' ),
+				'description' => __( 'Choose an ad unit to display above the header.', 'newspack-ads' ),
+				'hook_name'   => 'before_header',
 			),
 			'global_below_header' => array(
-				'name'            => __( 'Global: Below Header', 'newspack-ads' ),
-				'description'     => __( 'Choose an ad unit to display below the header.', 'newspack-ads' ),
-				'default_enabled' => true,
-				'hook_name'       => 'after_header',
+				'name'        => __( 'Global: Below Header', 'newspack-ads' ),
+				'description' => __( 'Choose an ad unit to display below the header.', 'newspack-ads' ),
+				'hook_name'   => 'after_header',
 			),
 			'global_above_footer' => array(
-				'name'            => __( 'Global: Above Footer', 'newspack-ads' ),
-				'description'     => __( 'Choose an ad unit to display above the footer.', 'newspack-ads' ),
-				'default_enabled' => true,
-				'hook_name'       => 'before_footer',
+				'name'        => __( 'Global: Above Footer', 'newspack-ads' ),
+				'description' => __( 'Choose an ad unit to display above the footer.', 'newspack-ads' ),
+				'hook_name'   => 'before_footer',
 			),
 			'sticky'              => array(
-				'name'            => __( 'Mobile Sticky Footer', 'newspack-ads' ),
-				'description'     => __( 'Choose a sticky ad unit to display at the bottom of the viewport on mobile devices (recommended sizes are 320x50, 300x50)', 'newspack-ads' ),
-				'default_enabled' => true,
-				'hook_name'       => 'before_footer',
+				'name'        => __( 'Mobile Sticky Footer', 'newspack-ads' ),
+				'description' => __( 'Choose a sticky ad unit to display at the bottom of the viewport on mobile devices (recommended sizes are 320x50, 300x50)', 'newspack-ads' ),
+				'hook_name'   => 'before_footer',
 			),
 		);
 		foreach ( $placements as $placement_key => $placement_config ) {
@@ -500,7 +496,10 @@ final class Placements {
 	 */
 	private static function is_stick_to_top( $placement_key ) {
 		$placements = self::get_placements();
-		$placement  = $placements[ $placement_key ];
+		if ( ! isset( $placements[ $placement_key ] ) ) {
+			return false;
+		}
+		$placement = $placements[ $placement_key ];
 		if ( in_array( 'stick_to_top', $placement['supports'], true ) ) {
 			return true;
 		}
@@ -522,11 +521,6 @@ final class Placements {
 	 * @return bool Whether the placement has been updated or not.
 	 */
 	public static function update_placement( $placement_key, $data ) {
-		$placements = self::get_placements();
-		if ( ! isset( $placements[ $placement_key ] ) ) {
-			return new \WP_Error( 'newspack_ads_invalid_placement', __( 'This placement does not exist.', 'newspack-ads' ) );
-		}
-
 		// Updates always enables the placement.
 		$data['enabled'] = true;
 

--- a/includes/integrations/class-scaip.php
+++ b/includes/integrations/class-scaip.php
@@ -46,6 +46,9 @@ final class SCAIP {
 		add_action( 'init', array( __CLASS__, 'register_placements' ) );
 		add_action( 'scaip_shortcode', [ __CLASS__, 'create_placement_action' ] );
 
+		// Setup Newspack Ads defaults on activation.
+		add_action( 'newspack_ads_activation_hook', array( __CLASS__, 'register_defaults' ) );
+
 		// Deprecate sidebar.
 		if ( ! self::is_legacy_widgets() ) {
 			remove_action( 'scaip_shortcode', 'scaip_shortcode_do_sidebar' );
@@ -144,6 +147,25 @@ final class SCAIP {
 	 */
 	public static function create_placement_action( $atts ) {
 		do_action( sprintf( self::HOOK_NAME, $atts['number'] ), $atts );
+	}
+
+	/**
+	 * Setup Newspack Ads defaults on activation.
+	 */
+	public static function register_defaults() {
+		$defaults = [
+			'repetitions'    => 3,
+			'legacy_widgets' => 0,
+		];
+		foreach ( $defaults as $key => $value ) {
+			$option_name = sprintf( '%s%s_%s', Settings::OPTION_NAME_PREFIX, 'scaip', $key );
+			if ( ! isset( self::OPTIONS_MAP[ $key ] ) ) {
+				$option_name = self::OPTIONS_MAP[ $key ];
+			}
+			if ( false === get_option( $option_name ) ) {
+				update_option( $option_name, $value );
+			}
+		}
 	}
 
 	/**

--- a/includes/integrations/class-scaip.php
+++ b/includes/integrations/class-scaip.php
@@ -159,7 +159,7 @@ final class SCAIP {
 		];
 		foreach ( $defaults as $key => $value ) {
 			$option_name = sprintf( '%s%s_%s', Settings::OPTION_NAME_PREFIX, 'scaip', $key );
-			if ( ! isset( self::OPTIONS_MAP[ $key ] ) ) {
+			if ( isset( self::OPTIONS_MAP[ $key ] ) ) {
 				$option_name = self::OPTIONS_MAP[ $key ];
 			}
 			if ( false === get_option( $option_name ) ) {

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -281,7 +281,7 @@ final class GAM_Model {
 		if ( ! $synced ) {
 			self::$ad_units = $ad_units;
 		}
-		return self::$ad_units;
+		return $ad_units;
 	}
 
 	/**

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -147,7 +147,7 @@ final class GAM_Model {
 	 */
 	public static function get_default_ad_units() {
 		$ad_units = [
-			[
+			'newspack_below_header'  => [
 				'name'  => \esc_html__( 'Newspack Below Header', 'newspack' ),
 				'sizes' => [
 					[ 320, 50 ],
@@ -157,42 +157,42 @@ final class GAM_Model {
 					[ 970, 250 ],
 				],
 			],
-			[
+			'newspack_sticky_footer' => [
 				'name'  => \esc_html__( 'Newspack Sticky Footer', 'newspack' ),
 				'sizes' => [
 					[ 320, 50 ],
 					[ 320, 100 ],
 				],
 			],
-			[
+			'newspack_sidebar_1'     => [
 				'name'  => \esc_html__( 'Newspack Sidebar 1', 'newspack' ),
 				'sizes' => [
 					[ 300, 250 ],
 					[ 300, 600 ],
 				],
 			],
-			[
+			'newspack_sidebar_2'     => [
 				'name'  => \esc_html__( 'Newspack Sidebar 2', 'newspack' ),
 				'sizes' => [
 					[ 300, 250 ],
 					[ 300, 600 ],
 				],
 			],
-			[
+			'newspack_in_article_1'  => [
 				'name'  => \esc_html__( 'Newspack In-Article 1', 'newspack' ),
 				'sizes' => [
 					[ 728, 90 ],
 					[ 300, 250 ],
 				],
 			],
-			[
+			'newspack_in_article_2'  => [
 				'name'  => \esc_html__( 'Newspack In-Article 2', 'newspack' ),
 				'sizes' => [
 					[ 728, 90 ],
 					[ 300, 250 ],
 				],
 			],
-			[
+			'newspack_in_article_3'  => [
 				'name'  => \esc_html__( 'Newspack In-Article 3', 'newspack' ),
 				'sizes' => [
 					[ 728, 90 ],
@@ -207,16 +207,16 @@ final class GAM_Model {
 		 */
 		$ad_units = apply_filters( 'newspack_ads_default_ad_units', $ad_units );
 		return array_map(
-			function( $ad_unit ) {
-				$sanitized_title       = str_replace( '-', '_', \sanitize_title( $ad_unit['name'] ) );
-				$ad_unit['id']         = $sanitized_title;
-				$ad_unit['code']       = $sanitized_title;
+			function( $id, $ad_unit ) {
+				$ad_unit['id']         = $id;
+				$ad_unit['code']       = $id;
 				$ad_unit['fluid']      = false;
 				$ad_unit['status']     = 'ACTIVE';
 				$ad_unit['is_default'] = true;
 				return $ad_unit;
 			},
-			$ad_units 
+			array_keys( $ad_units ),
+			array_values( $ad_units )
 		);
 	}
 

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -208,12 +208,12 @@ final class GAM_Model {
 		$ad_units = apply_filters( 'newspack_ads_default_ad_units', $ad_units );
 		return array_map(
 			function( $ad_unit ) {
-				$sanitized_title      = \sanitize_title( $ad_unit['name'] );
-				$ad_unit['id']        = $sanitized_title;
-				$ad_unit['code']      = $sanitized_title;
-				$ad_unit['fluid']     = false;
-				$ad_unit['status']    = 'ACTIVE';
-				$ad_unit['is_legacy'] = true;
+				$sanitized_title       = str_replace( '-', '_', \sanitize_title( $ad_unit['name'] ) );
+				$ad_unit['id']         = $sanitized_title;
+				$ad_unit['code']       = $sanitized_title;
+				$ad_unit['fluid']      = false;
+				$ad_unit['status']     = 'ACTIVE';
+				$ad_unit['is_default'] = true;
 				return $ad_unit;
 			},
 			$ad_units 

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -613,7 +613,7 @@ final class GAM_Model {
 		$attrs      = [];
 		$multisizes = [];
 
-		if ( true === $ad_unit['fluid'] ) {
+		if ( isset( $ad_unit['fluid'] ) && true === $ad_unit['fluid'] ) {
 			$attrs['height'] = 'fluid';
 			$attrs['layout'] = 'fluid';
 			$multisizes[]    = 'fluid';

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -277,8 +277,10 @@ final class GAM_Model {
 		} else {
 			$ad_units = array_merge( $ad_units, self::get_synced_gam_ad_units() );
 		}
-		$ad_units       = array_merge( $ad_units, self::get_default_ad_units() );
-		self::$ad_units = $ad_units;
+		$ad_units = array_merge( $ad_units, self::get_default_ad_units() );
+		if ( ! $synced ) {
+			self::$ad_units = $ad_units;
+		}
 		return self::$ad_units;
 	}
 

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -258,7 +258,7 @@ final class GAM_Model {
 	 * @return array Array of ad units.
 	 */
 	public static function get_ad_units( $synced = false ) {
-		if ( null !== self::$ad_units ) {
+		if ( null !== self::$ad_units && ! $synced ) {
 			return self::$ad_units;
 		}
 		$ad_units = self::get_legacy_ad_units();

--- a/tests/test-model.php
+++ b/tests/test-model.php
@@ -137,7 +137,7 @@ class ModelTest extends WP_UnitTestCase {
 		self::assertEquals(
 			count( $result ),
 			count( $default_ad_units ) + 1,
-			'The defalt ad units and the single legacy ad unit are returned, as there is no GAM connection.'
+			'The default ad units and the single legacy ad unit are returned, as there is no GAM connection.'
 		);
 		self::assertTrue(
 			$result[0]['is_legacy'],

--- a/tests/test-model.php
+++ b/tests/test-model.php
@@ -132,11 +132,12 @@ class ModelTest extends WP_UnitTestCase {
 	 * Ad units getter.
 	 */
 	public function test_ad_units_getter() {
-		$result = GAM_Model::get_ad_units();
+		$default_ad_units = GAM_Model::get_default_ad_units();
+		$result           = GAM_Model::get_ad_units();
 		self::assertEquals(
 			count( $result ),
-			1,
-			'Only the single legacy ad unit is returned, as there is no GAM connection.'
+			count( $default_ad_units ) + 1,
+			'The defalt ad units and the single legacy ad unit are returned, as there is no GAM connection.'
 		);
 		self::assertTrue(
 			$result[0]['is_legacy'],


### PR DESCRIPTION
Implements the following activation defaults, if the settings are not yet found on the database:

 - Default ad units assigned to their respective placements
 - SCAIP with the legacy option turned off (legacy should still be the default option for users that were already using Ads with SCAIP)
 - SCAIP number of repetitions set to 3 in order to use use all 3 in-article default ad units

Closes #411

### How to test

1. On a fresh install, check out this branch
2. Go through the onboarding wizard and activate the Ads plugin
3. Enable GAM and enter a legacy network code
4. Visit the Placements wizard and confirm the active placements have a default unit assigned to them
5. Visit the Add-Ons wizard and enable SCAIP
6. Visit the Settings wizard and confirm legacy mode is off and the number of repetitions is set to 3
7. VIsit the Placements again, edit the SCAIP placements and confirm the default units are assigned to them