### PR TITLE
fix(gam): refactor ad units getter sync strategy

### DIFF
--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -317,7 +317,7 @@ final class GAM_Model {
 		}
 		$ad_units = array_merge(
 			$ad_units,
-			self::get_synced_gam_ad_units(),
+			self::get_synced_ad_units(),
 			self::get_default_ad_units()
 		);
 		return $ad_units;
@@ -549,7 +549,7 @@ final class GAM_Model {
 	 *
 	 * @return array[] GAM items.
 	 */
-	private static function get_synced_gam_ad_units() {
+	public static function get_synced_ad_units() {
 		$gam_items = self::get_synced_gam_items();
 		if ( $gam_items ) {
 			return $gam_items['ad_units'];

--- a/tests/test-model.php
+++ b/tests/test-model.php
@@ -133,9 +133,10 @@ class ModelTest extends WP_UnitTestCase {
 	 */
 	public function test_ad_units_getter() {
 		$default_ad_units = GAM_Model::get_default_ad_units();
+		$synced_ad_units  = GAM_Model::get_synced_gam_ad_units();
 		$result           = GAM_Model::get_ad_units();
 		self::assertEquals(
-			3,
+			count( $default_ad_units ) + count( $synced_ad_units ) + 1,
 			count( $result ),
 			'All units are returned, because we want the synced units even without GAM connection.'
 		);

--- a/tests/test-model.php
+++ b/tests/test-model.php
@@ -133,7 +133,7 @@ class ModelTest extends WP_UnitTestCase {
 	 */
 	public function test_ad_units_getter() {
 		$default_ad_units = GAM_Model::get_default_ad_units();
-		$synced_ad_units  = GAM_Model::get_synced_gam_ad_units();
+		$synced_ad_units  = GAM_Model::get_synced_ad_units();
 		$result           = GAM_Model::get_ad_units();
 		self::assertEquals(
 			count( $default_ad_units ) + count( $synced_ad_units ) + 1,


### PR DESCRIPTION
The optimistic release merge from 8f5afd3b8b354e6dc7bba1bac2ec91631ac2032e replaced code from the still unreleased #406

This PR fixes those conflicts and I also took the opportunity to refactor it a little bit for better readability.

### How to test

Repeat steps from #428 and confirm it behaves as expected.