### PR TITLE
fix(gam): prioritize service account and other tweaks

### DIFF
--- a/includes/integrations/class-bidding-gam.php
+++ b/includes/integrations/class-bidding-gam.php
@@ -344,7 +344,7 @@ final class Bidding_GAM {
 		);
 		\wp_register_style(
 			'newspack-ads-bidding-gam',
-			plugins_url( '../dist/header-bidding-gam.css', __FILE__ ),
+			plugins_url( '../../dist/header-bidding-gam.css', __FILE__ ),
 			null,
 			filemtime( dirname( NEWSPACK_ADS_PLUGIN_FILE ) . '/dist/header-bidding-gam.css' )
 		);

--- a/includes/providers/gam/class-gam-api.php
+++ b/includes/providers/gam/class-gam-api.php
@@ -275,10 +275,7 @@ final class GAM_API {
 	 * @return int GAM network code.
 	 */
 	private static function get_gam_network_code() {
-		if ( empty( self::$network_code ) ) {
-			self::get_gam_network();
-		}
-		return self::$network_code;
+		return self::get_gam_network()->getNetworkCode();
 	}
 
 	/**

--- a/includes/providers/gam/class-gam-api.php
+++ b/includes/providers/gam/class-gam-api.php
@@ -12,44 +12,44 @@ use Newspack_Ads\Providers\GAM_Model;
 use Google\Auth\Credentials\ServiceAccountCredentials;
 use Google\AdsApi\Common\Configuration;
 use Google\AdsApi\AdManager\AdManagerSessionBuilder;
-use Google\AdsApi\AdManager\Util\v202111\StatementBuilder;
+use Google\AdsApi\AdManager\Util\v202205\StatementBuilder;
 use Google\AdsApi\AdManager\AdManagerSession;
-use Google\AdsApi\AdManager\v202111\AdUnitTargeting;
-use Google\AdsApi\AdManager\v202111\LineItemCreativeAssociation;
-use Google\AdsApi\AdManager\v202111\Statement;
-use Google\AdsApi\AdManager\v202111\String_ValueMapEntry;
-use Google\AdsApi\AdManager\v202111\TextValue;
-use Google\AdsApi\AdManager\v202111\SetValue;
-use Google\AdsApi\AdManager\v202111\CustomTargetingKey;
-use Google\AdsApi\AdManager\v202111\CustomTargetingValue;
-use Google\AdsApi\AdManager\v202111\ServiceFactory;
-use Google\AdsApi\AdManager\v202111\ArchiveAdUnits as ArchiveAdUnitsAction;
-use Google\AdsApi\AdManager\v202111\ActivateAdUnits as ActivateAdUnitsAction;
-use Google\AdsApi\AdManager\v202111\DeactivateAdUnits as DeactivateAdUnitsAction;
-use Google\AdsApi\AdManager\v202111\Network;
-use Google\AdsApi\AdManager\v202111\User;
-use Google\AdsApi\AdManager\v202111\AdUnit;
-use Google\AdsApi\AdManager\v202111\AdUnitSize;
-use Google\AdsApi\AdManager\v202111\AdUnitTargetWindow;
-use Google\AdsApi\AdManager\v202111\Order;
-use Google\AdsApi\AdManager\v202111\ArchiveOrders;
-use Google\AdsApi\AdManager\v202111\UpdateResult;
-use Google\AdsApi\AdManager\v202111\Creative;
-use Google\AdsApi\AdManager\v202111\LineItem;
-use Google\AdsApi\AdManager\v202111\EnvironmentType;
-use Google\AdsApi\AdManager\v202111\Size;
-use Google\AdsApi\AdManager\v202111\Company;
-use Google\AdsApi\AdManager\v202111\CompanyType;
+use Google\AdsApi\AdManager\v202205\AdUnitTargeting;
+use Google\AdsApi\AdManager\v202205\LineItemCreativeAssociation;
+use Google\AdsApi\AdManager\v202205\Statement;
+use Google\AdsApi\AdManager\v202205\String_ValueMapEntry;
+use Google\AdsApi\AdManager\v202205\TextValue;
+use Google\AdsApi\AdManager\v202205\SetValue;
+use Google\AdsApi\AdManager\v202205\CustomTargetingKey;
+use Google\AdsApi\AdManager\v202205\CustomTargetingValue;
+use Google\AdsApi\AdManager\v202205\ServiceFactory;
+use Google\AdsApi\AdManager\v202205\ArchiveAdUnits as ArchiveAdUnitsAction;
+use Google\AdsApi\AdManager\v202205\ActivateAdUnits as ActivateAdUnitsAction;
+use Google\AdsApi\AdManager\v202205\DeactivateAdUnits as DeactivateAdUnitsAction;
+use Google\AdsApi\AdManager\v202205\Network;
+use Google\AdsApi\AdManager\v202205\User;
+use Google\AdsApi\AdManager\v202205\AdUnit;
+use Google\AdsApi\AdManager\v202205\AdUnitSize;
+use Google\AdsApi\AdManager\v202205\AdUnitTargetWindow;
+use Google\AdsApi\AdManager\v202205\Order;
+use Google\AdsApi\AdManager\v202205\ArchiveOrders;
+use Google\AdsApi\AdManager\v202205\UpdateResult;
+use Google\AdsApi\AdManager\v202205\Creative;
+use Google\AdsApi\AdManager\v202205\LineItem;
+use Google\AdsApi\AdManager\v202205\EnvironmentType;
+use Google\AdsApi\AdManager\v202205\Size;
+use Google\AdsApi\AdManager\v202205\Company;
+use Google\AdsApi\AdManager\v202205\CompanyType;
 
-use Google\AdsApi\AdManager\v202111\Goal;
-use Google\AdsApi\AdManager\v202111\CreativePlaceholder;
-use Google\AdsApi\AdManager\v202111\Money;
-use Google\AdsApi\AdManager\v202111\Targeting;
-use Google\AdsApi\AdManager\v202111\CustomCriteriaSet;
-use Google\AdsApi\AdManager\v202111\CustomCriteria;
-use Google\AdsApi\AdManager\v202111\InventoryTargeting;
+use Google\AdsApi\AdManager\v202205\Goal;
+use Google\AdsApi\AdManager\v202205\CreativePlaceholder;
+use Google\AdsApi\AdManager\v202205\Money;
+use Google\AdsApi\AdManager\v202205\Targeting;
+use Google\AdsApi\AdManager\v202205\CustomCriteriaSet;
+use Google\AdsApi\AdManager\v202205\CustomCriteria;
+use Google\AdsApi\AdManager\v202205\InventoryTargeting;
 
-use Google\AdsApi\AdManager\v202111\ApiException;
+use Google\AdsApi\AdManager\v202205\ApiException;
 
 require_once NEWSPACK_ADS_COMPOSER_ABSPATH . 'autoload.php';
 
@@ -62,7 +62,7 @@ final class GAM_API {
 
 	const SERVICE_ACCOUNT_CREDENTIALS_OPTION_NAME = '_newspack_ads_gam_credentials';
 
-	const GAM_API_VERSION = 'v202111';
+	const GAM_API_VERSION = 'v202205';
 
 	/**
 	 * Codes of networks that the user has access to.

--- a/includes/providers/gam/class-gam-api.php
+++ b/includes/providers/gam/class-gam-api.php
@@ -382,7 +382,7 @@ final class GAM_API {
 
 	/**
 	 * Get all GAM Advertisers in the user's network.
-	 * 
+	 *
 	 * @return Company[] Array of Companies of typer Advertiser.
 	 */
 	private static function get_advertisers() {
@@ -408,7 +408,7 @@ final class GAM_API {
 	 * Get all Advertisers in the user's network, serialised.
 	 *
 	 * @param Company[] $companies Optional array of companies to serialise. If empty, return all advertisers.
-	 * 
+	 *
 	 * @return array[] Array of serialised companies.
 	 */
 	public static function get_serialised_advertisers( $companies = null ) {
@@ -445,7 +445,7 @@ final class GAM_API {
 	 * Get all GAM orders in the user's network.
 	 *
 	 * @param StatementBuilder $statement_builder (optional) Statement builder.
-	 * 
+	 *
 	 * @return Order[] Array of Orders.
 	 */
 	private static function get_orders( StatementBuilder $statement_builder = null ) {
@@ -478,7 +478,7 @@ final class GAM_API {
 	 *
 	 * @return Order[] Array of Orders.
 	 */
-	public static function get_orders_by_id( $ids = [] ) { 
+	public static function get_orders_by_id( $ids = [] ) {
 		if ( ! is_array( $ids ) ) {
 			$ids = [ $ids ];
 		}
@@ -493,7 +493,7 @@ final class GAM_API {
 	 *
 	 * @return Order[] Array of Orders.
 	 */
-	public static function get_orders_by_advertiser( $advertiser_id ) { 
+	public static function get_orders_by_advertiser( $advertiser_id ) {
 		$statement_builder = ( new StatementBuilder() )->where( sprintf( 'advertiserId = %d', $advertiser_id ) );
 		return self::get_orders( $statement_builder );
 	}
@@ -554,7 +554,7 @@ final class GAM_API {
 	 *
 	 * @return Creative[] Array of creatives.
 	 */
-	private static function get_creatives_by_advertiser( $advertiser_id ) { 
+	private static function get_creatives_by_advertiser( $advertiser_id ) {
 		$statement_builder = ( new StatementBuilder() )->where( sprintf( 'advertiserId = %d', $advertiser_id ) );
 		return self::get_creatives( $statement_builder );
 	}
@@ -594,7 +594,7 @@ final class GAM_API {
 	 * Get all GAM Line Items in the user's network.
 	 *
 	 * @param StatementBuilder $statement_builder (optional) Statement builder.
-	 * 
+	 *
 	 * @return LineItem[] Array of Orders.
 	 */
 	private static function get_line_items( StatementBuilder $statement_builder = null ) {
@@ -937,7 +937,7 @@ final class GAM_API {
 					$criteria_set->setChildren( $children );
 					$targeting->setCustomTargeting( $criteria_set );
 				}
-				
+
 				// Apply configured targeting to line item.
 				$line_item->setTargeting( $targeting );
 			}
@@ -975,7 +975,7 @@ final class GAM_API {
 							return new Size( $size[0], $size[1] );
 						},
 						$lica_config['sizes']
-					) 
+					)
 				);
 			}
 			$licas[] = $lica;
@@ -1191,7 +1191,7 @@ final class GAM_API {
 				),
 			]
 		);
-		
+
 		$targeting_key = null;
 		$found_keys    = $service->getCustomTargetingKeysByStatement( $statement )->getResults();
 		if ( empty( $found_keys ) ) {
@@ -1343,13 +1343,6 @@ final class GAM_API {
 	}
 
 	/**
-	 * Can this instance use OAuth for authentication?
-	 */
-	private static function can_use_oauth() {
-		return class_exists( 'Newspack\Google_OAuth' ) && \Newspack\Google_OAuth::is_oauth_configured();
-	}
-
-	/**
 	 * Get saved Service Account credentials config.
 	 */
 	private static function service_account_credentials_config() {
@@ -1387,11 +1380,9 @@ final class GAM_API {
 	 */
 	public static function connection_status() {
 		$connection_details = self::get_connection_details();
-		$can_use_oauth      = self::can_use_oauth();
 		$response           = [
 			'connected'       => false,
 			'connection_mode' => $connection_details['mode'],
-			'can_use_oauth'   => $can_use_oauth,
 		];
 		if ( false === self::is_environment_compatible() ) {
 			$response['incompatible'] = true;

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -304,7 +304,6 @@ final class GAM_Model {
 	 * @return array Array of ad units.
 	 */
 	public static function get_ad_units( $sync = true ) {
-		$ad_units = self::get_legacy_ad_units();
 		if ( $sync && ! self::$synced ) {
 			// Only sync once per execution.
 			if ( self::is_gam_connected() ) {
@@ -316,7 +315,7 @@ final class GAM_Model {
 			}
 		}
 		$ad_units = array_merge(
-			$ad_units,
+			self::get_legacy_ad_units(),
 			self::get_synced_ad_units(),
 			self::get_default_ad_units()
 		);


### PR DESCRIPTION
An available service account credential should be prioritized because it can be considered as a more stable connection than an OAuth token with an expiration date. This PR implements this change and removes the `can_use_service_account()` check because a service account connection method should always be available for a disconnected client.

The Google Ads SDK was also updated to the latest version.

### How to test this PR

1. Check out this branch and https://github.com/Automattic/newspack-plugin/pull/1694
2. Make sure your instance can use OAuth and connect with Google OAuth
3. Visit the GAM ad units wizard and confirm you see the synced ad units and the Service Account connection method at the bottom is **not** available
4. At the "Connections" page, disconnect from Google
5. Visit the wizard again and confirm you are able to use a Service Account connection
6. Upload a Service Account credential and confirm you are connected with synced ad units
7. Connect with Google OAuth again
8. Visit the ad units wizard and confirm you are able to remove the service account credential since it has been prioritized and is being used
9. Remove the credential and confirm you are still connected through Google OAuth