### PR TITLE
feat(placements): fixed height support

### DIFF
--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -35,19 +35,23 @@ final class Blocks {
 			'newspack-ads/ad-unit',
 			[
 				'attributes'      => [
-					'provider'    => [
+					'provider'     => [
 						'type'    => 'string',
 						'default' => 'gam',
 					],
-					'ad_unit'     => [
+					'ad_unit'      => [
 						'type' => 'string',
 					],
-					'bidders_ids' => [
+					'bidders_ids'  => [
 						'type'    => 'object',
 						'default' => [],
 					],
+					'fixed_height' => [
+						'type'    => 'boolean',
+						'default' => false,
+					],
 					// Legacy attribute.
-					'activeAd'    => [
+					'activeAd'     => [
 						'type' => 'string',
 					],
 				],
@@ -115,7 +119,7 @@ final class Blocks {
 
 	/**
 	 * Render block.
-	 * 
+	 *
 	 * @param array[] $attrs Block attributes.
 	 *
 	 * @return string Block HTML.

--- a/includes/class-placements.php
+++ b/includes/class-placements.php
@@ -79,6 +79,9 @@ final class Placements {
 					'bidders_ids'  => [
 						'sanitize_callback' => [ __CLASS__, 'sanitize_bidders_ids' ],
 					],
+					'fixed_height' => [
+						'sanitize_callback' => 'rest_sanitize_boolean',
+					],
 					'hooks'        => [
 						'sanitize_callback' => [ __CLASS__, 'sanitize_hooks_data' ],
 					],
@@ -130,6 +133,10 @@ final class Placements {
 
 		if ( isset( $data['ad_unit'] ) ) {
 			$sanitized_data['ad_unit'] = sanitize_text_field( $data['ad_unit'] );
+		}
+
+		if ( isset( $data['fixed_height'] ) ) {
+			$sanitized_data['fixed_height'] = rest_sanitize_boolean( $data['fixed_height'] );
 		}
 
 		if ( isset( $data['bidders_ids'] ) ) {
@@ -210,7 +217,7 @@ final class Placements {
 			$placements,
 			function( $placement ) {
 				return ! empty( $placement['name'] ) && true === $placement['show_ui'];
-			} 
+			}
 		);
 		return \rest_ensure_response( $placements );
 	}
@@ -228,6 +235,7 @@ final class Placements {
 			'ad_unit'      => $request['ad_unit'],
 			'bidders_ids'  => $request['bidders_ids'],
 			'hooks'        => $request['hooks'],
+			'fixed_height' => $request['fixed_height'],
 			'stick_to_top' => $request['stick_to_top'],
 		];
 		$result = self::update_placement( $request['placement'], $data );
@@ -254,10 +262,10 @@ final class Placements {
 
 	/**
 	 * Get the option name
-	 * 
+	 *
 	 * @param string $placement_key Placement key.
-	 * 
-	 * @return string Option name. 
+	 *
+	 * @return string Option name.
 	 */
 	public static function get_option_name( $placement_key ) {
 		return Settings::OPTION_NAME_PREFIX . 'placement_' . $placement_key;
@@ -508,7 +516,7 @@ final class Placements {
 
 	/**
 	 * Update a placement with an ad unit. Enables the placement by default.
-	 * 
+	 *
 	 * @param string $placement_key Placement key.
 	 * @param array  $data {
 	 *   Placement data.
@@ -548,7 +556,7 @@ final class Placements {
 
 	/**
 	 * Disable a placement.
-	 * 
+	 *
 	 * @param string $placement_key Placement key.
 	 *
 	 * @return bool Whether the placement has been disabled or not.
@@ -564,7 +572,7 @@ final class Placements {
 			wp_json_encode(
 				wp_parse_args(
 					[ 'enabled' => false ],
-					$placement_data 
+					$placement_data
 				)
 			)
 		);
@@ -722,7 +730,7 @@ final class Placements {
 
 		$provider_id = isset( $placement_data['provider'] ) ? $placement_data['provider'] : Providers::DEFAULT_PROVIDER;
 		$ad_unit     = $placement_data['ad_unit'];
-		
+
 		$is_amp        = Core::is_amp();
 		$is_sticky_amp = 'sticky' === $placement_key && true === $is_amp;
 		do_action( 'newspack_ads_before_placement_ad', $placement_key, $hook_key, $placement_data );

--- a/includes/class-placements.php
+++ b/includes/class-placements.php
@@ -724,15 +724,25 @@ final class Placements {
 			$placement_data = $placement['data'];
 		}
 
+		$placement_data['fixed_height'] = isset( $placement_data['fixed_height'] ) ? (bool) $placement_data['fixed_height'] : false;
+
 		if ( ! isset( $placement_data['ad_unit'] ) || empty( $placement_data['ad_unit'] ) ) {
 			return;
 		}
 
-		$provider_id = isset( $placement_data['provider'] ) ? $placement_data['provider'] : Providers::DEFAULT_PROVIDER;
+		$provider_id = isset( $placement_data['provider'] ) && ! empty( $placement_data['provider'] ) ? $placement_data['provider'] : Providers::DEFAULT_PROVIDER;
 		$ad_unit     = $placement_data['ad_unit'];
 
 		$is_amp        = Core::is_amp();
 		$is_sticky_amp = 'sticky' === $placement_key && true === $is_amp;
+
+		/**
+		 * Fires before an ad is injected into a placement.
+		 *
+		 * @param string $placement_key  The placement key.
+		 * @param string $hook_key       The placement hook hey.
+		 * @param array  $placement_data The placement data.
+		 */
 		do_action( 'newspack_ads_before_placement_ad', $placement_key, $hook_key, $placement_data );
 
 		/**
@@ -752,6 +762,7 @@ final class Placements {
 				$placement_key . '-' . $hook_key    => ! empty( $hook_key ),
 				'hook-' . $hook_key                 => ! empty( $hook_key ),
 				'stick-to-top'                      => $stick_to_top,
+				'fixed-height'                      => $placement_data['fixed_height'],
 			],
 			$placement_key,
 			$hook_key,

--- a/includes/class-placements.php
+++ b/includes/class-placements.php
@@ -588,6 +588,14 @@ final class Placements {
 	private static function can_display( $placement_key ) {
 		$placements = self::get_placements();
 
+		// Suppressed by post definition.
+		if ( is_singular() ) {
+			$post_suppressed = get_post_meta( get_the_ID(), 'newspack_ads_suppress_ads_placements', true );
+			if ( is_array( $post_suppressed ) && ! empty( $post_suppressed ) && in_array( $placement_key, $post_suppressed, true ) ) {
+				return false;
+			}
+		}
+
 		// Placement does not exist.
 		if ( ! isset( $placements[ $placement_key ] ) ) {
 			return false;

--- a/includes/customizer/class-customizer.php
+++ b/includes/customizer/class-customizer.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Newspack Ads Customizer.
- * 
+ *
  * @package Newspack
  */
 
@@ -112,7 +112,7 @@ final class Customizer {
 				[
 					'title' => $placement['name'],
 					'panel' => 'newspack-ads',
-				] 
+				]
 			);
 			$wp_customize->add_setting(
 				$setting_id,
@@ -121,7 +121,7 @@ final class Customizer {
 					'capability'        => $capability,
 					'transport'         => 'postMessage',
 					'sanitize_callback' => [ __CLASS__, 'sanitize' ],
-				] 
+				]
 			);
 			$wp_customize->add_control(
 				new Placement_Customize_Control(

--- a/includes/customizer/class-placement-customize-control.php
+++ b/includes/customizer/class-placement-customize-control.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Newspack Ads Placement Customize Control.
- * 
+ *
  * @package Newspack
  */
 
@@ -41,7 +41,7 @@ final class Placement_Customize_Control extends \WP_Customize_Control {
 
 	/**
 	 * Placement configuration.
-	 * 
+	 *
 	 * @var array
 	 */
 	private $placement = null;
@@ -121,6 +121,22 @@ final class Placement_Customize_Control extends \WP_Customize_Control {
 			$data = $value['hooks'][ $hook_key ];
 		}
 		return isset( $data['ad_unit'] ) ? $data['ad_unit'] : '';
+	}
+
+	/**
+	 * Get the value of "fixed height" feature given its hook key.
+	 *
+	 * @param string $hook_key Optional hook key, will look root placement otherwise.
+	 *
+	 * @return string Ad unit ID or empty string if not found.
+	 */
+	private function get_fixed_height_value( $hook_key = '' ) {
+		$value = json_decode( $this->value(), true );
+		$data  = $value;
+		if ( ! empty( $hook_key ) && isset( $value['hooks'], $value['hooks'][ $hook_key ] ) ) {
+			$data = $value['hooks'][ $hook_key ];
+		}
+		return isset( $data['fixed_height'] ) ? (bool) $data['fixed_height'] : false;
 	}
 
 	/**
@@ -263,6 +279,29 @@ final class Placement_Customize_Control extends \WP_Customize_Control {
 	}
 
 	/**
+	 * Render the control's "fixed height" checkbox.
+	 *
+	 * @param bool   $value    The current value of the control.
+	 * @param string $hook_key The hook key.
+	 */
+	private function render_fixed_height_checkbox( $value = false, $hook_key = '' ) {
+		$id_args = [ 'fixed-height' ];
+		if ( $hook_key ) {
+			$id_args[] = $hook_key;
+		}
+		$label    = __( 'Fixed height', 'newspack-ads' );
+		$input_id = $this->get_element_id( 'input', $id_args );
+		$desc_id  = $this->get_element_id( 'description', $id_args );
+		?>
+		<span class="customize-control fixed-height-checkbox">
+			<input id="<?php echo esc_attr( $input_id ); ?>" type="checkbox" value="1" <?php checked( $value, '1' ); ?> />
+			<label for="<?php echo esc_attr( $input_id ); ?>"><?php echo esc_html( $label ); ?></label>
+			<span id="<?php echo esc_attr( $desc_id ); ?>" class="description customize-control-description"><?php esc_html_e( 'Avoid content layout shift by using the ad unit height as fixed height for this placement. This is recommended if an ad will be shown across all devices.', 'newspack-ads' ); ?></span>
+		</span>
+		<?php
+	}
+
+	/**
 	 * Render the control's "stick to top" checkbox.
 	 *
 	 * @param bool   $value    The current value of the control.
@@ -341,6 +380,7 @@ final class Placement_Customize_Control extends \WP_Customize_Control {
 					$this->render_placement_hook_control( $hook_key, $this->placement );
 				}
 			}
+			$this->render_fixed_height_checkbox( $this->get_fixed_height_value() );
 			if ( in_array( 'stick_to_top', $this->placement['supports'], true ) ) {
 				$this->render_stick_to_top_checkbox( $this->get_stick_to_top_value() );
 			}

--- a/includes/customizer/class-placement-customize-control.php
+++ b/includes/customizer/class-placement-customize-control.php
@@ -296,7 +296,7 @@ final class Placement_Customize_Control extends \WP_Customize_Control {
 		<span class="customize-control fixed-height-checkbox">
 			<input id="<?php echo esc_attr( $input_id ); ?>" type="checkbox" value="1" <?php checked( $value, '1' ); ?> />
 			<label for="<?php echo esc_attr( $input_id ); ?>"><?php echo esc_html( $label ); ?></label>
-			<span id="<?php echo esc_attr( $desc_id ); ?>" class="description customize-control-description"><?php esc_html_e( 'Avoid content layout shift by using the ad unit height as fixed height for this placement. This is recommended if an ad will be shown across all devices.', 'newspack-ads' ); ?></span>
+			<span id="<?php echo esc_attr( $desc_id ); ?>" class="description customize-control-description"><?php esc_html_e( 'Avoid content layout shift by using the ad unit height as fixed height for this placement. This is recommended if an ad is guaranteed to be shown across all devices.', 'newspack-ads' ); ?></span>
 		</span>
 		<?php
 	}

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -55,8 +55,8 @@ final class GAM_Model {
 	 * @return void
 	 */
 	public static function init() {
-		add_action( 'init', array( __CLASS__, 'register_ad_post_type' ) );
-		add_action( 'newspack_ads_activation_hook', array( __CLASS__, 'register_default_placements_units' ) );
+		add_action( 'init', [ __CLASS__, 'register_ad_post_type' ] );
+		add_action( 'newspack_ads_activation_hook', [ __CLASS__, 'register_default_placements_units' ] );
 		GAM_API::set_network_code( get_option( self::OPTION_NAME_GAM_NETWORK_CODE, null ) );
 	}
 
@@ -585,17 +585,17 @@ final class GAM_Model {
 	 * @param string $unique_id The unique ID for this ad displayment.
 	 */
 	public static function get_ad_unit_code( $ad_unit, $unique_id = '' ) {
-		$sizes        = $ad_unit['sizes'];
 		$code         = $ad_unit['code'];
 		$network_code = self::get_active_network_code();
 		$unique_id    = $unique_id ?? uniqid();
-		if ( ! is_array( $sizes ) ) {
-			$sizes = [];
+
+		if ( ! is_array( $ad_unit['sizes'] ) ) {
+			$ad_unit['sizes'] = [];
 		}
 
 		// Remove all ad sizes greater than 600px wide for sticky ads.
 		if ( self::is_sticky( $ad_unit ) ) {
-			$sizes = array_filter(
+			$ad_unit['sizes'] = array_filter(
 				$sizes,
 				function( $size ) {
 					return $size[0] < 600;
@@ -621,25 +621,26 @@ final class GAM_Model {
 	 * @param string $unique_id Optional pre-defined unique ID for this ad displayment.
 	 */
 	public static function get_ad_unit_amp_code( $ad_unit, $unique_id = '' ) {
-		$sizes        = $ad_unit['sizes'];
 		$code         = $ad_unit['code'];
 		$network_code = self::get_active_network_code();
 		$targeting    = self::get_ad_targeting( $ad_unit );
 		$unique_id    = $unique_id ?? uniqid();
 
-		if ( ! is_array( $sizes ) ) {
-			$sizes = [];
+		if ( ! is_array( $ad_unit['sizes'] ) ) {
+			$ad_unit['sizes'] = [];
 		}
 
 		// Remove all ad sizes greater than 600px wide for sticky ads.
 		if ( self::is_sticky( $ad_unit ) ) {
-			$sizes = array_filter(
-				$sizes,
+			$ad_unit['sizes'] = array_filter(
+				$ad_unit['sizes'],
 				function( $size ) {
 					return $size[0] < 600;
 				}
 			);
 		}
+
+		$sizes = $ad_unit['sizes'];
 
 		$size_map = self::get_ad_unit_size_map( $ad_unit, $sizes );
 

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -596,7 +596,7 @@ final class GAM_Model {
 		// Remove all ad sizes greater than 600px wide for sticky ads.
 		if ( self::is_sticky( $ad_unit ) ) {
 			$ad_unit['sizes'] = array_filter(
-				$$ad_unit['sizes'],
+				$ad_unit['sizes'],
 				function( $size ) {
 					return $size[0] < 600;
 				}

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -35,11 +35,11 @@ final class GAM_Model {
 	public static $custom_post_type = 'newspack_ad_codes';
 
 	/**
-	 * Array of all unique div IDs used for ads.
+	 * Associative array of all ad slots that will be rendered on the page.
 	 *
 	 * @var array
 	 */
-	public static $ad_ids = [];
+	public static $slots = [];
 
 	/**
 	 * Whether GAM units were already synced.
@@ -160,9 +160,10 @@ final class GAM_Model {
 			);
 		}
 
-		$unique_id = $config['unique_id'] ?? uniqid();
-		$placement = $config['placement'] ?? '';
-		$context   = $config['context'] ?? '';
+		$unique_id    = $config['unique_id'] ?? uniqid();
+		$placement    = $config['placement'] ?? '';
+		$context      = $config['context'] ?? '';
+		$fixed_height = $config['fixed_height'] ?? false;
 
 		$ad_units = self::get_ad_units( false );
 
@@ -178,8 +179,9 @@ final class GAM_Model {
 		}
 		$ad_unit = $ad_units[ $index ];
 
-		$ad_unit['placement'] = $placement;
-		$ad_unit['context']   = $context;
+		$ad_unit['placement']    = $placement;
+		$ad_unit['context']      = $context;
+		$ad_unit['fixed_height'] = $fixed_height;
 
 		$ad_unit['ad_code']     = self::get_ad_unit_code( $ad_unit, $unique_id );
 		$ad_unit['amp_ad_code'] = self::get_ad_unit_amp_code( $ad_unit, $unique_id );
@@ -601,7 +603,7 @@ final class GAM_Model {
 			);
 		}
 
-		self::$ad_ids[ $unique_id ] = $ad_unit;
+		self::$slots[ $unique_id ] = $ad_unit;
 
 		$code = sprintf(
 			"<!-- /%s/%s --><div id='div-gpt-ad-%s-0'></div>",
@@ -707,7 +709,7 @@ final class GAM_Model {
 
 	/**
 	 * Get size map for responsive ads.
-	 * 
+	 *
 	 * Gather up all of the ad sizes which should be displayed on the same
 	 * viewports. As a heuristic, each ad slot can safely display ads with a 30%
 	 * difference from slot's width. e.g. for the following setup: [[300,200],
@@ -729,7 +731,7 @@ final class GAM_Model {
 	public static function get_responsive_size_map( $sizes, $width_diff_ratio = 0.3, $width_threshold = 600 ) {
 
 		array_multisort( $sizes );
-	
+
 		// Each existing size's width is size map viewport.
 		$viewports = array_unique( array_column( $sizes, 0 ) );
 
@@ -927,7 +929,7 @@ final class GAM_Model {
 					function( $user ) {
 						return $user->user_login;
 					},
-					get_coauthors() 
+					get_coauthors()
 				);
 			} else {
 				$authors = [ get_the_author_meta( 'user_login' ) ];
@@ -935,7 +937,7 @@ final class GAM_Model {
 			if ( ! empty( $authors ) ) {
 				$targeting['author'] = array_map( 'sanitize_text_field', $authors );
 			}
-					
+
 			// Add post type to targeting.
 			$targeting['post_type'] = get_post_type();
 

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -596,7 +596,7 @@ final class GAM_Model {
 		// Remove all ad sizes greater than 600px wide for sticky ads.
 		if ( self::is_sticky( $ad_unit ) ) {
 			$ad_unit['sizes'] = array_filter(
-				$sizes,
+				$$ad_unit['sizes'],
 				function( $size ) {
 					return $size[0] < 600;
 				}

--- a/includes/providers/gam/class-gam-provider.php
+++ b/includes/providers/gam/class-gam-provider.php
@@ -75,8 +75,9 @@ final class GAM_Provider extends Provider {
 		$ad_unit = GAM_Model::get_ad_unit_for_display(
 			$unit_id,
 			array(
-				'unique_id' => $placement_data['id'],
-				'placement' => $placement_key,
+				'unique_id'    => $placement_data['id'],
+				'placement'    => $placement_key,
+				'fixed_height' => isset( $placement_data['fixed_height'] ) ? (bool) $placement_data['fixed_height'] : false,
 			)
 		);
 		if ( \is_wp_error( $ad_unit ) ) {

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -348,7 +348,7 @@ final class GAM_Scripts {
 						 * Handle slot visibility.
 						 */
 						?>
-						if ( event.isEmpty && ! isFixedHeight( container ) || ( isFixedHeight(container) && ! container.ad_unit.in_viewport ) ) {
+						if ( event.isEmpty && ( ! isFixedHeight( container ) || ( isFixedHeight(container) && ! container.ad_unit.in_viewport ) ) ) {
 							container.parentNode.style.display = 'none';
 						} else {
 							container.parentNode.style.display = 'flex';

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -349,7 +349,7 @@ final class GAM_Scripts {
 						 * creatives to render on refresh control.
 						 */
 						?>
-						if ( ad_unit.fixed_height && container.parentNode.style.height === 'auto' ) {
+						if ( ad_unit.fixed_height && container.parentNode.style.height === 'auto' && event.size ) {
 							container.parentNode.style.height = event.size[1] + 'px';
 							event.slot.defineSizeMapping( googletag.sizeMapping().addSize( [ 0, 0 ], event.size ).build() );
 						}

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -383,9 +383,6 @@ final class GAM_Scripts {
 							}
 						}
 					} );
-					setInterval( function() {
-						googletag.pubads().refresh();
-					}, 5000 );
 				} );
 			} )();
 		</script>

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -169,11 +169,9 @@ final class GAM_Scripts {
 
 				var boundsContainers = {};
 
-				function inViewport( element ) {
+				function inOrPastViewport( element ) {
 					var bounding = element.getBoundingClientRect();
 					return (
-						bounding.top >= 0 &&
-						bounding.left >= 0 &&
 						bounding.right <= ( window.innerWidth || document.documentElement.clientWidth ) &&
 						bounding.bottom <= ( window.innerHeight || document.documentElement.clientHeight )
 					);
@@ -185,7 +183,7 @@ final class GAM_Scripts {
 					if ( ! container ) {
 						continue;
 					}
-					ad_unit.in_viewport = inViewport( container );
+					ad_unit.in_viewport = inOrPastViewport( container );
 					container.ad_unit = ad_unit;
 					<?php
 					/**

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -345,6 +345,16 @@ final class GAM_Scripts {
 						}
 						<?php
 						/**
+						 * Lock fixed height ad unit size mapping to prevent larger
+						 * creatives to render on refresh control.
+						 */
+						?>
+						if ( ad_unit.fixed_height && container.parentNode.style.height === 'auto' ) {
+							container.parentNode.style.height = event.size[1] + 'px';
+							event.slot.defineSizeMapping( googletag.sizeMapping().addSize( [ 0, 0 ], event.size ).build() );
+						}
+						<?php
+						/**
 						 * Handle slot visibility.
 						 */
 						?>
@@ -373,6 +383,9 @@ final class GAM_Scripts {
 							}
 						}
 					} );
+					setInterval( function() {
+						googletag.pubads().refresh();
+					}, 5000 );
 				} );
 			} )();
 		</script>

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -220,9 +220,10 @@ final class GAM_Scripts {
 					 */
 					?>
 					var shouldUseBounds = !! boundsWidth;
+					var availableWidth = window.innerWidth;
 					if ( shouldUseBounds ) {
 						var containerWidth = container.parentNode.offsetWidth;
-						var availableWidth = Math.max( boundsWidth, containerWidth ) + parseInt( ad_unit['bounds_bleed'] );
+						availableWidth = Math.max( boundsWidth, containerWidth ) + parseInt( ad_unit['bounds_bleed'] );
 						for ( viewportWidth in ad_unit['size_map'] ) {
 							var width = parseInt( viewportWidth );
 							if ( shouldUseBounds && width > availableWidth ) {
@@ -238,7 +239,8 @@ final class GAM_Scripts {
 					if ( ad_unit.fixed_height ) {
 						var height = 0;
 						for ( viewportWidth in ad_unit.size_map ) {
-							if ( viewportWidth < window.innerWidth ) {
+							if ( viewportWidth < availableWidth ) {
+								height = 0;
 								for ( size in ad_unit.size_map[ viewportWidth ] ) {
 									height = Math.max( height, ad_unit.size_map[ viewportWidth ][ size ][1] );
 								}

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -179,14 +179,6 @@ final class GAM_Scripts {
 					);
 				}
 
-				function isNewspackAd( adContainer ) {
-					return adContainer.parentNode.classList.contains( 'newspack_global_ad' );
-				}
-
-				function isFixedHeight( adContainer ) {
-					return adContainer.parentNode.classList.contains( 'fixed-height' );
-				}
-
 				for ( var container_id in all_ad_units ) {
 					var ad_unit = all_ad_units[ container_id ];
 					var container = document.querySelector( '#' + container_id );
@@ -340,7 +332,11 @@ final class GAM_Scripts {
 
 					googletag.pubads().addEventListener( 'slotRenderEnded', function( event ) {
 						var container = document.getElementById( event.slot.getSlotElementId() );
-						if ( ! isNewspackAd( container ) ) {
+						if ( ! container ) {
+							return;
+						}
+						var ad_unit = container.ad_unit;
+						if ( ! ad_unit ) {
 							return;
 						}
 						<?php
@@ -348,7 +344,7 @@ final class GAM_Scripts {
 						 * Handle slot visibility.
 						 */
 						?>
-						if ( event.isEmpty && ( ! isFixedHeight( container ) || ( isFixedHeight(container) && ! container.ad_unit.in_viewport ) ) ) {
+						if ( event.isEmpty && ( ! ad_unit.fixed_height || ( ad_unit.fixed_height && ! ad_unit.in_viewport ) ) ) {
 							container.parentNode.style.display = 'none';
 						} else {
 							container.parentNode.style.display = 'flex';

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -231,20 +231,24 @@ final class GAM_Scripts {
 					}
 					<?php
 					/**
-					 * Set fixed height for parentNode.
+					 * Set fixed height on parentNode for slots within viewport. Slots
+					 * outside of the viewport will have 'auto' height.
 					 */
 					?>
 					if ( ad_unit.fixed_height ) {
-						var height = 0;
-						for ( viewportWidth in ad_unit.size_map ) {
-							if ( viewportWidth < availableWidth ) {
-								height = 0;
-								for ( size in ad_unit.size_map[ viewportWidth ] ) {
-									height = Math.max( height, ad_unit.size_map[ viewportWidth ][ size ][1] );
+						var height = 'auto';
+						if ( ad_unit.in_viewport ) {
+							for ( viewportWidth in ad_unit.size_map ) {
+								if ( viewportWidth < availableWidth ) {
+									height = 0;
+									for ( size in ad_unit.size_map[ viewportWidth ] ) {
+										height = Math.max( height, ad_unit.size_map[ viewportWidth ][ size ][1] );
+									}
 								}
 							}
+							height = height + 'px';
 						}
-						container.parentNode.style.height = height + 'px';
+						container.parentNode.style.height = height;
 					}
 				}
 				googletag.cmd.push(function() {

--- a/src/blocks/ad-unit/edit.js
+++ b/src/blocks/ad-unit/edit.js
@@ -118,7 +118,6 @@ function Edit( { attributes, setAttributes } ) {
 								<div
 									className={ classNames( {
 										'newspack-ads-ad-block-edit-fields': true,
-										'one-column': providers.length < 2 && ! Object.keys( bidders ).length,
 									} ) }
 								>
 									<PlacementControl
@@ -130,8 +129,6 @@ function Edit( { attributes, setAttributes } ) {
 											setAttributes( value );
 										} }
 									/>
-								</div>
-								<div className="newspack-ads-ad-block-save-button">
 									<Button disabled={ ! unit } onClick={ () => setIsEditing( false ) } isPrimary>
 										{ __( 'Save', 'newspack-ads' ) }
 									</Button>

--- a/src/blocks/ad-unit/editor.scss
+++ b/src/blocks/ad-unit/editor.scss
@@ -17,7 +17,7 @@
 		padding: 16px;
 		position: relative;
 		width: 100%;
-
+		overflow: hidden;
 		svg.newspack-ads-ad-block-mock {
 			display: block;
 			pointer-events: none;
@@ -52,17 +52,14 @@
 			margin: 0;
 		}
 		.newspack-ads-ad-block-edit-fields {
-			align-items: baseline;
-			column-gap: 1em;
-			display: grid;
-			grid-template-columns: repeat( 2, 1fr );
-			row-gap: calc( 1em - 8px );
-			&.one-column {
-				grid-template-columns: repeat( 1, minmax( max-content, 50% ) );
+			max-width: 500px;
+			margin: 0 auto;
+			.components-base-control {
+				margin-bottom: 16px;
+				p {
+					font-size: 13px;
+				}
 			}
-		}
-		.newspack-ads-ad-block-save-button {
-			margin-top: calc( 1em - 8px );
 		}
 	}
 }

--- a/src/blocks/ad-unit/index.js
+++ b/src/blocks/ad-unit/index.js
@@ -43,6 +43,10 @@ export const settings = {
 			type: 'object',
 			default: {},
 		},
+		fixed_height: {
+			type: 'boolean',
+			default: false,
+		},
 		// Legacy attribute.
 		activeAd: {
 			type: 'string',

--- a/src/customizer/control.js
+++ b/src/customizer/control.js
@@ -37,6 +37,9 @@ import { set, debounce } from 'lodash';
 			$toggle.on( 'change', function () {
 				updateValue( '', 'enabled', $( this ).is( ':checked' ) );
 			} );
+			container.on( 'change', '.fixed-height-checkbox input[type=checkbox]', function () {
+				updateValue( '', 'fixed_height', $( this ).is( ':checked' ) );
+			} );
 			container.on( 'change', '.stick-to-top-checkbox input[type=checkbox]', function () {
 				updateValue( '', 'stick_to_top', $( this ).is( ':checked' ) );
 			} );

--- a/src/frontend/style.scss
+++ b/src/frontend/style.scss
@@ -14,6 +14,11 @@
 	overflow: initial !important;
 }
 
+.newspack_global_ad.fixed-height {
+	padding: 16px 0;
+	box-sizing: content-box;
+}
+
 /**
  * Placement mock
  */

--- a/src/placements/placement-control.js
+++ b/src/placements/placement-control.js
@@ -5,7 +5,7 @@
 /**
  * WordPress dependencies
  */
-import { Notice, SelectControl, TextControl } from '@wordpress/components';
+import { Notice, SelectControl, ToggleControl, TextControl } from '@wordpress/components';
 import { Fragment, useState, useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -169,6 +169,15 @@ const PlacementControl = ( {
 					}
 					return null;
 				} ) }
+			<ToggleControl
+				label={ __( 'Use fixed height', 'newspack-ads' ) }
+				help={ __(
+					'Avoid content layout shift by using the ad unit height as fixed height for this placement. This is recommended if an ad will be shown across all devices.',
+					'newspack-ads'
+				) }
+				checked={ !! value.fixed_height }
+				onChange={ data => onChange( { ...value, fixed_height: data } ) }
+			/>
 		</Fragment>
 	);
 };

--- a/src/placements/placement-control.js
+++ b/src/placements/placement-control.js
@@ -172,7 +172,7 @@ const PlacementControl = ( {
 			<ToggleControl
 				label={ __( 'Use fixed height', 'newspack-ads' ) }
 				help={ __(
-					'Avoid content layout shift by using the ad unit height as fixed height for this placement. This is recommended if an ad will be shown across all devices.',
+					'Avoid content layout shift by using the ad unit height as fixed height for this placement. This is recommended if an ad is guaranteed to be shown across all devices.',
 					'newspack-ads'
 				) }
 				checked={ !! value.fixed_height }

--- a/src/suppress-ads/index.js
+++ b/src/suppress-ads/index.js
@@ -7,7 +7,7 @@ import { registerPlugin } from '@wordpress/plugins';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { __ } from '@wordpress/i18n';
 import { ToggleControl } from '@wordpress/components';
-import { Component } from '@wordpress/element';
+import { Fragment, Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 
@@ -16,20 +16,53 @@ import { withDispatch, withSelect } from '@wordpress/data';
  */
 class NewspackSuppressAdsPanel extends Component {
 	render() {
-		const { newspack_ads_suppress_ads, updateSuppressAds } = this.props;
+		const placements = window.newspackAdsSuppressAds?.placements || {};
+		const {
+			newspack_ads_suppress_ads,
+			newspack_ads_suppress_ads_placements,
+			updateSuppressAds,
+			updateSuppressPlacements,
+		} = this.props;
+		console.log( newspack_ads_suppress_ads_placements );
 		return (
 			<PluginDocumentSettingPanel
 				name="newspack-ad-free"
-				title={ __( 'Newspack Ads Settings', 'newspack' ) }
+				title={ __( 'Newspack Ads Settings', 'newspack-ads' ) }
 				className="newspack-subtitle"
 			>
 				<ToggleControl
-					label={ __( "Don't show ads on this post or page", 'newspack' ) }
+					label={ __( "Don't show ads on this content", 'newspack-ads' ) }
 					checked={ newspack_ads_suppress_ads }
 					onChange={ value => {
 						updateSuppressAds( value );
 					} }
 				/>
+				{ ! newspack_ads_suppress_ads && (
+					<Fragment>
+						<p>{ __( 'Suppress specific placements:', 'newspack-ads' ) }</p>
+						{ Object.keys( placements ).map( placementKey => (
+							<ToggleControl
+								key={ placementKey }
+								label={ placements[ placementKey ].name }
+								checked={
+									newspack_ads_suppress_ads_placements &&
+									newspack_ads_suppress_ads_placements.indexOf( placementKey ) !== -1
+								}
+								onChange={ () => {
+									const suppressPlacements = newspack_ads_suppress_ads_placements?.length
+										? [ ...newspack_ads_suppress_ads_placements ]
+										: [];
+									if ( suppressPlacements.indexOf( placementKey ) !== -1 ) {
+										suppressPlacements.splice( suppressPlacements.indexOf( placementKey ), 1 );
+									} else {
+										suppressPlacements.push( placementKey );
+									}
+									updateSuppressPlacements( suppressPlacements );
+								} }
+							/>
+						) ) }
+					</Fragment>
+				) }
 			</PluginDocumentSettingPanel>
 		);
 	}
@@ -37,12 +70,19 @@ class NewspackSuppressAdsPanel extends Component {
 
 const ComposedPanel = compose( [
 	withSelect( select => {
-		const { newspack_ads_suppress_ads } = select( 'core/editor' ).getEditedPostAttribute( 'meta' );
-		return { newspack_ads_suppress_ads };
+		const { newspack_ads_suppress_ads, newspack_ads_suppress_ads_placements } = select(
+			'core/editor'
+		).getEditedPostAttribute( 'meta' );
+		return { newspack_ads_suppress_ads, newspack_ads_suppress_ads_placements };
 	} ),
 	withDispatch( dispatch => ( {
 		updateSuppressAds( value ) {
 			dispatch( 'core/editor' ).editPost( { meta: { newspack_ads_suppress_ads: value } } );
+		},
+		updateSuppressPlacements( value ) {
+			dispatch( 'core/editor' ).editPost( {
+				meta: { newspack_ads_suppress_ads_placements: value },
+			} );
 		},
 	} ) ),
 ] )( NewspackSuppressAdsPanel );

--- a/src/suppress-ads/index.js
+++ b/src/suppress-ads/index.js
@@ -23,7 +23,6 @@ class NewspackSuppressAdsPanel extends Component {
 			updateSuppressAds,
 			updateSuppressPlacements,
 		} = this.props;
-		console.log( newspack_ads_suppress_ads_placements );
 		return (
 			<PluginDocumentSettingPanel
 				name="newspack-ad-free"


### PR DESCRIPTION
Implements optional fixed height for ad placements.

Editing a placement from the wizard:

<img width="766" alt="image" src="https://user-images.githubusercontent.com/820752/172920005-2ffb1347-14c6-435b-92d6-ff169681d3d6.png">

Editing a block (dynamic placement):

<img width="388" alt="image" src="https://user-images.githubusercontent.com/820752/172920070-98b8f8f8-7dfd-400c-8760-9af850f839ab.png">

Editing a placement from the customizer:

<img width="343" alt="image" src="https://user-images.githubusercontent.com/820752/172920264-28a83479-7b3c-4f2c-a7fe-f455cd0b7c04.png">

## Broadstreet

Since Broadstreet zones only support one size, a simple div with a fixed height will contain the ad.

## GAM

To handle a variety of cases, the handling of fixed height occurs in two steps:

 1. A server-side rendered `<style />` applies media queries with height rules following the _viewport -> sizes_ map returned from [`get_ad_unit_size_map()`](https://github.com/Automattic/newspack-ads/blob/c394b4b9460c49862e26fb067009f26d1772b6a4/includes/providers/gam/class-gam-model.php#L759)
 2. To handle the odd case of altered size map from bounds containers, the height is dynamically readjusted as soon as the frontend-calculated bounds containers data is available

The case of the second step affecting CLS is very unlikely, considering it'll most likely happen outside of the viewport. Ads within bounds containers are inside post content, sidebar, and columns. This step is only executed to guarantee that a prioritized smaller ad with a larger height (300x250) doesn't get contained with a smaller height from a larger ad (728x90) calculated by the initial `<style />`.

### Viewport

CLS is an issue within the viewport. Ads with a fixed height that don't render any creative outside of the viewport will be hidden from the page.

~~Mind that although we could consider applying that logic to also use the rendered creative to fit the height and remove potential blank spaces from the slot, this is problematic for 2 reasons:~~

~1. Refresh control can change the rendered creative and cause extra annoying CLS (during read-time)~
~2. Lazy load options will also affect the time the creative height is known, which is likely to be the time when the slot is in the viewport~

**UPDATE** 
After @kmwilkerson [contribution](https://github.com/Automattic/newspack-ads/pull/439#issuecomment-1152732343), the fixed height will only be applied immediately for ads above the fold. Other ads will have their height set to `auto` until the slot renders a creative, at which point the height and its size map rules will be determined to use the rendered creative dimension. The size map is updated in order to prevent refresh control to render a creative that breaks the bounds.

## Placement suppression per post

Fixed height is most likely to be used for placements above the fold, which are the "Above header" and "Below header" placements. It is also very common to only display ads for such placements on inner content, not the homepage. Ads without creatives for such cases would not be hidden because they are above the fold and doing so would defeat the purpose of a fixed height.

To better accommodate this common practice and prevent unnecessary blank spaces, this PR also implements suppression of ads for specific placements on a page or post:

<img width="287" alt="image" src="https://user-images.githubusercontent.com/820752/172922621-945c6645-3518-49ca-9d2b-417f997998da.png">

This suppression occurs server-side and will not impact CLS for that page.

Closes #409 

## How to test this PR

1. Check out this branch and https://github.com/Automattic/newspack-plugin/pull/1697
2. Confirm you have AMP off (or AMP Plus)
3. Configure valid Broadstreet and GAM
4. Set the "Above header" placement with a multi-sized ad unit: `728x90`, `970x90`, `970x250` and fixed height
5. Visit a page and confirm the slot is `250` in height, regardless of the rendered creative
6. Change your window size to below 970, refresh and confirm the height is now `90`

### Customizer

1. Enter the customizer, edit the same placement by removing the fixed height and saving
2. Visit the page and confirm that fixed height is not applied
3. Back to the customizer, apply again and confirm fixed height is restored

### Bounds containers

1. Draft a 3 column page (columns within > 300 and < 700 width)
4. In a column, add an Ad unit block with an ad unit with the following sizes: `300x250` and `728x90` with fixed height
5. Save and visit the page
6. Confirm the fixed height is set to `250`
7. Inspect the element and observe the `height: 90px;` rule being overwritten by the inline rule

### Hiding empty slots with fixed height

1. Editing the same page as above, add content above the columns to ensure that the ad unit does not render above the fold
2. Change the ad unit block to an ad unit that is guaranteed to not render a creative
3. Visit the page, scroll to the slot and confirm it's hidden

### Placement suppression

1. Editing the same page as above, suppress the "Above header" placement at the "Newspack Ads Settings" section
4. Visit the page and confirm the placement is not rendered
5. Visit another page and confirm the placement renders as expected