### PR TITLE
fix: handling of default provider when GAM is not active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.37.1-hotfix.1](https://github.com/Automattic/newspack-ads/compare/v1.37.0...v1.37.1-hotfix.1) (2022-06-30)
+
+
+### Bug Fixes
+
+* handling of default provider when GAM is not active ([d42141e](https://github.com/Automattic/newspack-ads/commit/d42141e36a860a57e0d3d7bd9d916ebecd0e9ac4))
+
 # [1.37.0](https://github.com/Automattic/newspack-ads/compare/v1.36.0...v1.37.0) (2022-06-27)
 
 

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -9,6 +9,7 @@ namespace Newspack_Ads;
 
 use Newspack_Ads\Core;
 use Newspack_Ads\Placements;
+use Newspack_Ads\Providers;
 
 /**
  * Newspack Ads Blocks Management
@@ -36,8 +37,7 @@ final class Blocks {
 			[
 				'attributes'      => [
 					'provider'     => [
-						'type'    => 'string',
-						'default' => 'gam',
+						'type' => 'string',
 					],
 					'ad_unit'      => [
 						'type' => 'string',
@@ -74,7 +74,7 @@ final class Blocks {
 			[
 				'id'       => uniqid(),
 				'enabled'  => true,
-				'provider' => 'gam',
+				'provider' => Providers::get_default_provider(),
 				'ad_unit'  => isset( $attrs['activeAd'] ) ? $attrs['activeAd'] : '',
 			]
 		);

--- a/includes/class-placements.php
+++ b/includes/class-placements.php
@@ -288,7 +288,7 @@ final class Placements {
 			[
 				'enabled'  => isset( $config['default_enabled'] ) ? $config['default_enabled'] : false,
 				'ad_unit'  => isset( $config['default_ad_unit'] ) ? $config['default_ad_unit'] : '',
-				'provider' => Providers::DEFAULT_PROVIDER,
+				'provider' => Providers::get_default_provider(),
 			]
 		);
 
@@ -317,7 +317,7 @@ final class Placements {
 				$data['hooks'][ $hook_key ] = wp_parse_args(
 					$hook,
 					[
-						'provider' => Providers::DEFAULT_PROVIDER,
+						'provider' => Providers::get_default_provider(),
 					]
 				);
 				if ( isset( $hook['ad_unit'] ) && $hook['ad_unit'] && ! isset( $hook['id'] ) ) {
@@ -532,7 +532,7 @@ final class Placements {
 		// Updates always enables the placement.
 		$data['enabled'] = true;
 
-		$data['provider'] = isset( $data['provider'] ) ? $data['provider'] : Providers::DEFAULT_PROVIDER;
+		$data['provider'] = isset( $data['provider'] ) ? $data['provider'] : Providers::get_default_provider();
 
 		// Generate unique ID.
 		if ( isset( $data['ad_unit'] ) && $data['ad_unit'] ) {
@@ -738,7 +738,7 @@ final class Placements {
 			return;
 		}
 
-		$provider_id = isset( $placement_data['provider'] ) && ! empty( $placement_data['provider'] ) ? $placement_data['provider'] : Providers::DEFAULT_PROVIDER;
+		$provider_id = isset( $placement_data['provider'] ) && ! empty( $placement_data['provider'] ) ? $placement_data['provider'] : Providers::get_default_provider();
 		$ad_unit     = $placement_data['ad_unit'];
 
 		$is_amp        = Core::is_amp();

--- a/includes/class-providers.php
+++ b/includes/class-providers.php
@@ -167,7 +167,7 @@ final class Providers {
 			if ( $provider ) {
 				self::$providers_data[ $provider_id ] = array_merge(
 					self::get_serialised_provider( $provider ),
-					[ 'units' => $provider->get_units() ]
+					[ 'units' => $provider->get_units( true ) ]
 				);
 			} else {
 				self::$providers_data[ $provider_id ] = null;

--- a/includes/class-providers.php
+++ b/includes/class-providers.php
@@ -97,6 +97,19 @@ final class Providers {
 	}
 
 	/**
+	 * Get the default provider ID.
+	 *
+	 * @return string The default provider ID.
+	 */
+	public static function get_default_provider() {
+		$providers = self::get_active_providers();
+		if ( empty( $providers ) || isset( $providers[ self::DEFAULT_PROVIDER ] ) ) {
+			return self::DEFAULT_PROVIDER;
+		}
+		return array_key_first( $providers );
+	}
+
+	/**
 	 * Get a serialised provider data.
 	 *
 	 * @param Provider $provider The provider to serialise.
@@ -220,7 +233,7 @@ final class Providers {
 	 * @param array  $placement_data The placement data.
 	 */
 	public static function render_placement_ad_code( $unit_id, $provider_id, $placement_key, $hook_key, $placement_data ) {
-		$provider_id = isset( $provider_id ) && $provider_id ? $provider_id : self::DEFAULT_PROVIDER;
+		$provider_id = isset( $provider_id ) && $provider_id ? $provider_id : self::get_default_provider();
 		$provider    = self::get_provider( $provider_id );
 		if ( ! $provider ) {
 			return;

--- a/includes/customizer/class-placement-customize-control.php
+++ b/includes/customizer/class-placement-customize-control.php
@@ -95,11 +95,11 @@ final class Placement_Customize_Control extends \WP_Customize_Control {
 	 *
 	 * @param string $hook_key Optional hook key, will look root placement otherwise.
 	 *
-	 * @return string Provider ID or \Newspack_Ads\Providers::DEFAULT_PROVIDER if not found.
+	 * @return string Provider ID or empty string.
 	 */
 	private function get_provider_value( $hook_key = '' ) {
 		$value   = json_decode( $this->value(), true );
-		$default = Providers::DEFAULT_PROVIDER;
+		$default = '';
 		$data    = $value;
 		if ( ! empty( $hook_key ) && isset( $value['hooks'], $value['hooks'][ $hook_key ] ) ) {
 			$data = $value['hooks'][ $hook_key ];

--- a/includes/providers/broadstreet/class-broadstreet-provider.php
+++ b/includes/providers/broadstreet/class-broadstreet-provider.php
@@ -57,13 +57,15 @@ final class Broadstreet_Provider extends Provider {
 	/**
 	 * The provider available units for placement.
 	 *
+	 * @param bool $refresh Whether refresh provider units data.
+	 *
 	 * @return array[
 	 *  'name'  => string,
 	 *  'value' => string,
 	 *  'sizes' => array[]
 	 * ] The provider available units for placement.
 	 */
-	public function get_units() {
+	public function get_units( $refresh = false ) {
 		if ( ! self::is_plugin_active() || ! method_exists( '\Broadstreet_Utility', 'getZoneCache' ) ) {
 			return [];
 		}
@@ -72,7 +74,7 @@ final class Broadstreet_Provider extends Provider {
 		 * If getting through the dashboard, fetch from plugin utility and update
 		 * local cache.
 		 */
-		if ( is_admin() ) {
+		if ( true === $refresh ) {
 			$zones = \Broadstreet_Utility::getZoneCache();
 			\update_option( self::CACHE, $zones );
 		}

--- a/includes/providers/gam/class-gam-provider.php
+++ b/includes/providers/gam/class-gam-provider.php
@@ -41,14 +41,16 @@ final class GAM_Provider extends Provider {
 	/**
 	 * The provider available units for placement.
 	 *
+	 * @param bool $refresh Whether refresh provider units data.
+	 *
 	 * @return array[
 	 *  'name'  => string,
 	 *  'value' => string,
 	 *  'sizes' => array[]
 	 * ] The provider available units for placement.
 	 */
-	public function get_units() {
-		$ad_units = GAM_Model::get_ad_units();
+	public function get_units( $refresh = false ) {
+		$ad_units = GAM_Model::get_ad_units( $refresh );
 		return array_map(
 			function( $ad_unit ) {
 				return [

--- a/includes/providers/interface-provider.php
+++ b/includes/providers/interface-provider.php
@@ -38,12 +38,14 @@ interface Provider_Interface {
 	/**
 	 * The provider available units for placement.
 	 *
+	 * @param bool $refresh Whether refresh provider units data.
+	 *
 	 * @return array[
 	 *  'name'  => string,
 	 *  'value' => string
 	 * ] The provider available units for placement.
 	 */
-	public function get_units();
+	public function get_units( $refresh = false );
 
 	/**
 	 * The ad code for rendering.

--- a/newspack-ads.php
+++ b/newspack-ads.php
@@ -5,7 +5,7 @@
  * Description:     Ad services integration.
  * Author:          Automattic
  * License:         GPL2
- * Version:         1.37.0
+ * Version:         1.37.1-hotfix.1
  *
  * @package         Newspack
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack-ads",
-  "version": "1.37.0",
+  "version": "1.37.1-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack-ads",
-      "version": "1.37.0",
+      "version": "1.37.1-hotfix.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack-ads",
-  "version": "1.37.0",
+  "version": "1.37.1-hotfix.1",
   "author": "Automattic",
   "private": true,
   "scripts": {

--- a/src/blocks/ad-unit/edit.js
+++ b/src/blocks/ad-unit/edit.js
@@ -65,6 +65,12 @@ function Edit( { attributes, setAttributes } ) {
 		setInFlight( false );
 	}, [] );
 
+	useEffect( () => {
+		if ( providers?.length && ! attributes.provider ) {
+			setAttributes( { provider: providers[ 0 ].id } );
+		}
+	}, [ providers ] );
+
 	return (
 		<div { ...blockProps }>
 			{ ! isEditing && unit ? (

--- a/src/blocks/ad-unit/index.js
+++ b/src/blocks/ad-unit/index.js
@@ -34,7 +34,6 @@ export const settings = {
 	attributes: {
 		provider: {
 			type: 'string',
-			default: 'gam',
 		},
 		ad_unit: {
 			type: 'string',

--- a/src/customizer/control.js
+++ b/src/customizer/control.js
@@ -16,10 +16,10 @@ import { set, debounce } from 'lodash';
 			try {
 				value = JSON.parse( control.setting.get() || '{}' );
 			} catch ( e ) {
-				value = { enabled: false, provider: 'gam' };
+				value = { enabled: false };
 			}
 			container.find( '[data-provider]' ).hide();
-			container.find( `[data-provider="${ value.provider || 'gam' }"]` ).show();
+			container.find( `[data-provider="${ value.provider }"]` ).show();
 			const _update = debounce( function () {
 				control.setting.set( JSON.stringify( value ) );
 			}, 300 );

--- a/tests/class-newspack-ads-test-provider.php
+++ b/tests/class-newspack-ads-test-provider.php
@@ -23,13 +23,15 @@ class Newspack_Ads_Test_Provider extends Provider {
 	/**
 	 * The provider available units for placement.
 	 *
+	 * @param bool $refresh Whether refresh provider units data.
+	 *
 	 * @return array[
 	 *  'name'  => string,
 	 *  'value' => string,
 	 *  'sizes' => array[]
 	 * ] The provider available units for placement.
 	 */
-	public function get_units() {
+	public function get_units( $refresh = false ) {
 		return [
 			[
 				'name'  => 'Test Ad Unit',


### PR DESCRIPTION
The current implementation of the default provider assumes that GAM is always active and considered default. This causes unexpected behavior when Broadstreet is the only active provider and a placement does not include the `provider` attribute.

This PR fixes two issues:

 - Make sure GAM is active before using it as default. If not, the first active provider will be considered the default.
 - When placing an ad unit block with only 1 active provider, ensures the provider attribute is set to not rely on the default provider

## How to test

 - On the master branch, disable the GAM provider and enable Broadstreet
 - Attempt to place an ad unit block with a Broadstreet unit and confirm the ad unit does not render on the page
 - Also confirm that the "Save" button is greyed out because the provider is not set on the block
 - Check out this branch, refresh the page and confirm the ad renders
 - Edit the page again and confirm you are able to save and edit the unit
 - Enable GAM
 - Edit the page and confirm you are able to select and render GAM and Broadstreet units without issues