### PR TITLE
fix(broadstreet): amp responsive ads

### DIFF
--- a/includes/providers/broadstreet/class-broadstreet-provider.php
+++ b/includes/providers/broadstreet/class-broadstreet-provider.php
@@ -113,21 +113,21 @@ final class Broadstreet_Provider extends Provider {
 		}
 		$fixed_height = isset( $placement_data['fixed_height'] ) ? (bool) $placement_data['fixed_height'] : false;
 		$attrs        = [];
+		$zones        = $this->get_units();
+		$zone_idx     = array_search( $unit_id, array_column( $zones, 'value' ) );
+		if ( false === $zone_idx ) {
+			return;
+		}
+		$zone           = $zones[ $zone_idx ];
+		$width          = $zone['sizes'][0][0];
+		$attrs['style'] = sprintf( 'width: %dpx;', $width );
 		if ( $fixed_height ) {
-			$zones    = $this->get_units();
-			$zone_idx = array_search( $unit_id, array_column( $zones, 'value' ) );
-			if ( false !== $zone_idx ) {
-				$height         = $zones[ $zone_idx ]['sizes'][0][1];
-				$attrs['style'] = sprintf( 'height: %dpx;', $height );
-			}
+			$height         = $zone['sizes'][0][1];
+			$attrs['style'] = sprintf( '%s height: %dpx;', $attrs['style'], $height );
 		}
 		$code_attrs = [];
-		// Apply fixed layout for AMP ads.
-		if ( Core::is_amp() ) {
-			$code_attrs['layout'] = 'fixed';
-		}
 		return sprintf(
-			'<div %s>%s</div>',
+			'<div class="newspack-broadstreet-ad" %s>%s</div>',
 			implode(
 				' ',
 				array_map(

--- a/src/frontend/style.scss
+++ b/src/frontend/style.scss
@@ -14,9 +14,16 @@
 	overflow: initial !important;
 }
 
-.newspack_global_ad.fixed-height {
-	padding: 16px 0;
-	box-sizing: content-box;
+.newspack_global_ad {
+	max-width: 100%;
+	&.fixed-height {
+		padding: 16px 0;
+		box-sizing: content-box;
+	}
+}
+
+.newspack-broadstreet-ad {
+	max-width: 100%;
 }
 
 /**


### PR DESCRIPTION
This PR fixes AMP responsive ads for the Broadstreet provider. We're forcing the layout to `fixed` because of CSS incompatibility on how Broadstreet handles different viewports for the ad. A few CSS tweaks are enough to allow the default `responsive` layout to work as expected.

## How to test

1. Check out this branch and make sure you have AMP on
2. Make sure you have the Broadstreet provider configured
3. Set a Broadstreet unit to a global placement and visit the page
4. Confirm the ad renders as expected
5. Reload the page on mobile viewport
6. Confirm the ad is resized to fit the viewport