### PR TITLE
fix(broadstreet): allow units without fixed sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.37.3-hotfix.1](https://github.com/Automattic/newspack-ads/compare/v1.37.2...v1.37.3-hotfix.1) (2022-08-09)
+
+
+### Bug Fixes
+
+* **broadstreet:** allow units without fixed sizes ([7985959](https://github.com/Automattic/newspack-ads/commit/79859594c704932ca7df3bb7c5339c6043905f08))
+
 ## [1.37.2](https://github.com/Automattic/newspack-ads/compare/v1.37.1...v1.37.2) (2022-07-26)
 
 

--- a/includes/class-placements.php
+++ b/includes/class-placements.php
@@ -698,7 +698,13 @@ final class Placements {
 				<span class="newspack-ads__ad-placement-mock__label">
 					<?php printf( '%s - %s', esc_html( $provider->get_provider_name() ), esc_html( $ad_unit_data['name'] ) ); ?>
 					<br />
-					<?php echo esc_html( implode( ', ', array_map( 'Newspack_Ads\get_size_string', $sizes ) ) ); ?>
+					<?php
+					if ( count( $sizes ) ) {
+						echo esc_html( implode( ', ', array_map( 'Newspack_Ads\get_size_string', $sizes ) ) );
+					} else {
+						esc_html_e( 'Unknown size', 'newspack-ads' );
+					}
+					?>
 				</span>
 			</div>
 		</div>

--- a/includes/providers/broadstreet/class-broadstreet-provider.php
+++ b/includes/providers/broadstreet/class-broadstreet-provider.php
@@ -118,12 +118,18 @@ final class Broadstreet_Provider extends Provider {
 		if ( false === $zone_idx ) {
 			return;
 		}
-		$zone           = $zones[ $zone_idx ];
-		$width          = $zone['sizes'][0][0];
-		$attrs['style'] = sprintf( 'width: %dpx;', $width );
-		if ( $fixed_height ) {
-			$height         = $zone['sizes'][0][1];
-			$attrs['style'] = sprintf( '%s height: %dpx;', $attrs['style'], $height );
+		$zone = $zones[ $zone_idx ];
+		if ( ! empty( $zone['sizes'] ) ) {
+			$width = $zone['sizes'][0][0];
+			if ( $width && 0 < absint( $width ) ) {
+				$attrs['style'] = sprintf( 'width: %dpx;', $width );
+			}
+			if ( $fixed_height ) {
+				$height = $zone['sizes'][0][1];
+				if ( $height && 0 < absint( $height ) ) {
+					$attrs['style'] = sprintf( '%s height: %dpx;', $attrs['style'], $height );
+				}
+			}
 		}
 		$code_attrs = [];
 		return sprintf(

--- a/includes/providers/broadstreet/class-broadstreet-provider.php
+++ b/includes/providers/broadstreet/class-broadstreet-provider.php
@@ -130,6 +130,8 @@ final class Broadstreet_Provider extends Provider {
 					$attrs['style'] = sprintf( '%s height: %dpx;', $attrs['style'], $height );
 				}
 			}
+		} else {
+			$attrs['style'] = 'flex: 1 1 100%; width: 100%; height: auto;';
 		}
 		$code_attrs = [];
 		return sprintf(

--- a/newspack-ads.php
+++ b/newspack-ads.php
@@ -5,7 +5,7 @@
  * Description:     Ad services integration.
  * Author:          Automattic
  * License:         GPL2
- * Version:         1.37.2
+ * Version:         1.37.3-hotfix.1
  *
  * @package         Newspack
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack-ads",
-  "version": "1.37.2",
+  "version": "1.37.3-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack-ads",
-      "version": "1.37.2",
+      "version": "1.37.3-hotfix.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack-ads",
-  "version": "1.37.2",
+  "version": "1.37.3-hotfix.1",
   "author": "Automattic",
   "private": true,
   "scripts": {

--- a/src/blocks/ad-unit/edit.js
+++ b/src/blocks/ad-unit/edit.js
@@ -40,8 +40,8 @@ function Edit( { attributes, setAttributes } ) {
 	const provider = providers.find( p => p.id.toString() === attributes.provider );
 	const unit = provider?.units?.find( u => u.value.toString() === attributes.ad_unit );
 	const sizes = unit?.sizes || [];
-	const containerWidth = Math.max( ...sizes.map( s => s[ 0 ] ) ) || 300;
-	const containerHeight = Math.max( ...sizes.map( s => s[ 1 ] ) ) || 100;
+	const containerWidth = sizes.length ? Math.max( ...sizes.map( s => s[ 0 ] ) ) : 300;
+	const containerHeight = sizes.length ? Math.max( ...sizes.map( s => s[ 1 ] ) ) : 200;
 
 	useEffect( async () => {
 		// Legacy attribute.
@@ -94,23 +94,23 @@ function Edit( { attributes, setAttributes } ) {
 						className="newspack-ads-ad-block-placeholder"
 						style={ { width: containerWidth, height: containerHeight } }
 					>
-						{ sizes?.length > 0 && (
-							<Fragment>
-								<SVG
-									className="newspack-ads-ad-block-mock"
-									width={ containerWidth }
-									viewBox={ '0 0 ' + containerWidth + ' ' + containerHeight }
-								>
-									<rect width={ containerWidth } height={ containerHeight } strokeDasharray="2" />
-									<line x1="0" y1="0" x2="100%" y2="100%" strokeDasharray="2" />
-								</SVG>
-								<span className="newspack-ads-ad-block-ad-label">
-									{ providers.length > 1 && `${ provider.name } - ` } { unit.name }
-									<br />
-									{ sizes.map( size => `${ size[ 0 ] }x${ size[ 1 ] }` ).join( ', ' ) }
-								</span>
-							</Fragment>
-						) }
+						<Fragment>
+							<SVG
+								className="newspack-ads-ad-block-mock"
+								width={ containerWidth }
+								viewBox={ '0 0 ' + containerWidth + ' ' + containerHeight }
+							>
+								<rect width={ containerWidth } height={ containerHeight } strokeDasharray="2" />
+								<line x1="0" y1="0" x2="100%" y2="100%" strokeDasharray="2" />
+							</SVG>
+							<span className="newspack-ads-ad-block-ad-label">
+								{ providers.length > 1 && `${ provider.name } - ` } { unit.name }
+								<br />
+								{ sizes.length
+									? sizes.map( size => `${ size[ 0 ] }x${ size[ 1 ] }` ).join( ', ' )
+									: __( 'Unknown size', 'newspack-ads' ) }
+							</span>
+						</Fragment>
 						{ inFlight && <Spinner /> }
 					</div>
 				</Fragment>

--- a/src/frontend/style.scss
+++ b/src/frontend/style.scss
@@ -16,6 +16,7 @@
 
 .newspack_global_ad {
 	max-width: 100%;
+	flex: 1 1 auto;
 	&.fixed-height {
 		padding: 16px 0;
 		box-sizing: content-box;


### PR DESCRIPTION
Properly handle Broadstreet zones without a fixed size. It's currently assumed that all zones will have a size and it causes zones without size to be rendered with `width` set to `0`.

### How to test

1. Setup Broadstreet
2. Create a zone without a fixed size
3. Attach an ad to this zone through a campaign
4. Set this zone to an ad placement
5. Visit the page and make sure the ad is rendered