### PR TITLE
fix: usort() usage to return int instead of bool

### DIFF
--- a/includes/integrations/class-bidding-gam.php
+++ b/includes/integrations/class-bidding-gam.php
@@ -177,7 +177,7 @@ final class Bidding_GAM {
 					'batch'  => [
 						'sanitize_callback' => 'absint',
 					],
-					'fixing' => [ 
+					'fixing' => [
 						'sanitize_callback' => 'rest_sanitize_boolean',
 					],
 				],
@@ -232,7 +232,7 @@ final class Bidding_GAM {
 		);
 	}
 
-	
+
 
 	/**
 	 * Get a sanitized order config.
@@ -332,7 +332,7 @@ final class Bidding_GAM {
 			plugins_url( '../../dist/header-bidding-gam.js', __FILE__ ),
 			[ 'wp-components', 'wp-api-fetch' ],
 			filemtime( dirname( NEWSPACK_ADS_PLUGIN_FILE ) . '/dist/header-bidding-gam.js' ),
-			true 
+			true
 		);
 		wp_localize_script(
 			'newspack-ads-bidding-gam',
@@ -580,14 +580,14 @@ final class Bidding_GAM {
 						$orders_configs,
 						function( $order_config ) use ( $order ) {
 							return $order['id'] === $order_config['order_id'];
-						} 
+						}
 					);
 					if ( empty( $order_config ) ) {
 						return $order;
 					}
 					return array_merge( $order, array_shift( $order_config ) );
 				},
-				$orders 
+				$orders
 			);
 		} catch ( \Exception $e ) {
 			return new \WP_Error( 'newspack_ads_bidding_gam_error', $e->getMessage() );
@@ -635,7 +635,7 @@ final class Bidding_GAM {
 	 * @param int   $order_id The GAM Order ID.
 	 * @param array $data     The data to update with.
 	 *
-	 * @return bool|\WP_Error Whether the config was updated or WP_Error if order does not exist. 
+	 * @return bool|\WP_Error Whether the config was updated or WP_Error if order does not exist.
 	 */
 	private static function update_order_local_config( $order_id, $data ) {
 		if ( ! self::get_order_local_config( $order_id ) ) {
@@ -696,7 +696,7 @@ final class Bidding_GAM {
 
 		$config = self::get_order_local_config( $order_id );
 
-		if ( empty( $config ) || true === $fetch_remote ) { 
+		if ( empty( $config ) || true === $fetch_remote ) {
 			try {
 				$order = GAM_API::get_orders_by_id( [ $order_id ] );
 			} catch ( \Exception $e ) {
@@ -870,8 +870,8 @@ final class Bidding_GAM {
 		usort(
 			$buckets,
 			function( $a, $b ) {
-				return $a['max'] > $b['max'];
-			} 
+				return $a['max'] > $b['max'] ? 1 : -1;
+			}
 		);
 
 		// Assume all buckets share the same precision.

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -667,7 +667,7 @@ final class GAM_Model {
 			usort(
 				$sizes,
 				function( $a, $b ) {
-					return $a[0] * $a[1] < $b[0] * $b[1];
+					return $a[0] * $a[1] < $b[0] * $b[1] ? 1 : -1;
 				}
 			);
 			if ( ! isset( $attrs['layout'] ) ) {


### PR DESCRIPTION
This PR fixes the usage of `usort()` to return an integer instead of a boolean value.

Closes #498

### How to test

#### Header bidding with GAM

1. Setup GAM connection and header bidding support*
2. Create a new header bidding GAM order through Advertising -> Settings
3. Confirm the order is created without errors

* `define( 'NEWSPACK_EXPERIMENTAL_READER_ACTIVATION', true );` in your `wp-config.php` file

#### Ad unit slot rendering

1. Setup GAM with AMP and ad units containing multiple sizes for responsive ads
2. Visit the frontend and confirm the AMP ad renders as expected
3. Change your viewport and confirm the rendered ad is updated as expected
