### PR TITLE
fix: reorganize amp restricted settings

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -86,6 +86,7 @@ final class Core {
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/providers/gam/class-gam-model.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/providers/gam/class-gam-provider.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/providers/gam/class-gam-scripts.php';
+		include_once NEWSPACK_ADS_ABSPATH . '/includes/providers/gam/class-gam-lazy-loading.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/providers/broadstreet/class-broadstreet-provider.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-settings.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-custom-label.php';

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -86,7 +86,7 @@ final class Core {
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/providers/gam/class-gam-model.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/providers/gam/class-gam-provider.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/providers/gam/class-gam-scripts.php';
-		include_once NEWSPACK_ADS_ABSPATH . '/includes/providers/gam/class-gam-lazy-loading.php';
+		include_once NEWSPACK_ADS_ABSPATH . '/includes/providers/gam/class-gam-lazy-load.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/providers/broadstreet/class-broadstreet-provider.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-settings.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-custom-label.php';

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -168,44 +168,7 @@ final class Settings {
 	 * @return array Indexed or associative array of configured settings grouped by section name.
 	 */
 	public static function get_settings_list( $assoc = false ) {
-		$settings_list = array(
-			array(
-				'description' => __( 'Lazy Loading', 'newspack-ads' ),
-				'help'        => __( 'Enables pages to load faster, reduces resource consumption and contention, and improves viewability rate.', 'newspack-ads' ),
-				'section'     => 'lazy_load',
-				'key'         => 'active',
-				'type'        => 'boolean',
-				'default'     => true,
-				'public'      => true,
-			),
-			array(
-				'description' => __( 'Fetch margin percent', 'newspack-ads' ),
-				'help'        => __( 'Minimum distance from the current viewport a slot must be before we fetch the ad as a percentage of viewport size.', 'newspack-ads' ),
-				'section'     => 'lazy_load',
-				'key'         => 'fetch_margin_percent',
-				'type'        => 'int',
-				'default'     => 100,
-				'public'      => true,
-			),
-			array(
-				'description' => __( 'Render margin percent', 'newspack-ads' ),
-				'help'        => __( 'Minimum distance from the current viewport a slot must be before we render an ad.', 'newspack-ads' ),
-				'section'     => 'lazy_load',
-				'key'         => 'render_margin_percent',
-				'type'        => 'int',
-				'default'     => 0,
-				'public'      => true,
-			),
-			array(
-				'description' => __( 'Mobile scaling', 'newspack-ads' ),
-				'help'        => __( 'A multiplier applied to margins on mobile devices. This allows varying margins on mobile vs. desktop.', 'newspack-ads' ),
-				'section'     => 'lazy_load',
-				'key'         => 'mobile_scaling',
-				'type'        => 'float',
-				'default'     => 2,
-				'public'      => true,
-			),
-		);
+		$settings_list = [];
 
 		$default_setting = array(
 			'section' => '',

--- a/includes/integrations/class-ad-refresh-control.php
+++ b/includes/integrations/class-ad-refresh-control.php
@@ -150,21 +150,21 @@ class Ad_Refresh_Control {
 	 * @return WP_REST_Response The response.
 	 */
 	public static function api_get_settings() {
-		if ( Core::is_amp() ) {
-			return new \WP_Error(
-				'newspack_ad_refresh_control_amp',
-				__( 'AMP pages not supported', 'newspack-ads' ),
-				[
-					'status' => 400,
-				]
-			);
-		}
 		if ( ! self::is_active() ) {
 			return new \WP_Error(
 				'newspack_ad_refresh_control_not_active',
 				__( 'The "Ad Refresh Control" plugin is not active.', 'newspack-ads' ),
 				[
 					'status' => 404,
+				]
+			);
+		}
+		if ( Core::is_amp() ) {
+			return new \WP_Error(
+				'newspack_ad_refresh_control_amp',
+				__( 'AMP not supported', 'newspack-ads' ),
+				[
+					'status' => 400,
 				]
 			);
 		}

--- a/includes/integrations/class-ad-refresh-control.php
+++ b/includes/integrations/class-ad-refresh-control.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Newspack Ads "Ad Refresh Control" Plugin Settings
- * 
+ *
  * @link https://wordpress.org/plugins/ad-refresh-control/
  *
  * @package Newspack
@@ -9,6 +9,7 @@
 
 namespace Newspack_Ads\Integrations;
 
+use Newspack_Ads\Core;
 use Newspack_Ads\Settings;
 
 defined( 'ABSPATH' ) || exit;
@@ -149,10 +150,19 @@ class Ad_Refresh_Control {
 	 * @return WP_REST_Response The response.
 	 */
 	public static function api_get_settings() {
+		if ( Core::is_amp() ) {
+			return new \WP_Error(
+				'newspack_ad_refresh_control_amp',
+				__( 'AMP pages not supported', 'newspack-ads' ),
+				[
+					'status' => 400,
+				]
+			);
+		}
 		if ( ! self::is_active() ) {
 			return new \WP_Error(
 				'newspack_ad_refresh_control_not_active',
-				__( 'The "Ad Refresh Control" plugin is not active.', 'newspack' ),
+				__( 'The "Ad Refresh Control" plugin is not active.', 'newspack-ads' ),
 				[
 					'status' => 404,
 				]

--- a/includes/providers/gam/class-gam-lazy-load.php
+++ b/includes/providers/gam/class-gam-lazy-load.php
@@ -13,7 +13,7 @@ use Newspack_Ads\Settings;
 /**
  * Newspack Ads GAM Lazy Loading Class.
  */
-final class GAM_Lazy_Loading {
+final class GAM_Lazy_Load {
 
 	const SECTION = 'lazy_load';
 	/**
@@ -105,4 +105,4 @@ final class GAM_Lazy_Loading {
 		<?php
 	}
 }
-GAM_Lazy_Loading::init();
+GAM_Lazy_Load::init();

--- a/includes/providers/gam/class-gam-lazy-loading.php
+++ b/includes/providers/gam/class-gam-lazy-loading.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Newspack Ads GAM Lazy Loading Settings.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Ads\Providers;
+
+use Newspack_Ads\Core;
+use Newspack_Ads\Settings;
+
+/**
+ * Newspack Ads GAM Lazy Loading Class.
+ */
+final class GAM_Lazy_Loading {
+
+	const SECTION = 'lazy_load';
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_action( 'newspack_ads_settings_list', [ __CLASS__, 'register_settings' ] );
+		add_action( 'newspack_ads_gtag_before_script', [ __CLASS__, 'render_lazy_load_script' ] );
+	}
+
+	/**
+	 * Register GAM Lazy Loading settings.
+	 *
+	 * @param array $settings_list List of settings.
+	 *
+	 * @return array Updated list of settings.
+	 */
+	public static function register_settings( $settings_list ) {
+		if ( Core::is_amp() ) {
+			return $settings_list;
+		}
+		return array_merge(
+			[
+				[
+					'description' => __( 'Lazy Loading', 'newspack-ads' ),
+					'help'        => __( 'Enables pages to load faster, reduces resource consumption and contention, and improves viewability rate.', 'newspack-ads' ),
+					'section'     => self::SECTION,
+					'key'         => 'active',
+					'type'        => 'boolean',
+					'default'     => true,
+					'public'      => true,
+				],
+				[
+					'description' => __( 'Fetch margin percent', 'newspack-ads' ),
+					'help'        => __( 'Minimum distance from the current viewport a slot must be before we fetch the ad as a percentage of viewport size.', 'newspack-ads' ),
+					'section'     => self::SECTION,
+					'key'         => 'fetch_margin_percent',
+					'type'        => 'int',
+					'default'     => 100,
+					'public'      => true,
+				],
+				[
+					'description' => __( 'Render margin percent', 'newspack-ads' ),
+					'help'        => __( 'Minimum distance from the current viewport a slot must be before we render an ad.', 'newspack-ads' ),
+					'section'     => self::SECTION,
+					'key'         => 'render_margin_percent',
+					'type'        => 'int',
+					'default'     => 0,
+					'public'      => true,
+				],
+				[
+					'description' => __( 'Mobile scaling', 'newspack-ads' ),
+					'help'        => __( 'A multiplier applied to margins on mobile devices. This allows varying margins on mobile vs. desktop.', 'newspack-ads' ),
+					'section'     => self::SECTION,
+					'key'         => 'mobile_scaling',
+					'type'        => 'float',
+					'default'     => 2,
+					'public'      => true,
+				],
+			],
+			$settings_list
+		);
+	}
+
+	/**
+	 * Render lazy loading script.
+	 */
+	public static function render_lazy_load_script() {
+		if ( Core::is_amp() ) {
+			return;
+		}
+		$settings = Settings::get_settings( 'lazy_load', true );
+		if ( ! $settings['active'] ) {
+			return;
+		}
+		?>
+		<script data-amp-plus-allowed>
+			( function() {
+				var lazy_load = <?php echo wp_json_encode( $settings, JSON_FORCE_OBJECT ); ?>;
+				googletag.cmd.push( function() {
+					googletag.pubads().enableLazyLoad( {
+						fetchMarginPercent: lazy_load.fetch_margin_percent,
+						renderMarginPercent: lazy_load.render_margin_percent,
+						mobileScaling: lazy_load.mobile_scaling
+					} );
+				} );
+			} )();
+		</script>
+		<?php
+	}
+}
+GAM_Lazy_Loading::init();

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -163,7 +163,6 @@ final class GAM_Scripts {
 			( function() {
 				var ad_config        = <?php echo wp_json_encode( $ad_config ); ?>;
 				var all_ad_units     = <?php echo wp_json_encode( $prepared_unit_data ); ?>;
-				var lazy_load        = <?php echo wp_json_encode( Settings::get_settings( 'lazy_load', true ), JSON_FORCE_OBJECT ); ?>;
 				var common_targeting = <?php echo wp_json_encode( $common_targeting ); ?>;
 				var defined_ad_units = {};
 
@@ -321,13 +320,6 @@ final class GAM_Scripts {
 					}
 					googletag.pubads().collapseEmptyDivs();
 					googletag.pubads().enableSingleRequest();
-					if ( lazy_load && lazy_load.active ) {
-						googletag.pubads().enableLazyLoad( {
-							fetchMarginPercent: lazy_load.fetch_margin_percent,
-							renderMarginPercent: lazy_load.render_margin_percent,
-							mobileScaling: lazy_load.mobile_scaling
-						} );
-					}
 					googletag.enableServices();
 
 					for ( var container_id in defined_ad_units ) {


### PR DESCRIPTION
For better maintainability, this PR moves the GAM lazy load settings to its own class and script. It also hides settings that are not supported under AMP.

Closes #494 

### How to test

1. Visit the Advertising -> Add-Ons and make sure "Ad Refresh Control" is active
2. Make sure AMP is on (without AMP Plus) and visit "Advertising -> Settings"
3. Confirm you only see the "Custom Ad Label" section (or SCAIP settings as well, if installed)
4. Enable AMP Plus, refresh the page and confirm you also see Lazy Load and Refresh Control sections

#### Lazy load refactor

1. With AMP Plus on, enable lazy load and tweak the settings
2. Place some ad units and visit the frontend
3. Inspect the DOM and search for `lazy_load` and confirm you see this script rendered:

```js
			( function() {
				var lazy_load = {"active":true,"fetch_margin_percent":100,"render_margin_percent":0,"mobile_scaling":2};
				googletag.cmd.push( function() {
					googletag.pubads().enableLazyLoad( {
						fetchMarginPercent: lazy_load.fetch_margin_percent,
						renderMarginPercent: lazy_load.render_margin_percent,
						mobileScaling: lazy_load.mobile_scaling
					} );
				} );
			} )();
```