### PR TITLE
feat(gam): ad block recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.38.0-hotfix.1](https://github.com/Automattic/newspack-ads/compare/v1.37.3...v1.38.0-hotfix.1) (2022-09-14)
+
+
+### Features
+
+* **gam:** ad block recovery ([7a01501](https://github.com/Automattic/newspack-ads/commit/7a01501947f29c5a2fafc5201ca98d0763c97582))
+
 ## [1.37.3](https://github.com/Automattic/newspack-ads/compare/v1.37.2...v1.37.3) (2022-08-11)
 
 

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -86,6 +86,7 @@ final class Core {
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/providers/gam/class-gam-model.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/providers/gam/class-gam-provider.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/providers/gam/class-gam-scripts.php';
+		include_once NEWSPACK_ADS_ABSPATH . '/includes/providers/gam/class-gam-ad-block-recovery.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/providers/broadstreet/class-broadstreet-provider.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-settings.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-custom-label.php';

--- a/includes/providers/gam/class-gam-ad-block-recovery.php
+++ b/includes/providers/gam/class-gam-ad-block-recovery.php
@@ -75,7 +75,7 @@ final class GAM_Ad_Block_Recovery {
 			return;
 		}
 		$settings = Settings::get_settings( self::SECTION, true );
-		if ( ! $settings['active'] || empty( $settings['pub'] || empty( $settings['nonce'] ) ) ) {
+		if ( ! $settings['active'] || empty( $settings['pub'] ) || empty( $settings['nonce'] ) ) {
 			return;
 		}
 		?>

--- a/includes/providers/gam/class-gam-ad-block-recovery.php
+++ b/includes/providers/gam/class-gam-ad-block-recovery.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Newspack Ads GAM Ad Block Recovery Settings.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Ads\Providers;
+
+use Newspack_Ads\Core;
+use Newspack_Ads\Settings;
+
+/**
+ * Newspack Ads GAM Ad Block Recovery Class.
+ */
+final class GAM_Ad_Block_Recovery {
+
+	const SECTION = 'gam_ad_block_recovery';
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_action( 'newspack_ads_settings_list', [ __CLASS__, 'register_settings' ] );
+		add_action( 'newspack_ads_gtag_before_script', [ __CLASS__, 'render_script' ] );
+	}
+
+	/**
+	 * Register GAM Ad Block Recovery settings.
+	 *
+	 * @param array $settings_list List of settings.
+	 *
+	 * @return array Updated list of settings.
+	 */
+	public static function register_settings( $settings_list ) {
+		if ( Core::is_amp() ) {
+			return $settings_list;
+		}
+		return array_merge(
+			[
+				[
+					'description' => __( 'Ad Block Recovery', 'newspack-ads' ),
+					'help'        => __( 'Implement Ad Block Recovery functionality provided by Google Ad Manager', 'newspack-ads' ),
+					'section'     => self::SECTION,
+					'key'         => 'active',
+					'type'        => 'boolean',
+					'default'     => false,
+					'public'      => true,
+				],
+				[
+					'description' => __( 'Pub', 'newspack-ads' ),
+					'help'        => __( 'Numeric value after "pub-", provided by GAM. E.g.: 1234567891011121', 'newspack-ads' ),
+					'section'     => self::SECTION,
+					'key'         => 'pub',
+					'type'        => 'string',
+					'public'      => true,
+				],
+				[
+					'description' => __( 'Nonce', 'newspack-ads' ),
+					'help'        => __( '"Nonce" value provided by GAM. E.g.: Ab3De6GhiJklMnoPqRstUV', 'newspack-ads' ),
+					'section'     => self::SECTION,
+					'key'         => 'nonce',
+					'type'        => 'string',
+					'public'      => true,
+				],
+			],
+			$settings_list
+		);
+	}
+
+	/**
+	 * Render Ad Block Recovery script.
+	 */
+	public static function render_script() {
+		if ( Core::is_amp() ) {
+			return;
+		}
+		$settings = Settings::get_settings( self::SECTION, true );
+		if ( ! $settings['active'] || empty( $settings['pub'] || empty( $settings['nonce'] ) ) ) {
+			return;
+		}
+		?>
+		<script data-amp-plus-allowed async src="https://fundingchoicesmessages.google.com/i/pub-<?php echo \esc_attr( $settings['pub'] ); ?>?ers=1" nonce="<?php echo \esc_attr( $settings['nonce'] ); ?>"></script>
+		<script data-amp-plus-allowed nonce="<?php echo \esc_attr( $settings['nonce'] ); ?>">
+			( function() {
+				function signalGooglefcPresent() {
+					if ( !window.frames['googlefcPresent'] ) {
+						if ( document.body ) {
+							const iframe = document.createElement( 'iframe' );
+							iframe.style = 'width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;';
+							iframe.style.display = 'none';
+							iframe.name = 'googlefcPresent';
+							document.body.appendChild( iframe );
+						} else {
+							setTimeout( signalGooglefcPresent, 0 );
+						}
+					}
+				}
+				signalGooglefcPresent();
+			} )();
+		</script>
+		<?php
+	}
+}
+GAM_Ad_Block_Recovery::init();

--- a/newspack-ads.php
+++ b/newspack-ads.php
@@ -5,7 +5,7 @@
  * Description:     Ad services integration.
  * Author:          Automattic
  * License:         GPL2
- * Version:         1.37.3
+ * Version:         1.38.0-hotfix.1
  *
  * @package         Newspack
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack-ads",
-  "version": "1.37.3",
+  "version": "1.38.0-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack-ads",
-      "version": "1.37.3",
+      "version": "1.38.0-hotfix.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack-ads",
-  "version": "1.37.3",
+  "version": "1.38.0-hotfix.1",
   "author": "Automattic",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Implements GAM's Ad Block Recovery messaging, provided by Funding Choices.

Closes #505 

### How to test this PR

Since Funding Choices require URL approval, there's no way of testing the rendering of the recovery messaging.

1. Make sure you have AMP on and AMP Plus **off**
2. Visit the Advertising -> Settings wizard
3. Confirm you **can't** see the "Ad Block Recovery" section
4. Enable AMP Plus
5. Refresh the settings and confirm the new section
6. Enable the section, paste and save the following values for `pub` and `nonce` respectively:
   1. `8706684637650171`
   2. `MNc-oZaqRW2VBOls3yFxoA`
7. Visit the frontend, inspect the page and search for the `pub` value
8. Confirm you see the rendered script:

```html
<script data-amp-plus-allowed="" async="" src="https://fundingchoicesmessages.google.com/i/pub-8706684637650171?ers=1" nonce="MNc-oZaqRW2VBOls3yFxoA" data-amp-unvalidated-tag=""></script>
<script data-amp-plus-allowed="" nonce="MNc-oZaqRW2VBOls3yFxoA" data-amp-unvalidated-tag="">
			( function() {
				function signalGooglefcPresent() {
					if ( !window.frames['googlefcPresent'] ) {
						if ( document.body ) {
							const iframe = document.createElement( 'iframe' );
							iframe.style = 'width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;';
							iframe.style.display = 'none';
							iframe.name = 'googlefcPresent';
							document.body.appendChild( iframe );
						} else {
							setTimeout( signalGooglefcPresent, 0 );
						}
					}
				}
				signalGooglefcPresent();
			} )();
</script>
```
9. Back to the settings, leave nonce or pub empty, and save
10. Refresh the frontend and confirm the script is not rendered