### PR TITLE
fix: handle empty settings section

### DIFF
--- a/includes/providers/gam/class-gam-ad-block-recovery.php
+++ b/includes/providers/gam/class-gam-ad-block-recovery.php
@@ -75,6 +75,9 @@ final class GAM_Ad_Block_Recovery {
 			return;
 		}
 		$settings = Settings::get_settings( self::SECTION, true );
+		if ( empty( $settings ) ) {
+			return;
+		}
 		if ( ! $settings['active'] || empty( $settings['pub'] ) || empty( $settings['nonce'] ) ) {
 			return;
 		}


### PR DESCRIPTION
If never saved, the value of `$settings` here may be empty. In this case, the `$settings['active']` check will cause a PHP notice to be logged. 