### PR TITLE
fix: handle zero in ad unit size gracefully

### DIFF
--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -740,8 +740,11 @@ final class GAM_Model {
 			foreach ( $sizes as $size ) {
 				$is_in_viewport     = $size[0] <= $viewport_width;
 				$is_above_threshold = false !== $width_threshold && $width_threshold <= $size[0];
-				$diff               = min( $viewport_width, $size[0] ) / max( $viewport_width, $size[0] );
-				$is_within_ratio    = ( 1 - $width_diff_ratio ) <= $diff;
+				if ( 0 == $size[0] ) {
+					continue;
+				}
+				$diff            = min( $viewport_width, $size[0] ) / max( $viewport_width, $size[0] );
+				$is_within_ratio = ( 1 - $width_diff_ratio ) <= $diff;
 				if ( $is_in_viewport && ( $is_within_ratio || $is_above_threshold ) ) {
 					$size_map[ $viewport_width ][] = $size;
 				}

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -740,7 +740,7 @@ final class GAM_Model {
 			foreach ( $sizes as $size ) {
 				$is_in_viewport     = $size[0] <= $viewport_width;
 				$is_above_threshold = false !== $width_threshold && $width_threshold <= $size[0];
-				if ( 0 == $size[0] ) {
+				if ( 0 === $size[0] ) {
 					continue;
 				}
 				$diff            = min( $viewport_width, $size[0] ) / max( $viewport_width, $size[0] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue with `0x0` ad unit size, which is possible to create. 

### How to test the changes in this Pull Request:

1. Create an ad unit with size of 0 by 0
2. Use it in a placement
3. On `master`, observe a PHP Warning about division by zero logged
4. Switch to this branch, observe no warning 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->