### PR TITLE
fix(gam): identify insufficient permissions

### DIFF
--- a/includes/providers/gam/class-gam-api.php
+++ b/includes/providers/gam/class-gam-api.php
@@ -128,6 +128,9 @@ final class GAM_API {
 		if ( in_array( 'CommonError.CONCURRENT_MODIFICATION', $errors ) ) {
 			$error_message = __( 'Unexpected API error, please try again in 30 seconds.', 'newspack-ads' );
 		}
+		if ( in_array( 'PermissionError.PERMISSION_DENIED', $errors ) ) {
+			$error_message = __( 'You do not have permission to perform this action. Make sure to connect an account with administrative access.', 'newspack-ads' );
+		}
 		return new \WP_Error(
 			'newspack_ads_gam_error',
 			$error_message ?? __( 'An unexpected error occurred', 'newspack-ads' ),
@@ -311,7 +314,6 @@ final class GAM_API {
 			]
 		);
 		self::$session = ( new AdManagerSessionBuilder() )->from( $config )->withOAuth2Credential( $oauth2_credentials )->build();
-
 		return self::$session;
 	}
 


### PR DESCRIPTION
Adds "permission denied" to the supported types of generic error messages on GAM.

Ideally, we should be able to detect the authenticated session permissions beforehand so the user can address the issue immediately. I could not identify a solution [through Google's SDK](https://github.com/googleads/googleads-php-lib/blob/58.0.0/src/Google/AdsApi/AdManager/AdManagerSession.php) to implement such a feature.

This PR will just handle the error message if a privileged request is denied.

### How to test

1. Create a new service account with the role "Sales manager" (ping me if you'd like to use mine)
2. Connect to GAM using the service account JSON credentials
3. Attempt to edit/create an ad unit
4. Confirm you receive a comprehensive error message