### PR TITLE
feat(gam): sync default ad units

### DIFF
--- a/includes/providers/gam/api/class-ad-units.php
+++ b/includes/providers/gam/api/class-ad-units.php
@@ -94,7 +94,8 @@ final class Ad_Units extends Api_Object {
 	 * Get all GAM Ad Units in the user's network, serialized.
 	 *
 	 * @param int[] $ids Optional array of ad unit ids.
-	 * @return object[] Array of serialized ad units.
+	 *
+	 * @return array[] Array of serialized ad units.
 	 */
 	public function get_serialized_ad_units( $ids = [] ) {
 		try {
@@ -113,7 +114,8 @@ final class Ad_Units extends Api_Object {
 	 * Serialize Ad Unit.
 	 *
 	 * @param AdUnit $gam_ad_unit An AdUnit.
-	 * @return object Ad Unit configuration.
+	 *
+	 * @return array Ad Unit configuration.
 	 */
 	private function get_serialized_ad_unit( $gam_ad_unit ) {
 		$ad_unit = [

--- a/includes/providers/gam/api/class-ad-units.php
+++ b/includes/providers/gam/api/class-ad-units.php
@@ -39,16 +39,18 @@ final class Ad_Units extends Api_Object {
 	/**
 	 * Create a statement builder for ad unit retrieval.
 	 *
-	 * @param int[] $ids Optional array of ad unit ids.
+	 * @param int[]   $ids              Optional array of ad unit ids.
+	 * @param boolean $include_archived Whether to include archived ad units.
+	 *
 	 * @return StatementBuilder Statement builder.
 	 */
-	private static function get_statement_builder( $ids = [] ) {
+	private static function get_statement_builder( $ids = [], $include_archived = false ) {
 		// Get all non-archived ad units, unless ids are specified.
 		$statement_builder = new StatementBuilder();
-		if ( empty( $ids ) ) {
-			$statement_builder = $statement_builder->where( "Status IN('ACTIVE')" );
-		} else {
-			$statement_builder = $statement_builder->where( 'ID IN(' . implode( ', ', $ids ) . ')' );
+		if ( ! empty( $ids ) ) {
+			$statement_builder->where( 'ID IN(' . implode( ', ', $ids ) . ')' );
+		} elseif ( ! $include_archived ) {
+			$statement_builder->where( "Status IN('ACTIVE')" );
 		}
 		$statement_builder->orderBy( 'name ASC' )->limit( StatementBuilder::SUGGESTED_PAGE_LIMIT );
 		return $statement_builder;
@@ -58,12 +60,14 @@ final class Ad_Units extends Api_Object {
 	 * Get all GAM Ad Units in the user's network.
 	 * If $ids parameter is not specified, will return all ad units found.
 	 *
-	 * @param int[] $ids Optional array of ad unit ids.
+	 * @param int[]   $ids              Optional array of ad unit ids.
+	 * @param boolean $include_archived Whether to include archived ad units.
+	 *
 	 * @return AdUnit[] Array of AdUnits.
 	 */
-	private function get_ad_units( $ids = [] ) {
+	private function get_ad_units( $ids = [], $include_archived = false ) {
 		$gam_ad_units      = [];
-		$statement_builder = self::get_statement_builder( $ids );
+		$statement_builder = self::get_statement_builder( $ids, $include_archived );
 		$inventory_service = $this->get_inventory_service();
 
 		// Retrieve a small amount of items at a time, paging through until all items have been retrieved.
@@ -93,13 +97,14 @@ final class Ad_Units extends Api_Object {
 	/**
 	 * Get all GAM Ad Units in the user's network, serialized.
 	 *
-	 * @param int[] $ids Optional array of ad unit ids.
+	 * @param int[]   $ids              Optional array of ad unit ids.
+	 * @param boolean $include_archived Whether to include archived ad units.
 	 *
 	 * @return array[] Array of serialized ad units.
 	 */
-	public function get_serialized_ad_units( $ids = [] ) {
+	public function get_serialized_ad_units( $ids = [], $include_archived = false ) {
 		try {
-			$ad_units            = $this->get_ad_units( $ids );
+			$ad_units            = $this->get_ad_units( $ids, $include_archived );
 			$ad_units_serialised = [];
 			foreach ( $ad_units as $ad_unit ) {
 				$ad_units_serialised[] = $this->get_serialized_ad_unit( $ad_unit );

--- a/includes/providers/gam/api/class-api.php
+++ b/includes/providers/gam/api/class-api.php
@@ -130,20 +130,24 @@ class Api {
 				$errors[] = $error->getErrorString();
 			}
 		}
-		if ( in_array( 'UniqueError.NOT_UNIQUE', $errors ) ) {
-			$error_message = __( 'Name must be unique.', 'newspack-ads' );
-		}
-		if ( in_array( 'CommonError.CONCURRENT_MODIFICATION', $errors ) ) {
-			$error_message = __( 'Unexpected API error, please try again in 30 seconds.', 'newspack-ads' );
-		}
-		if ( in_array( 'PermissionError.PERMISSION_DENIED', $errors ) ) {
-			$error_message = __( 'You do not have permission to perform this action. Make sure to connect an account with administrative access.', 'newspack-ads' );
-		}
-		if ( in_array( 'AuthenticationError.NETWORK_API_ACCESS_DISABLED', $errors ) ) {
-			$network_code  = $this->get_network_code();
-			$settings_link = "https://admanager.google.com/${network_code}#admin/settings/network";
-			$error_message = __( 'API access for this GAM account is disabled.', 'newspack-ads' ) .
-			" <a href=\"${settings_link}\">" . __( 'Enable API access in your GAM settings.', 'newspack' ) . '</a>';
+		$network_code = $this->get_network_code();
+		$message_map  = [
+			'UniqueError.NOT_UNIQUE'                => __( 'Name must be unique.', 'newspack-ads' ),
+			'CommonError.CONCURRENT_MODIFICATION'   => __( 'Unexpected API error, please try again in 30 seconds.', 'newspack-ads' ),
+			'PermissionError.PERMISSION_DENIED'     => __( 'You do not have permission to perform this action. Make sure to connect an account with administrative access.', 'newspack-ads' ),
+			'AuthenticationError.NETWORK_NOT_FOUND' => __( 'The network code is invalid.', 'newspack-ads' ),
+			'AuthenticationError.NETWORK_API_ACCESS_DISABLED' => sprintf(
+				'%s <a href="%s" target="_blank">%s</a>',
+				__( 'API access for this GAM account is disabled.', 'newspack-ads' ),
+				"https://admanager.google.com/${network_code}#admin/settings/network",
+				__( 'Enable API access in your GAM settings.', 'newspack-ads' )
+			),
+		];
+		foreach ( $message_map as $error_type => $message ) {
+			if ( in_array( $error_type, $errors, true ) ) {
+				$error_message = $message;
+				break;
+			}
 		}
 		return new \WP_Error(
 			'newspack_ads_gam_error',

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -321,7 +321,7 @@ final class GAM_Model {
 			$api          = self::get_api();
 			if ( $api ) {
 				foreach ( $ad_units as $ad_unit_key => $ad_unit_config ) {
-					/** Only sync units that doesn't yet have an ID. */
+					/** Only sync units that don't yet have an ID. */
 					if ( ! empty( $ad_unit_config['id'] ) ) {
 						continue;
 					}


### PR DESCRIPTION
Default GAM ad units are currently treated as a static configuration. They are available for usage but are not located in any database or synced to GAM.

This PR implements GAM synchronization if possible. In case a GAM connection is not available, the default static behavior is preserved.

Closes #454

### How to test

1. Make sure your instance is disconnected from GAM
2. Check out this branch and visit the Advertising dashboard
3. Confirm you can use the static default ad units
4. Connect your instance with GAM
5. Visit the ad units configuration and confirm the units are no longer "default units" and you can edit them
6. Visit your GAM dashboard and confirm the units are created
7. Disconnect from GAM again
8. Confirm the default units are still treated as GAM items, but "Disconnected from GAM"