### PR TITLE
fix(placements): remove deprecated option handling

### DIFF
--- a/includes/class-placements.php
+++ b/includes/class-placements.php
@@ -292,17 +292,6 @@ final class Placements {
 			]
 		);
 
-		/**
-		 * Handle deprecated option name.
-		 */
-		$deprecated_option_name = '_newspack_advertising_placement_' . $placement_key;
-		$deprecated             = get_option( $deprecated_option_name );
-		if ( $deprecated ) {
-			delete_option( $deprecated_option_name );
-			update_option( self::get_option_name( $placement_key ), $deprecated );
-			return json_decode( $deprecated, true );
-		}
-
 		$data = wp_parse_args(
 			json_decode( get_option( self::get_option_name( $placement_key ) ), true ) ?? [],
 			$default_data


### PR DESCRIPTION
This PR removes the handling of a deprecated option name. This has been up for almost 1 year and automatically migrating placement data if the deprecated option is found.

It's safe to remove this and stop querying the database with non-existing options.

## How to test

No change should take place, ad placements should continue to render as expected.