### PR TITLE
fix(gam): validate api session

### DIFF
--- a/includes/providers/gam/api/class-api.php
+++ b/includes/providers/gam/api/class-api.php
@@ -221,7 +221,7 @@ class Api {
 	 * @throws \Exception If not able to fetch networks.
 	 */
 	public function get_serialized_networks() {
-		$networks = $this->get_networks();
+		$networks = $this->get_networks() ?? [];
 		return array_map(
 			function( $network ) {
 				return [

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -76,7 +76,7 @@ final class GAM_Model {
 	 * @return GAM_Api|false The GAM API, or false if unable to initialized.
 	 */
 	public static function get_api() {
-		if ( self::$api ) {
+		if ( isset( self::$api ) ) {
 			return self::$api;
 		}
 
@@ -97,8 +97,10 @@ final class GAM_Model {
 
 		try {
 			self::$api = new GAM_Api( $auth_method, $credentials, $network_code );
+			/** Test the connection once to ensure the session has GAM connection. */
+			self::$api->get_current_user();
 		} catch ( \Exception $e ) {
-			return false;
+			self::$api = false;
 		}
 
 		return self::$api;
@@ -406,11 +408,13 @@ final class GAM_Model {
 		if ( $sync && ! self::$synced ) {
 			// Only sync once per execution.
 			if ( self::is_api_connected() ) {
-				$api          = self::get_api();
-				$gam_ad_units = $api->ad_units->get_serialized_ad_units();
-				if ( ! \is_wp_error( $gam_ad_units ) && ! empty( $gam_ad_units ) ) {
-					self::sync_gam_settings( $gam_ad_units );
-					self::$synced = true;
+				$api = self::get_api();
+				if ( $api ) {
+					$gam_ad_units = $api->ad_units->get_serialized_ad_units();
+					if ( ! \is_wp_error( $gam_ad_units ) && ! empty( $gam_ad_units ) ) {
+						self::sync_gam_settings( $gam_ad_units );
+						self::$synced = true;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This PR ensures that the API session is valid before attempting to fetch objects.

### How to test

1. Make sure you are on the **master** branch
2. Connect through Service Account or OAuth with an account that doesn't have access to any GAM account
3. Visit the Advertising wizard and confirm the fatal error
4. Visit the WP's Customizer and also confirm the fatal error
5. Check out this branch, refresh the wizard and the Customizer
6. Confirm there are no fatal errors and GAM is being treated as disconnected/unavailable

In the future, we can handle messaging to notify that the session doesn't connect to any GAM account. For now, let's just avoid the fatal errors.