### PR TITLE
fix(gam): ensure api requests are made with network code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.39.4-hotfix.1](https://github.com/Automattic/newspack-ads/compare/v1.39.3...v1.39.4-hotfix.1) (2022-11-11)
+
+
+### Bug Fixes
+
+* **gam:** ensure api requests are made with network code ([d4a85a3](https://github.com/Automattic/newspack-ads/commit/d4a85a3f122e95dc184ce1fda3ae1f2c20e176c0))
+
 ## [1.39.3](https://github.com/Automattic/newspack-ads/compare/v1.39.2...v1.39.3) (2022-11-11)
 
 

--- a/includes/providers/gam/api/class-api.php
+++ b/includes/providers/gam/api/class-api.php
@@ -177,15 +177,21 @@ class Api {
 		if ( $this->session ) {
 			return $this->session;
 		}
-		$config        = new Configuration(
-			[
-				'AD_MANAGER' => [
-					'applicationName' => self::APP,
-					'networkCode'     => $this->network_code ?? '-',
-				],
-			]
-		);
-		$this->session = ( new AdManagerSessionBuilder() )->from( $config )->withOAuth2Credential( $this->credentials )->build();
+		$config = [
+			'AD_MANAGER' => [
+				'applicationName' => self::APP,
+			],
+		];
+		/** If a network code is not yet available, use first from list. */
+		if ( ! $this->network_code ) {
+			$session  = ( new AdManagerSessionBuilder() )->from( new Configuration( $config ) )->withOAuth2Credential( $this->credentials )->build();
+			$networks = $this->get_networks( $session );
+			if ( ! empty( $networks ) ) {
+				$this->network_code = $networks[0]->getNetworkCode();
+			}
+		}
+		$config['AD_MANAGER']['networkCode'] = $this->network_code;
+		$this->session                       = ( new AdManagerSessionBuilder() )->from( new Configuration( $config ) )->withOAuth2Credential( $this->credentials )->build();
 		return $this->session;
 	}
 
@@ -201,11 +207,16 @@ class Api {
 	/**
 	 * Get GAM networks the authenticated user has access to.
 	 *
+	 * @param AdManagerSession $session Optional session to use.
+	 *
 	 * @return Network[] Array of networks.
 	 */
-	private function get_networks() {
+	private function get_networks( $session = null ) {
+		if ( empty( $session ) ) {
+			$session = $this->get_session();
+		}
 		if ( empty( $this->networks ) ) {
-			$this->networks = ( new ServiceFactory() )->createNetworkService( $this->session )->getAllNetworks();
+			$this->networks = ( new ServiceFactory() )->createNetworkService( $session )->getAllNetworks();
 		}
 		return $this->networks;
 	}

--- a/newspack-ads.php
+++ b/newspack-ads.php
@@ -5,7 +5,7 @@
  * Description:     Ad services integration.
  * Author:          Automattic
  * License:         GPL2
- * Version:         1.39.3
+ * Version:         1.39.4-hotfix.1
  *
  * @package         Newspack
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "newspack-ads",
-  "version": "1.39.3",
+  "version": "1.39.4-hotfix.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "newspack-ads",
-      "version": "1.39.3",
+      "version": "1.39.4-hotfix.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newspack-ads",
-  "version": "1.39.3",
+  "version": "1.39.4-hotfix.1",
   "author": "Automattic",
   "private": true,
   "scripts": {


### PR DESCRIPTION
#551 surfaced an issue in which the network code for a GAM session may not always be available and they are required for most requests.

This PR ensures that if a network code is not yet set, it'll fetch from the top of the list to fulfill required requests.

The issue only occurs for fresh instances connecting GAM for the first time because the network code is not yet known.

### How to test

1. Make sure you're on the `release` branch
2. On a fresh install, upload a **valid** GAM service account credential
3. Confirm nothing happened (the request that validates the session couldn't fulfill because the network code is not yet known)
4. Check out this branch and confirm it's connected