### PR TITLE
feat(marketplace): product creation

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -150,6 +150,17 @@ install_db() {
 	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
 }
 
+install_deps() {
+	cd "$WP_CORE_DIR"
+	curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+
+	php wp-cli.phar core config --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --dbprefix=wptests_
+	php wp-cli.phar core install --url="$WP_SITE_URL" --title="Example" --admin_user=admin --admin_password=password --admin_email=info@example.com --path=$WP_CORE_DIR --skip-email
+
+	php wp-cli.phar plugin install woocommerce --activate
+}
+
 install_wp
 install_test_suite
 install_db
+install_deps

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -147,6 +147,7 @@ install_db() {
 	fi
 
 	# create database
+	mysqladmin drop $DB_NAME -f --user="$DB_USER" --password="$DB_PASS"$EXTRA
 	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
 }
 

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -147,7 +147,7 @@ install_db() {
 	fi
 
 	# create database
-	mysqladmin drop $DB_NAME -f --user="$DB_USER" --password="$DB_PASS"$EXTRA
+	mysqladmin drop $DB_NAME -f --user="$DB_USER" --password="$DB_PASS"$EXTRA || true
 	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
 }
 

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -101,6 +101,7 @@ final class Core {
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-widget.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/customizer/class-customizer.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-suppression.php';
+		include_once NEWSPACK_ADS_ABSPATH . '/includes/marketplace/class-marketplace.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/functions.php';
 	}
 

--- a/includes/class-placements.php
+++ b/includes/class-placements.php
@@ -380,17 +380,17 @@ final class Placements {
 	private static function register_default_placements() {
 		$placements = array(
 			'global_above_header' => array(
-				'name'        => __( 'Global: Above Header', 'newspack-ads' ),
+				'name'        => __( 'Above Header', 'newspack-ads' ),
 				'description' => __( 'Choose an ad unit to display above the header.', 'newspack-ads' ),
 				'hook_name'   => 'before_header',
 			),
 			'global_below_header' => array(
-				'name'        => __( 'Global: Below Header', 'newspack-ads' ),
+				'name'        => __( 'Below Header', 'newspack-ads' ),
 				'description' => __( 'Choose an ad unit to display below the header.', 'newspack-ads' ),
 				'hook_name'   => 'after_header',
 			),
 			'global_above_footer' => array(
-				'name'        => __( 'Global: Above Footer', 'newspack-ads' ),
+				'name'        => __( 'Above Footer', 'newspack-ads' ),
 				'description' => __( 'Choose an ad unit to display above the footer.', 'newspack-ads' ),
 				'hook_name'   => 'before_footer',
 			),

--- a/includes/marketplace/class-marketplace.php
+++ b/includes/marketplace/class-marketplace.php
@@ -100,7 +100,7 @@ final class Marketplace {
 			$actions = [
 				'edit' => sprintf(
 					'<a href="%s">%s</a>',
-					esc_url( admin_url( 'admin.php?page=newspack-ads-wizard#/marketplace/' . $post->ID ) ),
+					esc_url( admin_url( 'admin.php?page=newspack-ads-wizard#/marketplace' ) ),
 					esc_html__( 'Edit in Newspack Ads', 'newspack-ads' )
 				),
 			];
@@ -119,7 +119,7 @@ final class Marketplace {
 	 */
 	public static function get_edit_post_link( $link, $post_id, $context ) {
 		if ( self::is_ad_product( $post_id ) ) {
-			$link = admin_url( 'admin.php?page=newspack-ads-wizard#/marketplace/' . $post_id );
+			$link = admin_url( 'admin.php?page=newspack-ads-wizard#/marketplace' );
 		}
 		return $link;
 	}

--- a/includes/marketplace/class-marketplace.php
+++ b/includes/marketplace/class-marketplace.php
@@ -321,6 +321,7 @@ final class Marketplace {
 				self::get_product_title( $product )
 			)
 		);
+		$product->save();
 		return $product;
 	}
 

--- a/includes/marketplace/class-marketplace.php
+++ b/includes/marketplace/class-marketplace.php
@@ -1,0 +1,505 @@
+<?php
+/**
+ * Newspack Ads Marketplace
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Ads;
+
+use Newspack_Ads\Settings;
+use Newspack_Ads\Providers\GAM_Model;
+use Newspack_Ads\Placements;
+use WC_Product_Simple;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Newspack Ads Marketplace Class.
+ */
+final class Marketplace {
+
+	const PRODUCTS_OPTION_NAME = '_newspack_ads_products';
+
+	const PRODUCT_META_PREFIX = '_ad_';
+
+	const PURCHASE_ACTION = 'newspack_ads_purchase';
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		\add_action( 'rest_api_init', [ __CLASS__, 'register_rest_routes' ] );
+		\add_filter( 'post_row_actions', [ __CLASS__, 'post_row_actions' ], PHP_INT_MAX, 2 );
+		\add_filter( 'get_edit_post_link', [ __CLASS__, 'get_edit_post_link' ], PHP_INT_MAX, 3 );
+	}
+
+	/**
+	 * Register API endpoints.
+	 */
+	public static function register_rest_routes() {
+		\register_rest_route(
+			Settings::API_NAMESPACE,
+			'/products',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ __CLASS__, 'api_get' ],
+				'permission_callback' => [ 'Newspack_Ads\Settings', 'api_permissions_check' ],
+			]
+		);
+		\register_rest_route(
+			Settings::API_NAMESPACE,
+			'/products/(?P<id>\d+)',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ __CLASS__, 'api_get' ],
+				'permission_callback' => [ 'Newspack_Ads\Settings', 'api_permissions_check' ],
+			]
+		);
+		\register_rest_route(
+			Settings::API_NAMESPACE,
+			'/products',
+			[
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ __CLASS__, 'api_create' ],
+				'permission_callback' => [ 'Newspack_Ads\Settings', 'api_permissions_check' ],
+				'args'                => self::get_product_args(),
+			]
+		);
+		\register_rest_route(
+			Settings::API_NAMESPACE,
+			'/products/(?P<id>\d+)',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ __CLASS__, 'api_update' ],
+				'permission_callback' => [ 'Newspack_Ads\Settings', 'api_permissions_check' ],
+				'args'                => self::get_product_args(),
+			]
+		);
+		\register_rest_route(
+			Settings::API_NAMESPACE,
+			'/products/(?P<id>\d+)',
+			[
+				'methods'             => \WP_REST_Server::DELETABLE,
+				'callback'            => [ __CLASS__, 'api_delete' ],
+				'permission_callback' => [ 'Newspack_Ads\Settings', 'api_permissions_check' ],
+			]
+		);
+	}
+
+	/**
+	 * Custom post row actions.
+	 *
+	 * @param array    $actions Array of actions.
+	 * @param \WP_Post $post    Post object.
+	 *
+	 * @return array
+	 */
+	public static function post_row_actions( $actions, $post ) {
+		if ( self::is_ad_product( $post ) ) {
+			$actions = [
+				'edit' => sprintf(
+					'<a href="%s">%s</a>',
+					esc_url( admin_url( 'admin.php?page=newspack-ads-wizard#/marketplace/' . $post->ID ) ),
+					esc_html__( 'Edit in Newspack Ads', 'newspack-ads' )
+				),
+			];
+		}
+		return $actions;
+	}
+
+	/**
+	 * Get ad product edit link.
+	 *
+	 * @param string   $link Link.
+	 * @param int      $post_id Post ID.
+	 * @param bool|int $context Context.
+	 *
+	 * @return string
+	 */
+	public static function get_edit_post_link( $link, $post_id, $context ) {
+		if ( self::is_ad_product( $post_id ) ) {
+			$link = admin_url( 'admin.php?page=newspack-ads-wizard#/marketplace/' . $post_id );
+		}
+		return $link;
+	}
+
+	/**
+	 * Ad Product REST Arguments
+	 *
+	 * @return array
+	 */
+	private static function get_product_args() {
+		return [
+			'placements'     => [
+				'required'          => true,
+				'type'              => 'array',
+				'sanitize_callback' => [ __CLASS__, 'sanitize_placements' ],
+			],
+			'price'          => [
+				'required'          => true,
+				'type'              => 'string',
+				'sanitize_callback' => [ __CLASS__, 'sanitize_price' ],
+			],
+			'payable_event'  => [
+				'required'          => true,
+				'type'              => 'string',
+				'sanitize_callback' => [ __CLASS__, 'sanitize_payable_event' ],
+				'default'           => 'cpd',
+			],
+			'required_sizes' => [
+				'required'          => true,
+				'type'              => 'array',
+				'sanitize_callback' => [ __CLASS__, 'sanitize_sizes' ],
+			],
+		];
+	}
+
+	/**
+	 * Sanitize placements.
+	 *
+	 * @param array $placements Placements.
+	 *
+	 * @return array
+	 */
+	public static function sanitize_placements( $placements ) {
+		return array_map( 'sanitize_text_field', $placements );
+	}
+
+	/**
+	 * Sanitize sizes.
+	 *
+	 * @param string[] $sizes List of size strings.
+	 *
+	 * @return string[]
+	 */
+	public static function sanitize_sizes( $sizes ) {
+		return array_filter(
+			array_map(
+				function( $size ) {
+					$size       = \sanitize_text_field( $size );
+					$dimensions = explode( 'x', $size );
+					if ( 2 !== count( $dimensions ) ) {
+						return null;
+					}
+					foreach ( $dimensions as $dimension ) {
+						if ( ! is_numeric( $dimension ) ) {
+							return null;
+						}
+					}
+					return $size;
+				},
+				$sizes
+			)
+		);
+	}
+
+	/**
+	 * Sanitize payable event.
+	 *
+	 * @param string $price_unit Payable event.
+	 *
+	 * @return string
+	 */
+	public static function sanitize_payable_event( $price_unit ) {
+		$units = [
+			'cpm',
+			'cpc',
+			'cpv',
+			'cpd',
+			'viewable_cpm',
+		];
+		return in_array( $price_unit, $units, true ) ? $price_unit : '';
+	}
+
+	/**
+	 * Sanitize a price.
+	 *
+	 * @param string|number $price Price.
+	 *
+	 * @return float Price.
+	 */
+	public static function sanitize_price( $price ) {
+		if ( empty( $price ) || ! is_numeric( $price ) ) {
+			return 0;
+		}
+		return round( floatval( $price ), 2 );
+	}
+
+	/**
+	 * Get a product by placement.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response containing the ad product data or error.
+	 */
+	public static function api_get( $request ) {
+		if ( ! empty( $request['id'] ) ) {
+			$id      = $request['id'];
+			$product = self::get_product( $id );
+			if ( ! $product ) {
+				return new \WP_Error( 'newspack_ads_product_not_found', __( 'Ad product not found.', 'newspack-ads' ), [ 'status' => 404 ] );
+			}
+			return \rest_ensure_response( self::get_product_data( $product ) );
+		} else {
+			return \rest_ensure_response( array_map( [ __CLASS__, 'get_product_data' ], self::get_products() ) );
+		}
+	}
+
+	/**
+	 * Create a new ad product.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response containing the ad product data or error.
+	 */
+	public static function api_create( $request ) {
+		$args    = array_intersect_key( $request->get_params(), self::get_product_args() );
+		$product = self::update_product( new WC_Product_Simple(), $args );
+		return \rest_ensure_response( self::get_product_data( $product ) );
+	}
+
+	/**
+	 * Update an ad product.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response containing the ad product data or error.
+	 */
+	public static function api_update( $request ) {
+		$args    = array_intersect_key( $request->get_params(), self::get_product_args() );
+		$id      = $request['id'];
+		$product = self::get_product( $id );
+		if ( ! $product ) {
+			$product = new WC_Product_Simple();
+		}
+		$product = self::update_product( $product, $args );
+		return \rest_ensure_response( self::get_product_data( $product ) );
+	}
+
+	/**
+	 * Delete an ad product.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response containing all products or error.
+	 */
+	public static function api_delete( $request ) {
+		$id = $request['id'];
+		if ( ! $id ) {
+			return new \WP_Error( 'newspack_ads_product_not_found', __( 'Ad product not found.', 'newspack-ads' ), [ 'status' => 404 ] );
+		}
+		$res = self::delete_product( $id );
+		if ( ! \is_wp_error( $res ) ) {
+			$res = array_map( [ __CLASS__, 'get_product_data' ], self::get_products() );
+		}
+		return \rest_ensure_response( $res );
+	}
+
+	/**
+	 * Update a product with the sanitized arguments.
+	 *
+	 * @param WC_Product_Simple $product   The product to update.
+	 * @param array             $args      The sanitized ad product arguments.
+	 *
+	 * @return WC_Product_Simple The updated product.
+	 */
+	private static function update_product( $product, $args ) {
+		$product->set_name(
+			sprintf(
+			/* translators: %s: product title */
+				__( 'Ad - %s', 'newspack-ads' ),
+				self::get_product_title( $product )
+			)
+		);
+		$product->set_regular_price( $args['price'] );
+		$product->set_virtual( true );
+		$product->set_catalog_visibility( 'hidden' );
+		$product->is_visible( false );
+		$product->save();
+		foreach ( $args as $key => $value ) {
+			self::set_product_meta( $product->get_id(), $key, $value );
+		}
+		self::set_ad_product( $product );
+		return $product;
+	}
+
+	/**
+	 * Delete a product given its ID.
+	 *
+	 * @param int $product_id Product ID.
+	 *
+	 * @return \WP_Error|void
+	 */
+	private static function delete_product( $product_id ) {
+		$product = self::get_product( $product_id );
+		if ( ! $product ) {
+			return new \WP_Error( 'newspack_ads_product_not_found', __( 'Ad product not found.', 'newspack-ads' ), [ 'status' => 404 ] );
+		}
+		wp_delete_post( $product_id, true );
+		$product->delete( true );
+	}
+
+	/**
+	 * Register ad product ID as wp option.
+	 *
+	 * @param WC_Product_Simple $product The product to set.
+	 *
+	 * @return bool Whether the value was updated or not.
+	 */
+	private static function set_ad_product( $product ) {
+		$id = $product->get_id();
+		/** Bail if WC Product is not saved. */
+		if ( ! $id ) {
+			return;
+		}
+		$products = array_map(
+			function( $product ) {
+				return $product->get_id();
+			},
+			self::get_products()
+		);
+		if ( ! in_array( $id, $products, true ) ) {
+			$products[] = $id;
+		}
+		return update_option( self::PRODUCTS_OPTION_NAME, $products );
+	}
+
+	/**
+	 * Get product placements.
+	 *
+	 * @param WC_Product_Simple|array $product The product object or data to get placements for.
+	 *
+	 * @return array Placements.
+	 */
+	public static function get_product_placements( $product ) {
+		if ( $product instanceof WC_Product_Simple ) {
+			$product = self::get_product_data( $product );
+		}
+		$placements         = Placements::get_placements();
+		$product_placements = [];
+		foreach ( $product['placements'] as $placement_key ) {
+			if ( isset( $placements[ $placement_key ] ) ) {
+				$product_placements[] = $placements[ $placement_key ];
+			}
+		}
+		return $product_placements;
+	}
+
+	/**
+	 * Get product title
+	 *
+	 * @param WC_Product_Simple|array $product The product object or data to get title for.
+	 *
+	 * @return string Product title.
+	 */
+	public static function get_product_title( $product ) {
+		$placements = self::get_product_placements( $product );
+		return implode(
+			', ',
+			array_map(
+				function( $placement ) {
+					return $placement['name'];
+				},
+				$placements
+			)
+		);
+	}
+
+	/**
+	 * Whether the post is an ad product.
+	 *
+	 * @param WP_Post|int $post_id Post object or ID.
+	 *
+	 * @return bool Whether the post is an ad product.
+	 */
+	public static function is_ad_product( $post_id ) {
+		if ( $post_id instanceof \WP_Post ) {
+			$post_id = $post_id->ID;
+		}
+		if ( empty( $post_id ) ) {
+			return false;
+		}
+		$ids = get_option( self::PRODUCTS_OPTION_NAME, [] );
+		return in_array( $post_id, array_map( 'absint', $ids ), true );
+	}
+
+	/**
+	 * Set a product meta.
+	 *
+	 * @param int    $product_id The product ID.
+	 * @param string $key        The meta key.
+	 * @param mixed  $value      The meta value.
+	 *
+	 * @return void
+	 */
+	private static function set_product_meta( $product_id, $key, $value ) {
+		\update_post_meta( $product_id, self::PRODUCT_META_PREFIX . $key, $value );
+	}
+
+	/**
+	 * Get a product meta.
+	 *
+	 * @param int    $product_id The product ID.
+	 * @param string $key        The meta key.
+	 *
+	 * @return mixed
+	 */
+	private static function get_product_meta( $product_id, $key ) {
+		return \get_post_meta( $product_id, self::PRODUCT_META_PREFIX . $key, true );
+	}
+
+	/**
+	 * Get all placement products.
+	 *
+	 * @return WC_Product_Simple[] Ad products keyed by their placement.
+	 */
+	public static function get_products() {
+		$ids = get_option( self::PRODUCTS_OPTION_NAME, [] );
+		if ( ! is_array( $ids ) || empty( $ids ) ) {
+			return [];
+		}
+		$products = [];
+		foreach ( $ids as $id ) {
+			$products[] = self::get_product( $id );
+		}
+		return array_filter( $products );
+	}
+
+	/**
+	 * Get a product given its ID.
+	 *
+	 * @param string $id The product id.
+	 *
+	 * @return WC_Product_Simple|null Ad product or null if not found.
+	 */
+	public static function get_product( $id ) {
+		$product = \wc_get_product( $id );
+		if ( $product && ! is_wp_error( $product ) ) {
+			return new WC_Product_Simple( $product );
+		}
+		return null;
+	}
+
+	/**
+	 * Get ad product data.
+	 *
+	 * @param WC_Product_Simple $product The product.
+	 *
+	 * @return array
+	 */
+	public static function get_product_data( $product ) {
+		if ( ! $product || ! $product->get_id() ) {
+			return [];
+		}
+		$args_keys = array_keys( self::get_product_args() );
+		$data      = [
+			'id' => $product->get_id(),
+		];
+		foreach ( $args_keys as $key ) {
+			$data[ $key ] = self::get_product_meta( $product->get_id(), $key );
+		}
+		return $data;
+	}
+}
+Marketplace::init();

--- a/includes/marketplace/class-marketplace.php
+++ b/includes/marketplace/class-marketplace.php
@@ -100,7 +100,7 @@ final class Marketplace {
 			$actions = [
 				'edit' => sprintf(
 					'<a href="%s">%s</a>',
-					esc_url( admin_url( 'admin.php?page=newspack-ads-wizard#/marketplace' ) ),
+					esc_url( admin_url( 'admin.php?page=newspack-advertising-wizard#/marketplace' ) ),
 					esc_html__( 'Edit in Newspack Ads', 'newspack-ads' )
 				),
 			];
@@ -119,7 +119,7 @@ final class Marketplace {
 	 */
 	public static function get_edit_post_link( $link, $post_id, $context ) {
 		if ( self::is_ad_product( $post_id ) ) {
-			$link = admin_url( 'admin.php?page=newspack-ads-wizard#/marketplace' );
+			$link = admin_url( 'admin.php?page=newspack-advertising-wizard#/marketplace' );
 		}
 		return $link;
 	}

--- a/includes/marketplace/class-marketplace.php
+++ b/includes/marketplace/class-marketplace.php
@@ -305,13 +305,6 @@ final class Marketplace {
 	 * @return WC_Product_Simple The updated product.
 	 */
 	private static function update_product( $product, $args ) {
-		$product->set_name(
-			sprintf(
-			/* translators: %s: product title */
-				__( 'Ad - %s', 'newspack-ads' ),
-				self::get_product_title( $product )
-			)
-		);
 		$product->set_regular_price( $args['price'] );
 		$product->set_virtual( true );
 		$product->set_catalog_visibility( 'hidden' );
@@ -321,6 +314,13 @@ final class Marketplace {
 			self::set_product_meta( $product->get_id(), $key, $value );
 		}
 		self::set_ad_product( $product );
+		$product->set_name(
+			sprintf(
+			/* translators: %s: product title */
+				__( 'Ad - %s', 'newspack-ads' ),
+				self::get_product_title( $product )
+			)
+		);
 		return $product;
 	}
 

--- a/tests/test-marketplace.php
+++ b/tests/test-marketplace.php
@@ -100,6 +100,7 @@ class MarketplaceTest extends WP_UnitTestCase {
 		$this->assertEquals( '5', $data['price'] );
 		$this->assertEquals( [ '920x250' ], $data['required_sizes'] );
 		$this->assertEquals( [ 'global_below_header' ], $data['placements'] );
+		$this->assertEquals( 'Ad &#8211; Below Header', get_the_title( $data['id'] ) );
 	}
 
 	/**

--- a/tests/test-marketplace.php
+++ b/tests/test-marketplace.php
@@ -5,9 +5,6 @@
  * @package Newspack\Tests
  */
 
-use Newspack_Ads\Marketplace;
-use Newspack_Ads\Placements;
-
 /**
  * Test Marketplace
  */

--- a/tests/test-marketplace.php
+++ b/tests/test-marketplace.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Test Marketplace
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack_Ads\Marketplace;
+use Newspack_Ads\Placements;
+
+/**
+ * Test Marketplace
+ */
+class MarketplaceTest extends WP_UnitTestCase {
+
+	/**
+	 * Holds the WP REST Server object
+	 *
+	 * @var WP_REST_Server
+	 */
+	private $server;
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		// Initialize REST API.
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+		do_action( 'rest_api_init' );
+
+		// Create and set admin user for API calls.
+		$this->administrator = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $this->administrator );
+	}
+
+	/**
+	 * Get a product.
+	 *
+	 * @param int $id Product ID.
+	 *
+	 * @return WP_REST_Response
+	 */
+	private function get_product( $id ) {
+		$request = new WP_REST_Request( 'GET', '/newspack-ads/v1/products/' . $id );
+		return $this->server->dispatch( $request );
+	}
+
+	/**
+	 * Create a product.
+	 *
+	 * @param array $params Request body params.
+	 *
+	 * @return WP_REST_Response
+	 */
+	private function create_product( $params = [] ) {
+		if ( empty( $params ) ) {
+			$params = [
+				'placements'     => [ 'global_below_header' ],
+				'required_sizes' => [ '920x250' ],
+				'price'          => '5',
+			];
+		}
+		$request = new WP_REST_Request( 'POST', '/newspack-ads/v1/products' );
+		$request->set_body_params( $params );
+		return $this->server->dispatch( $request );
+	}
+
+	/**
+	 * Update a product.
+	 *
+	 * @param int   $id     Product ID.
+	 * @param array $params Request body params.
+	 *
+	 * @return WP_REST_Response
+	 */
+	private function update_product( $id, $params ) {
+		$request = new WP_REST_Request( 'PUT', '/newspack-ads/v1/products/' . $id );
+		$request->set_body_params( $params );
+		return $this->server->dispatch( $request );
+	}
+
+	/**
+	 * Delete a product
+	 *
+	 * @param int $id Product ID.
+	 *
+	 * @return WP_REST_Response
+	 */
+	private function delete_product( $id ) {
+		$request = new WP_REST_Request( 'DELETE', '/newspack-ads/v1/products/' . $id );
+		return $this->server->dispatch( $request );
+	}
+
+	/**
+	 * Test create product.
+	 */
+	public function test_create_product() {
+		$response = $this->create_product();
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( '5', $data['price'] );
+		$this->assertEquals( [ '920x250' ], $data['required_sizes'] );
+		$this->assertEquals( [ 'global_below_header' ], $data['placements'] );
+	}
+
+	/**
+	 * Test update product.
+	 */
+	public function test_update_product() {
+		$product  = $this->create_product()->get_data();
+		$response = $this->update_product( $product['id'], array_merge( $product, [ 'price' => '10' ] ) );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( '10', $data['price'] );
+	}
+
+	/**
+	 * Test get product.
+	 */
+	public function test_get_product() {
+		$product  = $this->create_product()->get_data();
+		$response = $this->get_product( $product['id'] );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( $product['id'], $data['id'] );
+	}
+
+	/**
+	 * Test delete product.
+	 */
+	public function test_delete_product() {
+		$product  = $this->create_product()->get_data();
+		$response = $this->delete_product( $product['id'] );
+		$this->assertEquals( 200, $response->get_status() );
+		$response = $this->get_product( $product['id'] );
+		$this->assertEquals( 404, $response->get_status() );
+	}
+}


### PR DESCRIPTION
This PR implements the ad product as a custom WooCommerce product as part of the marketplace project. This and future PRs for this project should be merged into `epic/marketplace`.

<img width="1279" alt="image" src="https://user-images.githubusercontent.com/820752/203848743-df86646d-da04-4720-b524-64a20a2c3d0b.png">

The ad product will be initially defined with a CPD (cost per day) and its orders configured as sponsorships with a flat fee. The advertiser should be able to purchase a range of dates for the sponsorship to last (yet to be implemented).

The ad product configuration consists of:
 - Placements (required at least one)
 - Required sizes (required at least one)
 - Cost per day

The available placements are gathered from the active placements and their configuration. The selection of placements will determine the available sizes, which should all be available for the advertiser to upload creatives.

<img width="718" alt="image" src="https://user-images.githubusercontent.com/820752/203849211-2bb0e02f-49a8-478e-8af3-19e2f03c742c.png">

The proposed UI is a placeholder just for representing how the ad product is built. It will be later revised for a better experience.

## WooCommerce integration tests

The tests were updated to load WooCommerce for integration tests.

## How to test this PR

1. Check out this branch and https://github.com/Automattic/newspack-plugin/pull/2150
2. Confirm you have WooCommerce installed and active
3. Visit the Newspack -> Advertising wizard
4. Confirm you are connected to GAM and have active placements configured with ad units
5. Navigate to the new "Marketplace" tab
6. Confirm there's a button to "Create new product"
7. Click the button and confirm the modal is opened with the list of active placements for selection
8. Select different placements and confirm the unique sizes are displayed to select which are required
9. Select different sizes
10. Enter a CPD and save
11. Confirm the product is saved
12. Refresh the page and confirm the product persists
13. Edit the product values, save and confirm the values are updated
14. Visit the Products table, provided by WooCommerce, and confirm the links redirect to the wizard
15. Back to the wizard, click to delete the ad product
16. Confirm the product is deleted (not trashed)
