### PR TITLE
feat: "fixed height" a global setting with max threshold

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -86,6 +86,7 @@ final class Core {
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/providers/broadstreet/class-broadstreet-provider.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-settings.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-custom-label.php';
+		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-fixed-height.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-providers.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-bidding.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/bidders/class-medianet.php';

--- a/includes/class-fixed-height.php
+++ b/includes/class-fixed-height.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Newspack Ads Fixed Height Settings.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Ads;
+
+use Newspack_Ads\Core;
+use Newspack_Ads\Settings;
+
+/**
+ * Newspack Ads Fixed Height Class.
+ */
+final class Fixed_Height {
+
+	const SECTION = 'fixed_height';
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_action( 'newspack_ads_settings_list', [ __CLASS__, 'register_settings' ] );
+	}
+
+	/**
+	 * Register Fixed Height settings.
+	 *
+	 * @param array $settings_list List of settings.
+	 *
+	 * @return array Updated list of settings.
+	 */
+	public static function register_settings( $settings_list ) {
+		if ( Core::is_amp() ) {
+			return $settings_list;
+		}
+		return array_merge(
+			$settings_list,
+			[
+				[
+					'description' => __( 'Fixed height', 'newspack-ads' ),
+					'help'        => __( 'If enabled, ad slots will be rendered with a fixed height determined by the unit\'s sizes configuration.', 'newspack-ads' ),
+					'section'     => self::SECTION,
+					'key'         => 'active',
+					'type'        => 'boolean',
+					'default'     => true,
+					'public'      => true,
+				],
+				[
+					'description' => __( 'Use maximum fixed height', 'newspack-ads' ),
+					'help'        => __( 'If enabled, rendered creatives larger than "maximum fixed height" will adjust the height accordingly and cause layout shift.', 'newspack-ads' ),
+					'section'     => self::SECTION,
+					'key'         => 'use_max_height',
+					'type'        => 'boolean',
+					'default'     => true,
+					'public'      => true,
+				],
+				[
+					'description' => __( 'Maximum fixed height', 'newspack-ads' ),
+					'help'        => __( 'Maximum value for the fixed height applied to the ad slot, in pixels.', 'newspack-ads' ),
+					'section'     => self::SECTION,
+					'key'         => 'max_height',
+					'type'        => 'int',
+					'default'     => 100,
+					'public'      => true,
+				],
+			]
+		);
+	}
+}
+Fixed_Height::init();

--- a/includes/class-fixed-height.php
+++ b/includes/class-fixed-height.php
@@ -47,7 +47,7 @@ final class Fixed_Height {
 					'public'      => true,
 				],
 				[
-					'description' => __( 'Use maximum fixed height', 'newspack-ads' ),
+					'description' => __( 'Set a maximum fixed height', 'newspack-ads' ),
 					'help'        => __( 'If enabled, rendered creatives larger than "maximum fixed height" will adjust the height accordingly and cause layout shift.', 'newspack-ads' ),
 					'section'     => self::SECTION,
 					'key'         => 'use_max_height',

--- a/includes/class-placements.php
+++ b/includes/class-placements.php
@@ -79,9 +79,6 @@ final class Placements {
 					'bidders_ids'  => [
 						'sanitize_callback' => [ __CLASS__, 'sanitize_bidders_ids' ],
 					],
-					'fixed_height' => [
-						'sanitize_callback' => 'rest_sanitize_boolean',
-					],
 					'hooks'        => [
 						'sanitize_callback' => [ __CLASS__, 'sanitize_hooks_data' ],
 					],
@@ -133,10 +130,6 @@ final class Placements {
 
 		if ( isset( $data['ad_unit'] ) ) {
 			$sanitized_data['ad_unit'] = sanitize_text_field( $data['ad_unit'] );
-		}
-
-		if ( isset( $data['fixed_height'] ) ) {
-			$sanitized_data['fixed_height'] = rest_sanitize_boolean( $data['fixed_height'] );
 		}
 
 		if ( isset( $data['bidders_ids'] ) ) {
@@ -235,7 +228,6 @@ final class Placements {
 			'ad_unit'      => $request['ad_unit'],
 			'bidders_ids'  => $request['bidders_ids'],
 			'hooks'        => $request['hooks'],
-			'fixed_height' => $request['fixed_height'],
 			'stick_to_top' => $request['stick_to_top'],
 		];
 		$result = self::update_placement( $request['placement'], $data );
@@ -727,8 +719,6 @@ final class Placements {
 			$placement_data = $placement['data'];
 		}
 
-		$placement_data['fixed_height'] = isset( $placement_data['fixed_height'] ) ? (bool) $placement_data['fixed_height'] : false;
-
 		if ( ! isset( $placement_data['ad_unit'] ) || empty( $placement_data['ad_unit'] ) ) {
 			return;
 		}
@@ -765,7 +755,7 @@ final class Placements {
 				$placement_key . '-' . $hook_key    => ! empty( $hook_key ),
 				'hook-' . $hook_key                 => ! empty( $hook_key ),
 				'stick-to-top'                      => $stick_to_top,
-				'fixed-height'                      => $placement_data['fixed_height'],
+				'fixed-height'                      => Settings::get_setting( 'fixed_height', 'active' ),
 			],
 			$placement_key,
 			$hook_key,

--- a/includes/customizer/class-placement-customize-control.php
+++ b/includes/customizer/class-placement-customize-control.php
@@ -124,22 +124,6 @@ final class Placement_Customize_Control extends \WP_Customize_Control {
 	}
 
 	/**
-	 * Get the value of "fixed height" feature given its hook key.
-	 *
-	 * @param string $hook_key Optional hook key, will look root placement otherwise.
-	 *
-	 * @return string Ad unit ID or empty string if not found.
-	 */
-	private function get_fixed_height_value( $hook_key = '' ) {
-		$value = json_decode( $this->value(), true );
-		$data  = $value;
-		if ( ! empty( $hook_key ) && isset( $value['hooks'], $value['hooks'][ $hook_key ] ) ) {
-			$data = $value['hooks'][ $hook_key ];
-		}
-		return isset( $data['fixed_height'] ) ? (bool) $data['fixed_height'] : false;
-	}
-
-	/**
 	 * Get the value of "stick to top" feature given its hook key.
 	 *
 	 * @param string $hook_key Optional hook key, will look root placement otherwise.
@@ -279,29 +263,6 @@ final class Placement_Customize_Control extends \WP_Customize_Control {
 	}
 
 	/**
-	 * Render the control's "fixed height" checkbox.
-	 *
-	 * @param bool   $value    The current value of the control.
-	 * @param string $hook_key The hook key.
-	 */
-	private function render_fixed_height_checkbox( $value = false, $hook_key = '' ) {
-		$id_args = [ 'fixed-height' ];
-		if ( $hook_key ) {
-			$id_args[] = $hook_key;
-		}
-		$label    = __( 'Fixed height', 'newspack-ads' );
-		$input_id = $this->get_element_id( 'input', $id_args );
-		$desc_id  = $this->get_element_id( 'description', $id_args );
-		?>
-		<span class="customize-control fixed-height-checkbox">
-			<input id="<?php echo esc_attr( $input_id ); ?>" type="checkbox" value="1" <?php checked( $value, '1' ); ?> />
-			<label for="<?php echo esc_attr( $input_id ); ?>"><?php echo esc_html( $label ); ?></label>
-			<span id="<?php echo esc_attr( $desc_id ); ?>" class="description customize-control-description"><?php esc_html_e( 'Avoid content layout shift by using the ad unit height as fixed height for this placement. This is recommended if an ad is guaranteed to be shown across all devices.', 'newspack-ads' ); ?></span>
-		</span>
-		<?php
-	}
-
-	/**
 	 * Render the control's "stick to top" checkbox.
 	 *
 	 * @param bool   $value    The current value of the control.
@@ -380,7 +341,6 @@ final class Placement_Customize_Control extends \WP_Customize_Control {
 					$this->render_placement_hook_control( $hook_key, $this->placement );
 				}
 			}
-			$this->render_fixed_height_checkbox( $this->get_fixed_height_value() );
 			if ( in_array( 'stick_to_top', $this->placement['supports'], true ) ) {
 				$this->render_stick_to_top_checkbox( $this->get_stick_to_top_value() );
 			}

--- a/includes/providers/broadstreet/class-broadstreet-provider.php
+++ b/includes/providers/broadstreet/class-broadstreet-provider.php
@@ -9,6 +9,7 @@ namespace Newspack_Ads\Providers;
 
 use Newspack_Ads\Providers\Provider;
 use Newspack_Ads\Core;
+use Newspack_Ads\Settings;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -111,7 +112,7 @@ final class Broadstreet_Provider extends Provider {
 		if ( ! self::is_plugin_active() || ! method_exists( '\Broadstreet_Utility', 'getZoneCode' ) ) {
 			return '';
 		}
-		$fixed_height = isset( $placement_data['fixed_height'] ) ? (bool) $placement_data['fixed_height'] : false;
+		$fixed_height = Settings::get_setting( 'fixed_height', 'active' );
 		$attrs        = [];
 		$zones        = $this->get_units();
 		$zone_idx     = array_search( $unit_id, array_column( $zones, 'value' ) );

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -209,10 +209,9 @@ final class GAM_Model {
 			);
 		}
 
-		$unique_id    = $config['unique_id'] ?? uniqid();
-		$placement    = $config['placement'] ?? '';
-		$context      = $config['context'] ?? '';
-		$fixed_height = $config['fixed_height'] ?? false;
+		$unique_id = $config['unique_id'] ?? uniqid();
+		$placement = $config['placement'] ?? '';
+		$context   = $config['context'] ?? '';
 
 		$ad_units = self::get_ad_units( false );
 
@@ -228,9 +227,8 @@ final class GAM_Model {
 		}
 		$ad_unit = $ad_units[ $index ];
 
-		$ad_unit['placement']    = $placement;
-		$ad_unit['context']      = $context;
-		$ad_unit['fixed_height'] = $fixed_height;
+		$ad_unit['placement'] = $placement;
+		$ad_unit['context']   = $context;
 
 		$ad_unit['ad_code']     = self::get_ad_unit_code( $ad_unit, $unique_id );
 		$ad_unit['amp_ad_code'] = self::get_ad_unit_amp_code( $ad_unit, $unique_id );

--- a/includes/providers/gam/class-gam-provider.php
+++ b/includes/providers/gam/class-gam-provider.php
@@ -83,9 +83,8 @@ final class GAM_Provider extends Provider {
 		$ad_unit = GAM_Model::get_ad_unit_for_display(
 			$unit_id,
 			array(
-				'unique_id'    => $placement_data['id'],
-				'placement'    => $placement_key,
-				'fixed_height' => isset( $placement_data['fixed_height'] ) ? (bool) $placement_data['fixed_height'] : false,
+				'unique_id' => $placement_data['id'],
+				'placement' => $placement_key,
 			)
 		);
 		if ( \is_wp_error( $ad_unit ) ) {

--- a/src/blocks/ad-unit/index.js
+++ b/src/blocks/ad-unit/index.js
@@ -42,10 +42,6 @@ export const settings = {
 			type: 'object',
 			default: {},
 		},
-		fixed_height: {
-			type: 'boolean',
-			default: false,
-		},
 		// Legacy attribute.
 		activeAd: {
 			type: 'string',

--- a/src/customizer/control.js
+++ b/src/customizer/control.js
@@ -37,9 +37,6 @@ import { set, debounce } from 'lodash';
 			$toggle.on( 'change', function () {
 				updateValue( '', 'enabled', $( this ).is( ':checked' ) );
 			} );
-			container.on( 'change', '.fixed-height-checkbox input[type=checkbox]', function () {
-				updateValue( '', 'fixed_height', $( this ).is( ':checked' ) );
-			} );
 			container.on( 'change', '.stick-to-top-checkbox input[type=checkbox]', function () {
 				updateValue( '', 'stick_to_top', $( this ).is( ':checked' ) );
 			} );

--- a/src/frontend/style.scss
+++ b/src/frontend/style.scss
@@ -20,6 +20,9 @@
 	&.fixed-height {
 		padding: 16px 0;
 		box-sizing: content-box;
+		> * {
+			margin: 0;
+		}
 	}
 }
 

--- a/src/placements/placement-control.js
+++ b/src/placements/placement-control.js
@@ -5,7 +5,7 @@
 /**
  * WordPress dependencies
  */
-import { Notice, SelectControl, ToggleControl, TextControl } from '@wordpress/components';
+import { Notice, SelectControl, TextControl } from '@wordpress/components';
 import { Fragment, useState, useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -169,15 +169,6 @@ const PlacementControl = ( {
 					}
 					return null;
 				} ) }
-			<ToggleControl
-				label={ __( 'Use fixed height', 'newspack-ads' ) }
-				help={ __(
-					'Avoid content layout shift by using the ad unit height as fixed height for this placement. This is recommended if an ad is guaranteed to be shown across all devices.',
-					'newspack-ads'
-				) }
-				checked={ !! value.fixed_height }
-				onChange={ data => onChange( { ...value, fixed_height: data } ) }
-			/>
 		</Fragment>
 	);
 };


### PR DESCRIPTION
Changes how the "fixed height" system, implemented in #439, behaves. It's currently set as a per-placement setting and this PR turns it into a global setting with max height support:

<img width="1069" alt="image" src="https://user-images.githubusercontent.com/820752/215162103-be61438d-b744-4129-8f67-97eab6e6be8a.png">

If "max height" is enabled, any creative rendering above the defined threshold will cause a layout shift (CLS).

## How to test

1. Checkout this branch and https://github.com/Automattic/newspack-plugin/pull/2255
2. Visit **Advertising -> Settings** and confirm you see the new "Fixed height" section with the above defaults
3. Make sure you have GAM configured and set the Below Header and Footer placements with units containing the sizes: 728x90 970x90 970x250
4. Visit the home page and confirm the CLS occurring from 100 to 250 if the slot renders the 970x250 creative
5. Refresh until a creative with a height of 90px renders and confirm the slot height is at 100px without causing any CLS
6. Change the "Maximum fixed height" value to 150 and confirm the value is applied on the front-end
7. Disable the use of maximum fixed height, save, visit the front-end and confirm the slot is fixed with 250px of height and without any CLS
8. Visit the Customizer, edit the placement, and confirm the "Fixed height" setting is gone and you can save without issues
9. Visit "Advertising -> Placements", edit a placement, and also confirm the "Fixed height" setting is gone and you can save without issues
10. Edit a page, add an Ad Unit block, confirm the "Fixed height" setting is gone and you can save without issues
