### PR TITLE
fix(gam): handle API fatal and session errors

### DIFF
--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -39,6 +39,20 @@ final class GAM_Model {
 	private static $api = null;
 
 	/**
+	 * GAM Api fatal error message.
+	 *
+	 * @var string
+	 */
+	private static $api_fatal_error = null;
+
+	/**
+	 * GAM Api session error message.
+	 *
+	 * @var string
+	 */
+	private static $api_session_error = null;
+
+	/**
 	 * Custom post type
 	 *
 	 * @var string
@@ -95,14 +109,20 @@ final class GAM_Model {
 
 		$network_code = self::get_active_network_code();
 
+		$api = null;
 		try {
-			self::$api = new GAM_Api( $auth_method, $credentials, $network_code );
-			/** Test the connection once to ensure the session has GAM connection. */
-			self::$api->get_current_user();
+			$api = new GAM_Api( $auth_method, $credentials, $network_code );
 		} catch ( \Exception $e ) {
-			self::$api = false;
+			self::$api_fatal_error = $e->getMessage();
+			return false;
 		}
-
+		$init_res = $api->init();
+		if ( is_wp_error( $init_res ) ) {
+			self::$api_session_error = $init_res->get_error_message();
+			return false;
+		}
+		$api->get_current_user();
+		self::$api = $api;
 		return self::$api;
 	}
 
@@ -1077,17 +1097,17 @@ final class GAM_Model {
 		} elseif ( get_queried_object() ) {
 			$queried_object = get_queried_object();
 			if ( 'WP_Term' === get_class( $queried_object ) ) {
-				
+
 				switch ( $queried_object->taxonomy ) {
-						
+
 					case 'category':
 						$targeting['category'] = [ sanitize_text_field( $queried_object->slug ) ];
 						break;
-						
+
 					case 'post_tag':
 						$targeting['tag'] = [ sanitize_text_field( $queried_object->slug ) ];
 						break;
-						
+
 				}
 			}
 		}
@@ -1135,6 +1155,10 @@ final class GAM_Model {
 				update_option( self::OPTION_NAME_GAM_NETWORK_CODE, $network_code );
 			}
 			$status['is_network_code_matched'] = self::is_network_code_matched();
+		} elseif ( self::$api_fatal_error ) {
+			return new \WP_Error( 'newspack_ads_gam_api_fatal_error', self::$api_fatal_error );
+		} elseif ( self::$api_session_error ) {
+			return new \WP_Error( 'newspack_ads_gam_api_session_error', self::$api_session_error );
 		}
 		return $status;
 	}


### PR DESCRIPTION
This PR restores proper error messages in the dashboard UI and separates the types of GAM API errors while initializing. The fatal error (environment incompatibility) is irrecoverable and is thrown while instantiating the API. A session error comes from `API->init()` and can be recovered by submitting valid credentials.

<img width="1070" alt="image" src="https://user-images.githubusercontent.com/820752/219744212-376eac78-a09e-44c6-9d97-f666632d0584.png">

<img width="1057" alt="image" src="https://user-images.githubusercontent.com/820752/219744362-317091f5-dcab-4225-ae2f-ade45e88913e.png">

Closes #560

### How to test

1. Check out this branch and https://github.com/Automattic/newspack-plugin/pull/2289
2. Visit the Advertising dashboard and if you are not connected, confirm the "missing credentials" error
3. If you are connected, disconnect to confirm the message
4. Connect again and confirm you are connected and without any message
5. Disconnect once more
6. Install the [Constant Contact Form](https://wordpress.org/plugins/constant-contact-forms/) plugin to trigger the incompatibility error
7. Visit the dashboard and confirm the error message without the ability to connect