### PR TITLE
fix(placements): suppress render for inactive providers

### DIFF
--- a/includes/class-placements.php
+++ b/includes/class-placements.php
@@ -719,6 +719,14 @@ final class Placements {
 			$placement_data = $placement['data'];
 		}
 
+		// Provider is not active.
+		if (
+			isset( $placement_data['provider'] ) &&
+			! Providers::is_provider_active( $placement_data['provider'] )
+		) {
+			return;
+		}
+
 		if ( ! isset( $placement_data['ad_unit'] ) || empty( $placement_data['ad_unit'] ) ) {
 			return;
 		}

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -411,6 +411,16 @@ final class GAM_Scripts {
 	 * @param array  $placement_data The placement data.
 	 */
 	public static function print_fixed_height_css( $placement_key, $hook_key, $placement_data ) {
+		if ( ! \newspack_ads_should_show_ads() ) {
+			return;
+		}
+		if ( ! Providers::is_provider_active( 'gam' ) ) {
+			return;
+		}
+		if ( Core::is_amp() ) {
+			return;
+		}
+
 		if ( 'gam' !== $placement_data['provider'] ) {
 			return;
 		}


### PR DESCRIPTION
The recent implementation of default fixed height for placements surfaced an issue with how the suppression for ads is applied when the provider is not active.

The suppression currently occurs only at the provider code level. The placement code is still applied and results in an empty div. This div is still processed by the fixed height CSS and results in a blank space.

This PR ensures the placement doesn't render any markup as well as the fixed height CSS.

## How to test

1. Confirm the issue in master by configuring placements with GAM active
2. Disable GAM, visit the frontend, and confirm the blank spaces
3. Checkout this branch, refresh, and confirm the units are not rendered
4. Enable GAM, refresh, and confirm the units are rendered again with proper fixed height
