### PR TITLE
fix: proper usage of useEffect cleanup function

### DIFF
--- a/src/blocks/ad-unit/edit.js
+++ b/src/blocks/ad-unit/edit.js
@@ -43,26 +43,29 @@ function Edit( { attributes, setAttributes } ) {
 	const containerWidth = sizes.length ? Math.max( ...sizes.map( s => s[ 0 ] ) ) : 300;
 	const containerHeight = sizes.length ? Math.max( ...sizes.map( s => s[ 1 ] ) ) : 200;
 
-	useEffect( async () => {
-		// Legacy attribute.
-		if ( attributes.activeAd && ! attributes.ad_unit ) {
-			setAttributes( { ad_unit: attributes.activeAd } );
-		}
+	useEffect( () => {
+		const fetchData = async () => {
+			// Legacy attribute.
+			if ( attributes.activeAd && ! attributes.ad_unit ) {
+				setAttributes( { ad_unit: attributes.activeAd } );
+			}
 
-		setInFlight( true );
-		// Fetch providers.
-		try {
-			setProviders( await apiFetch( { path: '/newspack-ads/v1/providers' } ) );
-		} catch ( err ) {
-			setError( err );
-		}
-		// Fetch bidders.
-		try {
-			setBidders( await apiFetch( { path: '/newspack-ads/v1/bidders' } ) );
-		} catch ( err ) {
-			setBiddersError( err );
-		}
-		setInFlight( false );
+			setInFlight( true );
+			// Fetch providers.
+			try {
+				setProviders( await apiFetch( { path: '/newspack-ads/v1/providers' } ) );
+			} catch ( err ) {
+				setError( err );
+			}
+			// Fetch bidders.
+			try {
+				setBidders( await apiFetch( { path: '/newspack-ads/v1/bidders' } ) );
+			} catch ( err ) {
+				setBiddersError( err );
+			}
+			setInFlight( false );
+		};
+		fetchData();
 	}, [] );
 
 	useEffect( () => {


### PR DESCRIPTION
Fix the usage of `useEffect` cleanup function.

Related: https://github.com/Automattic/newspack-plugin/issues/2269 https://github.com/Automattic/newspack-plugin/pull/2335

## How to test

1. Check out this branch
2. Add a new Ad Unit block to a post
3. Make sure you are able to select the unit and save
4. Visit the front end and confirm the unit is rendered without issues