### PR TITLE
fix(gam): handle account without networks

### DIFF
--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -121,7 +121,6 @@ final class GAM_Model {
 			self::$api_session_error = $init_res->get_error_message();
 			return false;
 		}
-		$api->get_current_user();
 		self::$api = $api;
 		return self::$api;
 	}


### PR DESCRIPTION
This PR ensures that a connected Google OAuth account that doesn't have access to any GAM networks is properly handled without throwing 500 errors.

<img width="1087" alt="image" src="https://user-images.githubusercontent.com/820752/225923449-20ab9e07-7a5d-4da2-8881-9caf354c2b5d.png">

Closes #621 

### How to test

1. Checkout this branch and make sure you have Google OAuth support using NM's proxied connection (ping me for instructions)
2. Connect to an account that is not connected to any GAM network
3. Visit the Ads wizard and confirm the error message as in the image above and #621 is no longer reproducible