### PR TITLE
fix(gam): handle sticky ads without amp

### DIFF
--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -409,6 +409,7 @@ final class GAM_Scripts {
 						if ( stickyClose ) {
 							stickyClose.addEventListener( 'click', function() {
 								stickyContainer.parentNode.removeChild( stickyContainer );
+								document.body.style.paddingBottom = initialBodyPadding;
 							} );
 						}
 						googletag.pubads().addEventListener( 'slotRenderEnded', function( event ) {

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -325,6 +325,12 @@ final class GAM_Scripts {
 							mapping.addSize( [ width, 0 ], baseSizes.concat( mappedSizes ) );
 						}
 						<?php
+						// Sticky ads should only be shown on mobile (screen width <=600px).
+						?>
+						if ( ad_unit['sticky'] ) {
+							mapping.addSize( [600, 0], baseSizes );
+						}
+						<?php
 						// On viewports smaller than the smallest ad size, don't show any ads.
 						?>
 						mapping.addSize( [0, 0], baseSizes );
@@ -397,7 +403,6 @@ final class GAM_Scripts {
 					 */
 					?>
 					if ( ad_unit.sticky ) {
-						mapping.addSize( [600, 0], baseSizes ); <?php // Sticky ads are only shown on desktop. ?>
 						var stickyContainer = container.parentNode;
 						var stickyClose = stickyContainer.querySelector( 'button.newspack_sticky_ad__close' );
 						var initialBodyPadding = document.body.style.paddingBottom;
@@ -421,6 +426,22 @@ final class GAM_Scripts {
 							}
 						} );
 					}
+					<?php
+					/**
+					 * Sticky header & sticky ad handling.
+					 *
+					 * If the site uses sticky header and a sticky ad, the ad should
+					 * be offset by the header height in order to stack the sticky
+					 * elements on top of each other.
+					 */
+					?>
+					( function () {
+						var stickyAd = document.querySelector( '.h-stk .stick-to-top:last-child' );
+						var siteHeader = document.querySelector( '.h-stk .site-header' );
+						if ( stickyAd && siteHeader ) {
+							stickyAd.style.top = 'calc(' + siteHeader.offsetHeight + 'px + 1rem)';
+						}
+					} )();
 				} );
 			} )();
 		</script>

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -325,12 +325,6 @@ final class GAM_Scripts {
 							mapping.addSize( [ width, 0 ], baseSizes.concat( mappedSizes ) );
 						}
 						<?php
-						// Sticky ads should only be shown on mobile (screen width <=600px).
-						?>
-						if ( ad_unit['sticky'] ) {
-							mapping.addSize( [600, 0], baseSizes );
-						}
-						<?php
 						// On viewports smaller than the smallest ad size, don't show any ads.
 						?>
 						mapping.addSize( [0, 0], baseSizes );
@@ -372,7 +366,7 @@ final class GAM_Scripts {
 						 * Handle slot visibility.
 						 */
 						?>
-						if ( event.isEmpty && ( ! ad_unit.fixed_height.active || ( ad_unit.fixed_height.active && ! ad_unit.in_viewport ) ) ) {
+						if ( event.isEmpty && ( ad_unit.sticky || ! ad_unit.fixed_height.active || ( ad_unit.fixed_height.active && ! ad_unit.in_viewport ) ) ) {
 							container.parentNode.style.display = 'none';
 						} else {
 							container.parentNode.style.display = 'flex';
@@ -397,6 +391,36 @@ final class GAM_Scripts {
 							}
 						}
 					} );
+					<?php
+					/**
+					 * Handle Sticky Ads.
+					 */
+					?>
+					if ( ad_unit.sticky ) {
+						mapping.addSize( [600, 0], baseSizes ); <?php // Sticky ads are only shown on desktop. ?>
+						var stickyContainer = container.parentNode;
+						var stickyClose = stickyContainer.querySelector( 'button.newspack_sticky_ad__close' );
+						var initialBodyPadding = document.body.style.paddingBottom;
+						if ( stickyClose ) {
+							stickyClose.addEventListener( 'click', function() {
+								stickyContainer.parentNode.removeChild( stickyContainer );
+							} );
+						}
+						googletag.pubads().addEventListener( 'slotRenderEnded', function( event ) {
+							var container = document.getElementById( event.slot.getSlotElementId() );
+							if ( ! container ) {
+								return;
+							}
+							var ad_unit = container.ad_unit;
+							if ( ! ad_unit || ! ad_unit.sticky ) {
+								return;
+							}
+							if ( ! event.isEmpty && document.body.clientWidth <= 600 ) {
+								stickyContainer.style.display = 'flex';
+								document.body.style.paddingBottom = stickyContainer.clientHeight + 'px';
+							}
+						} );
+					}
 				} );
 			} )();
 		</script>


### PR DESCRIPTION
Move the non-AMP sticky ads handling from [Newspack Theme](https://github.com/Automattic/newspack-theme/blob/1dfb96be14281347ca155115a92079c31b4c59c6/newspack-theme/js/src/amp-plus.js#L16-L46) to here.

Pushing as a hotfix because [sites without AMP or AMP Plus currently have no handling of the sticky ads](https://github.com/Automattic/newspack-theme/blob/1dfb96be14281347ca155115a92079c31b4c59c6/newspack-theme/functions.php#L451-L464), making them non-dismissable.

### How to test

1. While in the master branch, make sure you don't have AMP or the AMP Plus flag
2. Place a sticky ad and confirm on mobile viewport that you are unable to dismiss it (clicking on the X does nothing)
3. Check out this branch and confirm the ad can be dismissed
4. Refresh the page, scroll down, and confirm there's padding applied to the body, preserving the contents that would be otherwise behind the ad
5. Change the sticky ad placement to an ad unit that doesn't render a creative
6. Refresh the page and confirm the sticky ad doesn't render on an empty slot

#### Sticky header and sidebar sticky ad

1. Change your header settings to sticky
2. Set an ad unit in the Sidebar - After sidebar placement and toggle the sticky mode
3. Visit an article, scroll down and confirm the ad sticks below the sticky header without overlapping