### PR TITLE
Add .cache and .github to .distignore

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,11 +1,13 @@
 # A set of files you probably don't want in your WordPress.org distribution
 .babelrc
+.cache
 .deployignore
 .distignore
 .editorconfig
 .eslintignore
 .eslintrc
 .git
+.github
 .gitignore
 .gitlab-ci.yml
 .travis.yml


### PR DESCRIPTION
The release ZIP currently includes `.cache` and `.github` directories, which is probably not expected. This change excludes them both from the release ZIP.