### PR TITLE
fix(gam): update api version

### DIFF
--- a/includes/providers/gam/api/class-ad-units.php
+++ b/includes/providers/gam/api/class-ad-units.php
@@ -9,18 +9,18 @@ namespace Newspack_Ads\Providers\GAM\Api;
 
 use Newspack_Ads\Providers\GAM\Api;
 use Newspack_Ads\Providers\GAM\Api\Api_Object;
-use Google\AdsApi\AdManager\Util\v202208\StatementBuilder;
-use Google\AdsApi\AdManager\v202208\ServiceFactory;
-use Google\AdsApi\AdManager\v202208\InventoryService;
-use Google\AdsApi\AdManager\v202208\Size;
-use Google\AdsApi\AdManager\v202208\EnvironmentType;
-use Google\AdsApi\AdManager\v202208\AdUnit;
-use Google\AdsApi\AdManager\v202208\AdUnitSize;
-use Google\AdsApi\AdManager\v202208\AdUnitTargetWindow;
-use Google\AdsApi\AdManager\v202208\ArchiveAdUnits as ArchiveAdUnitsAction;
-use Google\AdsApi\AdManager\v202208\ActivateAdUnits as ActivateAdUnitsAction;
-use Google\AdsApi\AdManager\v202208\DeactivateAdUnits as DeactivateAdUnitsAction;
-use Google\AdsApi\AdManager\v202208\ApiException;
+use Google\AdsApi\AdManager\Util\v202305\StatementBuilder;
+use Google\AdsApi\AdManager\v202305\ServiceFactory;
+use Google\AdsApi\AdManager\v202305\InventoryService;
+use Google\AdsApi\AdManager\v202305\Size;
+use Google\AdsApi\AdManager\v202305\EnvironmentType;
+use Google\AdsApi\AdManager\v202305\AdUnit;
+use Google\AdsApi\AdManager\v202305\AdUnitSize;
+use Google\AdsApi\AdManager\v202305\AdUnitTargetWindow;
+use Google\AdsApi\AdManager\v202305\ArchiveAdUnits as ArchiveAdUnitsAction;
+use Google\AdsApi\AdManager\v202305\ActivateAdUnits as ActivateAdUnitsAction;
+use Google\AdsApi\AdManager\v202305\DeactivateAdUnits as DeactivateAdUnitsAction;
+use Google\AdsApi\AdManager\v202305\ApiException;
 
 /**
  * Newspack Ads GAM Ad Units

--- a/includes/providers/gam/api/class-advertisers.php
+++ b/includes/providers/gam/api/class-advertisers.php
@@ -8,10 +8,10 @@
 namespace Newspack_Ads\Providers\GAM\Api;
 
 use Newspack_Ads\Providers\GAM\Api\Api_Object;
-use Google\AdsApi\AdManager\Util\v202208\StatementBuilder;
-use Google\AdsApi\AdManager\v202208\ServiceFactory;
-use Google\AdsApi\AdManager\v202208\Company;
-use Google\AdsApi\AdManager\v202208\CompanyType;
+use Google\AdsApi\AdManager\Util\v202305\StatementBuilder;
+use Google\AdsApi\AdManager\v202305\ServiceFactory;
+use Google\AdsApi\AdManager\v202305\Company;
+use Google\AdsApi\AdManager\v202305\CompanyType;
 
 /**
  * Newspack Ads GAM Advertisers

--- a/includes/providers/gam/api/class-api.php
+++ b/includes/providers/gam/api/class-api.php
@@ -14,10 +14,10 @@ use Google\Auth\OAuth2;
 use Google\AdsApi\Common\Configuration;
 use Google\AdsApi\AdManager\AdManagerSessionBuilder;
 use Google\AdsApi\AdManager\AdManagerSession;
-use Google\AdsApi\AdManager\v202208\ServiceFactory;
-use Google\AdsApi\AdManager\v202208\Network;
-use Google\AdsApi\AdManager\v202208\User;
-use Google\AdsApi\AdManager\v202208\ApiException;
+use Google\AdsApi\AdManager\v202305\ServiceFactory;
+use Google\AdsApi\AdManager\v202305\Network;
+use Google\AdsApi\AdManager\v202305\User;
+use Google\AdsApi\AdManager\v202305\ApiException;
 
 require_once NEWSPACK_ADS_COMPOSER_ABSPATH . 'autoload.php';
 require_once 'class-api-object.php';
@@ -35,7 +35,7 @@ class Api {
 	// https://developers.google.com/ad-manager/api/soap_xml: An arbitrary string name identifying your application. This will be shown in Google's log files.
 	const APP = 'Newspack';
 
-	const API_VERSION = 'v202208';
+	const API_VERSION = 'v202305';
 
 	/**
 	 * Codes of networks that the user has access to.

--- a/includes/providers/gam/api/class-creatives.php
+++ b/includes/providers/gam/api/class-creatives.php
@@ -9,10 +9,10 @@ namespace Newspack_Ads\Providers\GAM\Api;
 
 use Newspack_Ads\Providers\GAM\Api;
 use Newspack_Ads\Providers\GAM\Api\Api_Object;
-use Google\AdsApi\AdManager\Util\v202208\StatementBuilder;
-use Google\AdsApi\AdManager\v202208\ServiceFactory;
-use Google\AdsApi\AdManager\v202208\Creative;
-use Google\AdsApi\AdManager\v202208\Size;
+use Google\AdsApi\AdManager\Util\v202305\StatementBuilder;
+use Google\AdsApi\AdManager\v202305\ServiceFactory;
+use Google\AdsApi\AdManager\v202305\Creative;
+use Google\AdsApi\AdManager\v202305\Size;
 
 /**
  * Newspack Ads GAM Creatives

--- a/includes/providers/gam/api/class-line-items.php
+++ b/includes/providers/gam/api/class-line-items.php
@@ -9,21 +9,21 @@ namespace Newspack_Ads\Providers\GAM\Api;
 
 use Newspack_Ads\Providers\GAM\Api;
 use Newspack_Ads\Providers\GAM\Api\Api_Object;
-use Google\AdsApi\AdManager\Util\v202208\StatementBuilder;
-use Google\AdsApi\AdManager\v202208\ServiceFactory;
-use Google\AdsApi\AdManager\v202208\LineItemService;
-use Google\AdsApi\AdManager\v202208\LineItemCreativeAssociation;
-use Google\AdsApi\AdManager\v202208\LineItem;
-use Google\AdsApi\AdManager\v202208\Size;
-use Google\AdsApi\AdManager\v202208\Money;
-use Google\AdsApi\AdManager\v202208\Goal;
-use Google\AdsApi\AdManager\v202208\Targeting;
-use Google\AdsApi\AdManager\v202208\AdUnitTargeting;
-use Google\AdsApi\AdManager\v202208\InventoryTargeting;
-use Google\AdsApi\AdManager\v202208\CreativePlaceholder;
-use Google\AdsApi\AdManager\v202208\CustomCriteriaSet;
-use Google\AdsApi\AdManager\v202208\CustomCriteria;
-use Google\AdsApi\AdManager\v202208\ApiException;
+use Google\AdsApi\AdManager\Util\v202305\StatementBuilder;
+use Google\AdsApi\AdManager\v202305\ServiceFactory;
+use Google\AdsApi\AdManager\v202305\LineItemService;
+use Google\AdsApi\AdManager\v202305\LineItemCreativeAssociation;
+use Google\AdsApi\AdManager\v202305\LineItem;
+use Google\AdsApi\AdManager\v202305\Size;
+use Google\AdsApi\AdManager\v202305\Money;
+use Google\AdsApi\AdManager\v202305\Goal;
+use Google\AdsApi\AdManager\v202305\Targeting;
+use Google\AdsApi\AdManager\v202305\AdUnitTargeting;
+use Google\AdsApi\AdManager\v202305\InventoryTargeting;
+use Google\AdsApi\AdManager\v202305\CreativePlaceholder;
+use Google\AdsApi\AdManager\v202305\CustomCriteriaSet;
+use Google\AdsApi\AdManager\v202305\CustomCriteria;
+use Google\AdsApi\AdManager\v202305\ApiException;
 
 /**
  * Newspack Ads GAM Line Items

--- a/includes/providers/gam/api/class-orders.php
+++ b/includes/providers/gam/api/class-orders.php
@@ -9,11 +9,11 @@ namespace Newspack_Ads\Providers\GAM\Api;
 
 use Newspack_Ads\Providers\GAM\Api;
 use Newspack_Ads\Providers\GAM\Api\Api_Object;
-use Google\AdsApi\AdManager\Util\v202208\StatementBuilder;
-use Google\AdsApi\AdManager\v202208\ServiceFactory;
-use Google\AdsApi\AdManager\v202208\Order;
-use Google\AdsApi\AdManager\v202208\ArchiveOrders as ArchiveOrdersAction;
-use Google\AdsApi\AdManager\v202208\ApiException;
+use Google\AdsApi\AdManager\Util\v202305\StatementBuilder;
+use Google\AdsApi\AdManager\v202305\ServiceFactory;
+use Google\AdsApi\AdManager\v202305\Order;
+use Google\AdsApi\AdManager\v202305\ArchiveOrders as ArchiveOrdersAction;
+use Google\AdsApi\AdManager\v202305\ApiException;
 
 /**
  * Newspack Ads GAM Orders

--- a/includes/providers/gam/api/class-targeting-keys.php
+++ b/includes/providers/gam/api/class-targeting-keys.php
@@ -9,13 +9,13 @@ namespace Newspack_Ads\Providers\GAM\Api;
 
 use Newspack_Ads\Providers\GAM\Api;
 use Newspack_Ads\Providers\GAM\Api\Api_Object;
-use Google\AdsApi\AdManager\v202208\Statement;
-use Google\AdsApi\AdManager\v202208\String_ValueMapEntry;
-use Google\AdsApi\AdManager\v202208\TextValue;
-use Google\AdsApi\AdManager\v202208\SetValue;
-use Google\AdsApi\AdManager\v202208\CustomTargetingKey;
-use Google\AdsApi\AdManager\v202208\CustomTargetingValue;
-use Google\AdsApi\AdManager\v202208\ServiceFactory;
+use Google\AdsApi\AdManager\v202305\Statement;
+use Google\AdsApi\AdManager\v202305\String_ValueMapEntry;
+use Google\AdsApi\AdManager\v202305\TextValue;
+use Google\AdsApi\AdManager\v202305\SetValue;
+use Google\AdsApi\AdManager\v202305\CustomTargetingKey;
+use Google\AdsApi\AdManager\v202305\CustomTargetingValue;
+use Google\AdsApi\AdManager\v202305\ServiceFactory;
 
 /**
  * Newspack Ads GAM Default Targeting Keys


### PR DESCRIPTION
Updates the GAM API version from `v202208` to `v202305`.

### How to test

1. Install this branch on a fresh install
2. Connect to GAM using a service account or through Google OAuth
3. Confirm the account's ad units are synced
4. Create a new ad unit, and confirm it's created on the ad manager's dashboard
5. Archive the created ad unit and confirm it's archived on the ad manager's dashboard