### PR TITLE
feat(gam): support parent ad unit path

### DIFF
--- a/includes/providers/gam/api/class-ad-units.php
+++ b/includes/providers/gam/api/class-ad-units.php
@@ -15,6 +15,7 @@ use Google\AdsApi\AdManager\v202305\InventoryService;
 use Google\AdsApi\AdManager\v202305\Size;
 use Google\AdsApi\AdManager\v202305\EnvironmentType;
 use Google\AdsApi\AdManager\v202305\AdUnit;
+use Google\AdsApi\AdManager\v202305\AdUnitParent;
 use Google\AdsApi\AdManager\v202305\AdUnitSize;
 use Google\AdsApi\AdManager\v202305\AdUnitTargetWindow;
 use Google\AdsApi\AdManager\v202305\ArchiveAdUnits as ArchiveAdUnitsAction;
@@ -116,6 +117,21 @@ final class Ad_Units extends Api_Object {
 	}
 
 	/**
+	 * Get serialized ad unit parent.
+	 *
+	 * @param AdUnitParent $parent An ad unit parent.
+	 *
+	 * @return array
+	 */
+	public static function get_serialized_parent( $parent ) {
+		return [
+			'id'   => $parent->getId(),
+			'name' => $parent->getName(),
+			'code' => $parent->getAdUnitCode(),
+		];
+	}
+
+	/**
 	 * Serialize Ad Unit.
 	 *
 	 * @param AdUnit $gam_ad_unit An AdUnit.
@@ -123,8 +139,20 @@ final class Ad_Units extends Api_Object {
 	 * @return array Ad Unit configuration.
 	 */
 	private function get_serialized_ad_unit( $gam_ad_unit ) {
+		$path = array_map( [ __CLASS__, 'get_serialized_parent' ], $gam_ad_unit->getParentPath() );
+		// Remove path that matches `ca-pub-<int>` pattern.
+		$path = array_values(
+			array_filter(
+				$path,
+				function( $parent ) {
+					return ! preg_match( '/^ca-pub-\d+$/', $parent['code'] );
+				}
+			)
+		);
+
 		$ad_unit = [
 			'id'     => $gam_ad_unit->getId(),
+			'path'   => $path,
 			'code'   => $gam_ad_unit->getAdUnitCode(),
 			'status' => $gam_ad_unit->getStatus(),
 			'name'   => $gam_ad_unit->getName(),

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -109,6 +109,7 @@ final class GAM_Scripts {
 				'unique_id'        => $unique_id,
 				'name'             => esc_attr( $ad_unit['name'] ),
 				'code'             => esc_attr( $ad_unit['code'] ),
+				'path'             => $ad_unit['path'],
 				'sizes'            => $sizes,
 				'fluid'            => (bool) $ad_unit['fluid'],
 				'fixed_height'     => $fixed_height,
@@ -285,8 +286,16 @@ final class GAM_Scripts {
 							slotSizes = slotSizes.concat( 'fluid' );
 						}
 
+						var codeParts = [ ad_config['network_code'] ];
+						if ( ad_unit.path && ad_unit.path.length ) {
+							codeParts = codeParts.concat( ad_unit.path.map( function( parent ) {
+								return parent['code'];
+							} ) );
+						}
+						codeParts.push( ad_unit['code'] );
+						var code = '/' + codeParts.join( '/' );
 						defined_ad_units[ container_id ] = googletag.defineSlot(
-							'/' + ad_config['network_code'] + '/' + ad_unit['code'],
+							code,
 							slotSizes,
 							container_id
 						).addService( googletag.pubads() );


### PR DESCRIPTION
Implements support for parent ad unit path when configuring the slots.

Closes #493 

### How to test

1. Check out this branch and https://github.com/Automattic/newspack-plugin/pull/2592
2. Make sure you have GAM configured
3. Navigate to your GAM dashboard and create a child ad unit, through Inventory -> Ad Units and click "+ Add child ad unit":
<img width="421" alt="image" src="https://github.com/Automattic/newspack-ads/assets/820752/721a64e7-bc6b-442c-92b5-a8e6406f489b">

4. In WP dashboard, visit Newspack -> Advertising -> Configure GAM
5. Locate the created unit and click to edit
6. Confirm the code includes the parent unit code in its path
7. Visit "Placements", apply the new child unit to a global placement
8. Visit the front-end with the `?googfc` URL parameter
9. Locate the new unit in the console and confirm the code includes the parent path