### PR TITLE
feat(marketplace): email settings

### DIFF
--- a/includes/marketplace/class-api.php
+++ b/includes/marketplace/class-api.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Ads Marketplace
+ * Newspack Ads Marketplace API.
  *
  * @package Newspack
  */

--- a/includes/marketplace/class-api.php
+++ b/includes/marketplace/class-api.php
@@ -7,6 +7,7 @@
 
 namespace Newspack_Ads\Marketplace;
 
+use Newspack_Ads\Marketplace;
 use Newspack_Ads\Settings;
 use WC_Product_Simple;
 
@@ -32,6 +33,28 @@ final class API {
 	 * Register API endpoints.
 	 */
 	public static function register_rest_routes() {
+		/**
+		 * Settings.
+		 */
+		\register_rest_route(
+			Settings::API_NAMESPACE,
+			'/marketplace/settings',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ __CLASS__, 'api_get_settings' ],
+				'permission_callback' => [ 'Newspack_Ads\Settings', 'api_permissions_check' ],
+			]
+		);
+		\register_rest_route(
+			Settings::API_NAMESPACE,
+			'/marketplace/settings',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ __CLASS__, 'api_update_settings' ],
+				'permission_callback' => [ 'Newspack_Ads\Settings', 'api_permissions_check' ],
+				'args'                => Marketplace::get_settings_args(),
+			]
+		);
 		/**
 		 * Ad Product.
 		 */
@@ -112,6 +135,28 @@ final class API {
 				'permission_callback' => [ 'Newspack_Ads\Settings', 'api_permissions_check' ],
 			]
 		);
+	}
+
+	/**
+	 * Get marketplace settings.
+	 *
+	 * @return \WP_REST_Response containing the ad product data or error.
+	 */
+	public static function api_get_settings() {
+		return \rest_ensure_response( Marketplace::get_settings() );
+	}
+
+	/**
+	 * Update marketplace settings.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 *
+	 * @return \WP_REST_Response containing the ad product data or error.
+	 */
+	public static function api_update_settings( $request ) {
+		$args = array_intersect_key( $request->get_params(), Marketplace::get_settings_args() );
+		Marketplace::update_settings( $args );
+		return \rest_ensure_response( Marketplace::get_settings() );
 	}
 
 	/**

--- a/includes/marketplace/class-email.php
+++ b/includes/marketplace/class-email.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Newspack Ads Marketplace: Email notification.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Ads\Marketplace;
+
+use Newspack_Ads\Marketplace;
+
+/**
+ * Newspack Ads Marketplace Email Notification Class.
+ */
+final class Email {
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_filter( 'woocommerce_email_headers', [ __CLASS__, 'email_headers' ], 10, 3 );
+		add_filter( 'woocommerce_email_subject_new_order', [ __CLASS__, 'email_subject' ], 10, 2 );
+		add_filter( 'woocommerce_email_additional_content_new_order', [ __CLASS__, 'email_additional_content' ], 10, 2 );
+	}
+
+	/**
+	 * Modify email headers.
+	 *
+	 * @param string $header    Email headers.
+	 * @param string $method_id Method ID.
+	 * @param object $object    Object.
+	 */
+	public static function email_headers( $header, $method_id, $object ) {
+		if ( 'new_order' !== $method_id || ! $object->get_meta( 'newspack_ads_is_ad_order' ) ) {
+			return $header;
+		}
+		$settings = Marketplace::get_settings();
+		if ( ! $settings['enable_email_notification'] || empty( $settings['notification_email_address'] ) ) {
+			return $header;
+		}
+		$header .= 'Cc: ' . $settings['notification_email_address'] . "\r\n";
+		return $header;
+	}
+
+	/**
+	 * Modify email subject.
+	 *
+	 * @param string $subject Email subject.
+	 * @param object $object  Object.
+	 */
+	public static function email_subject( $subject, $object ) {
+		if ( ! $object->get_meta( 'newspack_ads_is_ad_order' ) ) {
+			return $subject;
+		}
+		return sprintf(
+			/* translators: %1$s: site name, %2$s: order ID */
+			__( '[%1$s] New Marketplace Ad Order #%2$s', 'newspack-ads' ),
+			get_bloginfo( 'name' ),
+			$object->get_id()
+		);
+	}
+
+	/**
+	 * Modify email additional content.
+	 *
+	 * @param string $content Email content.
+	 * @param object $object  Object.
+	 */
+	public static function email_additional_content( $content, $object ) {
+		if ( ! $object->get_meta( 'newspack_ads_is_ad_order' ) ) {
+			return $content;
+		}
+		$gam_link = sprintf(
+			'<a href="%s">%s</a>',
+			esc_url( Product_Order::get_gam_order_url( $object ) ),
+			esc_html__( 'View order in GAM', 'newspack-ads' )
+		);
+		$content .= '<p>' . $gam_link . '</p>';
+		return $content;
+	}
+}
+Email::init();

--- a/includes/marketplace/class-marketplace.php
+++ b/includes/marketplace/class-marketplace.php
@@ -18,6 +18,9 @@ defined( 'ABSPATH' ) || exit;
  * Newspack Ads Marketplace Class.
  */
 final class Marketplace {
+
+	const SETTINGS_OPTION_NAME = 'newspack_ads_marketplace_settings';
+
 	/**
 	 * Initialize hooks.
 	 */
@@ -66,6 +69,51 @@ final class Marketplace {
 			$link = admin_url( 'admin.php?page=newspack-advertising-wizard#/marketplace' );
 		}
 		return $link;
+	}
+
+	/**
+	 * Marketplace Settings REST Arguments.
+	 *
+	 * @return array
+	 */
+	public static function get_settings_args() {
+		return [
+			'enable_email_notification'  => [
+				'required'          => true,
+				'type'              => 'boolean',
+				'sanitize_callback' => 'rest_sanitize_boolean',
+			],
+			'notification_email_address' => [
+				'required'          => true,
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_email',
+			],
+		];
+	}
+
+	/**
+	 * Get marketplace settings.
+	 *
+	 * @return array Settings.
+	 */
+	public static function get_settings() {
+		$default_settings = [
+			'enable_email_notification'  => true,
+			'notification_email_address' => get_option( 'admin_email' ),
+		];
+		$settings         = get_option( self::SETTINGS_OPTION_NAME, [] );
+		return wp_parse_args( $settings, $default_settings );
+	}
+
+	/**
+	 * Update marketplace settings.
+	 *
+	 * @param array $settings Settings.
+	 *
+	 * @return bool
+	 */
+	public static function update_settings( $settings ) {
+		return update_option( self::SETTINGS_OPTION_NAME, $settings );
 	}
 
 }

--- a/includes/marketplace/class-marketplace.php
+++ b/includes/marketplace/class-marketplace.php
@@ -29,6 +29,7 @@ final class Marketplace {
 		require_once 'class-product.php';
 		require_once 'class-product-cart.php';
 		require_once 'class-product-order.php';
+		require_once 'class-email.php';
 		require_once 'class-api.php';
 
 		\add_filter( 'get_edit_post_link', [ __CLASS__, 'get_edit_post_link' ], PHP_INT_MAX, 3 );

--- a/includes/marketplace/class-product.php
+++ b/includes/marketplace/class-product.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Ads Marketplace
+ * Newspack Ads Marketplace Product.
  *
  * @package Newspack
  */


### PR DESCRIPTION
Implements support for custom email notifications on marketplace orders.

<img width="1052" alt="image" src="https://github.com/Automattic/newspack-ads/assets/820752/257a29c4-274e-4dc6-b640-1c9f7f7aea7c">

### How to test this PR

1. Check out this branch and https://github.com/Automattic/newspack-plugin/pull/2628
2. Make sure you are connected to a GAM account and have marketplace products created (see https://github.com/Automattic/newspack-ads/pull/566)
3. Visit Advertising -> Marketplace -> Settings
4. Confirm it renders as in the image above
5. Set a custom email and save
6. Make sure you have "New Order" emails enabled in WC (per form instruction)
7. Edit a new page and add the "Marketplace" block, which renders only a placeholder component in the editor
8. Visit the page, select a product, a valid date range (cannot be starting Today), and upload creatives that match the ad product requirements of size (see https://github.com/Automattic/newspack-ads/pull/670)
9. Proceed to payment and place the order
10. Confirm the email is sent with the following subject line: **`[Site Name] New Marketplace Ad Order #{order_id}`**
11. Confirm the email body has a link to **"View order in GAM"**