### PR TITLE
fix: dont throw fatals if parentPath is null

### DIFF
--- a/includes/providers/gam/api/class-ad-units.php
+++ b/includes/providers/gam/api/class-ad-units.php
@@ -139,6 +139,12 @@ final class Ad_Units extends Api_Object {
 	 * @return array Ad Unit configuration.
 	 */
 	private function get_serialized_ad_unit( $gam_ad_unit ) {
+		$parent_path = $gam_ad_unit->getParentPath();
+		if ( $parent_path) ) {
+			$path = array_map( [ __CLASS__, 'get_serialized_parent' ], $parent_path );
+		} else {
+			$path = [];
+		}
 		$path = array_map( [ __CLASS__, 'get_serialized_parent' ], $gam_ad_unit->getParentPath() );
 		// Remove path that matches `ca-pub-<int>` pattern.
 		$path = array_values(

--- a/includes/providers/gam/api/class-ad-units.php
+++ b/includes/providers/gam/api/class-ad-units.php
@@ -145,7 +145,7 @@ final class Ad_Units extends Api_Object {
 		} else {
 			$path = [];
 		}
-		$path = array_map( [ __CLASS__, 'get_serialized_parent' ], $gam_ad_unit->getParentPath() );
+
 		// Remove path that matches `ca-pub-<int>` pattern.
 		$path = array_values(
 			array_filter(

--- a/includes/providers/gam/api/class-ad-units.php
+++ b/includes/providers/gam/api/class-ad-units.php
@@ -140,7 +140,7 @@ final class Ad_Units extends Api_Object {
 	 */
 	private function get_serialized_ad_unit( $gam_ad_unit ) {
 		$parent_path = $gam_ad_unit->getParentPath();
-		if ( $parent_path) ) {
+		if ( $parent_path ) {
 			$path = array_map( [ __CLASS__, 'get_serialized_parent' ], $parent_path );
 		} else {
 			$path = [];


### PR DESCRIPTION
Not sure how to force `getParentPath` to return `null` because [according to the docs it should always return an array (and an empty array if there is no parent)](https://developers.google.com/ad-manager/api/reference/v202305/InventoryService.AdUnit#parentpath). It can happen somehow though! If it does, we don't want fatal errors.