### PR TITLE
fix(gam): validate network code on session creation

### DIFF
--- a/includes/providers/gam/api/class-api.php
+++ b/includes/providers/gam/api/class-api.php
@@ -217,27 +217,6 @@ class Api {
 	}
 
 	/**
-	 * Whether the given network code is valid for the authenticated user.
-	 *
-	 * @param int $network_code Network code to validate.
-	 *
-	 * @return bool Whether the network code is valid.
-	 */
-	public function validate_network_code( $network_code ) {
-		$session = $this->get_session();
-		if ( \is_wp_error( $session ) ) {
-			return $session;
-		}
-		$networks = $this->get_networks( $session );
-		foreach ( $networks as $network ) {
-			if ( $network_code === $network->getNetworkCode() ) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	/**
 	 * Get GAM Connection User.
 	 *
 	 * @return User

--- a/includes/providers/gam/api/class-api.php
+++ b/includes/providers/gam/api/class-api.php
@@ -207,17 +207,34 @@ class Api {
 				'applicationName' => self::APP,
 			],
 		];
-		/** If a network code is not yet available, use first from list. */
-		if ( ! $this->network_code ) {
-			$session  = ( new AdManagerSessionBuilder() )->from( new Configuration( $config ) )->withOAuth2Credential( $this->credentials )->build();
-			$networks = $this->get_networks( $session );
-			if ( ! empty( $networks ) ) {
-				$this->network_code = $networks[0]->getNetworkCode();
+
+		// Get network code and add it to the session config.
+		$config['AD_MANAGER']['networkCode'] = $this->get_network_code( ( new AdManagerSessionBuilder() )->from( new Configuration( $config ) )->withOAuth2Credential( $this->credentials )->build() );
+
+		// Generate and return session.
+		$this->session = ( new AdManagerSessionBuilder() )->from( new Configuration( $config ) )->withOAuth2Credential( $this->credentials )->build();
+		return $this->session;
+	}
+
+	/**
+	 * Whether the given network code is valid for the authenticated user.
+	 *
+	 * @param int $network_code Network code to validate.
+	 *
+	 * @return bool Whether the network code is valid.
+	 */
+	public function validate_network_code( $network_code ) {
+		$session = $this->get_session();
+		if ( \is_wp_error( $session ) ) {
+			return $session;
+		}
+		$networks = $this->get_networks( $session );
+		foreach ( $networks as $network ) {
+			if ( $network_code === $network->getNetworkCode() ) {
+				return true;
 			}
 		}
-		$config['AD_MANAGER']['networkCode'] = $this->network_code;
-		$this->session                       = ( new AdManagerSessionBuilder() )->from( new Configuration( $config ) )->withOAuth2Credential( $this->credentials )->build();
-		return $this->session;
+		return false;
 	}
 
 	/**
@@ -269,12 +286,14 @@ class Api {
 	/**
 	 * Get user's GAM network. Defaults to the first found network if not found or empty.
 	 *
+	 * @param AdManagerSession $session Optional session to use.
+	 *
 	 * @return Network GAM network.
 	 *
 	 * @throws \Exception If there is no GAM network to use.
 	 */
-	public function get_network() {
-		$networks     = $this->get_networks();
+	public function get_network( $session = null ) {
+		$networks     = $this->get_networks( $session );
 		$network_code = $this->network_code;
 		if ( empty( $networks ) ) {
 			throw new \Exception( __( 'Missing GAM Ad network.', 'newspack-ads' ) );
@@ -292,10 +311,12 @@ class Api {
 	/**
 	 * Get user's GAM network code.
 	 *
+	 * @param AdManagerSession $session Optional session to use.
+	 *
 	 * @return int GAM network code.
 	 */
-	public function get_network_code() {
-		return $this->get_network()->getNetworkCode();
+	public function get_network_code( $session = null ) {
+		return $this->get_network( $session )->getNetworkCode();
 	}
 
 	/**

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -650,8 +650,11 @@ final class GAM_Model {
 		}
 
 		if ( isset( $settings['network_code'] ) && $serialised_ad_units && ! empty( $serialised_ad_units ) ) {
-			$synced_gam_items                              = get_option( self::OPTION_NAME_GAM_ITEMS, [] );
-			$network_code                                  = sanitize_text_field( $settings['network_code'] );
+			$synced_gam_items = get_option( self::OPTION_NAME_GAM_ITEMS, [] );
+			$network_code     = sanitize_text_field( $settings['network_code'] );
+			if ( empty( $synced_gam_items ) || ! is_array( $synced_gam_items ) ) {
+				$synced_gam_items = [];
+			}
 			$synced_gam_items[ $network_code ]['ad_units'] = $serialised_ad_units;
 			self::update_gam_config( $network_code, $synced_gam_items );
 		}
@@ -667,7 +670,7 @@ final class GAM_Model {
 	 */
 	private static function update_gam_config( $network_code, $gam_items ) {
 		update_option( self::OPTION_NAME_LEGACY_NETWORK_CODE, $network_code );
-		update_option( self::OPTION_NAME_GAM_ITEMS, $synced_gam_items );
+		update_option( self::OPTION_NAME_GAM_ITEMS, $gam_items );
 		// Avoid notoptions cache issue.
 		wp_cache_delete( 'notoptions', 'options' );
 		wp_cache_delete( 'alloptions', 'options' );

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -362,7 +362,7 @@ final class GAM_Model {
 						}
 						$ad_units[ $ad_unit_key ] = $gam_ad_unit;
 					}
-					update_option( self::OPTION_NAME_DEFAULT_UNITS, $ad_units );
+					self::update_default_units( $ad_units );
 				}
 			}
 		}
@@ -382,6 +382,20 @@ final class GAM_Model {
 			array_keys( $ad_units ),
 			array_values( $ad_units )
 		);
+	}
+
+	/**
+	 * Update default units
+	 *
+	 * @param array $ad_units Default units.
+	 *
+	 * @return void
+	 */
+	private static function update_default_units( $ad_units ) {
+		update_option( self::OPTION_NAME_DEFAULT_UNITS, $ad_units );
+		// Avoid notoptions cache issue.
+		wp_cache_delete( 'notoptions', 'options' );
+		wp_cache_delete( 'alloptions', 'options' );
 	}
 
 	/**
@@ -639,9 +653,24 @@ final class GAM_Model {
 			$synced_gam_items                              = get_option( self::OPTION_NAME_GAM_ITEMS, [] );
 			$network_code                                  = sanitize_text_field( $settings['network_code'] );
 			$synced_gam_items[ $network_code ]['ad_units'] = $serialised_ad_units;
-			update_option( self::OPTION_NAME_LEGACY_NETWORK_CODE, $network_code );
-			update_option( self::OPTION_NAME_GAM_ITEMS, $synced_gam_items );
+			self::update_gam_config( $network_code, $synced_gam_items );
 		}
+	}
+
+	/**
+	 * Update GAM configuration.
+	 *
+	 * @param string $network_code Network code.
+	 * @param array  $gam_items    GAM Items.
+	 *
+	 * @return void
+	 */
+	private static function update_gam_config( $network_code, $gam_items ) {
+		update_option( self::OPTION_NAME_LEGACY_NETWORK_CODE, $network_code );
+		update_option( self::OPTION_NAME_GAM_ITEMS, $synced_gam_items );
+		// Avoid notoptions cache issue.
+		wp_cache_delete( 'notoptions', 'options' );
+		wp_cache_delete( 'alloptions', 'options' );
 	}
 
 	/**
@@ -1149,6 +1178,9 @@ final class GAM_Model {
 			if ( ! empty( $network_code ) ) {
 				$status['network_code'] = $network_code;
 				update_option( self::OPTION_NAME_GAM_NETWORK_CODE, $network_code );
+				// Avoid notoptions cache issue.
+				wp_cache_delete( 'notoptions', 'options' );
+				wp_cache_delete( 'alloptions', 'options' );
 			}
 			$status['is_network_code_matched'] = self::is_network_code_matched();
 		} elseif ( self::$api_fatal_error ) {
@@ -1207,6 +1239,9 @@ final class GAM_Model {
 			return new \WP_Error( 'newspack_ads_gam_credentials', __( 'Invalid credentials configuration.', 'newspack-ads' ) );
 		}
 		$update_result = update_option( self::SERVICE_ACCOUNT_CREDENTIALS_OPTION_NAME, $config );
+		// Avoid notoptions cache issue.
+		wp_cache_delete( 'notoptions', 'options' );
+		wp_cache_delete( 'alloptions', 'options' );
 		if ( ! $update_result ) {
 			return new \WP_Error( 'newspack_ads_gam_credentials', __( 'Unable to update GAM credentials', 'newspack-ads' ) );
 		}


### PR DESCRIPTION
Validate the stored network code while creating the GAM API session. This change prevents user/credentials from getting stuck with an invalid network code when the connected account is updated.

It also adds cache deletion on option updates to prevent the 'notoptions' bug on memcache.

### How to test

1. While on the master branch, make sure you are connected to GAM
2. Manually change `_newspack_ads_service_google_ad_manager_network_code` and `_newspack_ads_gam_network_code` to an invalid value:
```
wp option update _newspack_ads_service_google_ad_manager_network_code "1"
wp option update _newspack_ads_gam_network_code "1"
```

3. Refresh the Advertising dashboard and confirm you get the "**The network code is invalid.**" error
4. Check out this branch, refresh, and confirm the error is gone and the network code is updated to match the network your account has access to.