### PR TITLE
fix(gam): default units array search matching

### DIFF
--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -346,7 +346,7 @@ final class GAM_Model {
 							continue;
 						}
 						$ad_unit_idx = array_search( $ad_unit_config['name'], array_column( $gam_ad_units, 'name' ) );
-						if ( $ad_unit_idx ) {
+						if ( false !== $ad_unit_idx ) {
 							$gam_ad_unit = $gam_ad_units[ $ad_unit_idx ];
 							/** Update ad unit status to 'ACTIVE' if not active. */
 							if ( 'ACTIVE' !== $gam_ad_unit['status'] ) {


### PR DESCRIPTION
If the found synced GAM ad unit is at index `0` it will be ignored by the current check and cause a faulty ad unit collection:

![image](https://github.com/Automattic/newspack-ads/assets/820752/b73c8782-d379-4ad1-842e-7f2468a0a3b4)

This PR fixes the index check by doing a strict comparison to `false`.