### PR TITLE
fix(gam): silence network code check warning

### DIFF
--- a/includes/providers/gam/api/class-api.php
+++ b/includes/providers/gam/api/class-api.php
@@ -209,8 +209,12 @@ class Api {
 		];
 
 		// Get network code and add it to the session config.
-		$config['AD_MANAGER']['networkCode'] = $this->get_network_code( ( new AdManagerSessionBuilder() )->from( new Configuration( $config ) )->withOAuth2Credential( $this->credentials )->build() );
-
+		try {
+			// We're silencing errors here because the SDK throws a warning when the request config doesn't include a network code.
+			$config['AD_MANAGER']['networkCode'] = @$this->get_network_code( ( new AdManagerSessionBuilder() )->from( new Configuration( $config ) )->withOAuth2Credential( $this->credentials )->build() ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		} catch ( \Exception $e ) {
+			return $this->get_error( $e, __( 'Unable to fetch network code from GAM.', 'newspack-ads' ) );
+		}
 		// Generate and return session.
 		$this->session = ( new AdManagerSessionBuilder() )->from( new Configuration( $config ) )->withOAuth2Credential( $this->credentials )->build();
 		return $this->session;


### PR DESCRIPTION
Prevents the following warning coming from GAM's SDK:

```
PHP Warning:  Network code is not specified. An API function will reject requests if it requires a network code.
```

This request is sent without a network code on purpose because it's fetching which network code it'll use.

### How to test

1. While on the master branch, confirm you're connected to GAM and visit the Advertising dashboard
2. Confirm you see the warning in your logs
3. Check out this branch, refresh the page and confirm there are no warnings