### PR TITLE
fix(gam): handle missing ad unit 'path'

### DIFF
--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -109,7 +109,7 @@ final class GAM_Scripts {
 				'unique_id'        => $unique_id,
 				'name'             => esc_attr( $ad_unit['name'] ),
 				'code'             => esc_attr( $ad_unit['code'] ),
-				'path'             => $ad_unit['path'],
+				'path'             => $ad_unit['path'] ?? '',
 				'sizes'            => $sizes,
 				'fluid'            => (bool) $ad_unit['fluid'],
 				'fixed_height'     => $fixed_height,


### PR DESCRIPTION
Cached ad units may not include the 'path' property. This prevents from this throwing a warning.

### How to test

GAM ads should continue to render without issues or server warnings.