### PR TITLE
chore: newspack.pub > newspack.com

### DIFF
--- a/newspack-ads.php
+++ b/newspack-ads.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name:     Newspack Ads
- * Plugin URI:      https://newspack.blog
+ * Plugin URI:      https://newspack.com
  * Description:     Ad services integration.
  * Author:          Automattic
  * License:         GPL2


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Updates some lingering legacy URLs throughout the code. All instances of newspack.pub or newspack.blog should be newspack.com

### How to test the changes in this Pull Request:

No functional changes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
