### PR TITLE
🛠️ Update Deprecated Constant: FILTER_SANITIZE_STRING

### DIFF
--- a/includes/integrations/class-bidding-gam.php
+++ b/includes/integrations/class-bidding-gam.php
@@ -322,7 +322,7 @@ final class Bidding_GAM {
 	public static function enqueue_scripts() {
 
 		$slug = 'newspack-advertising-wizard';
-		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_STRING ) !== $slug ) {
+		if ( filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) !== $slug ) {
 			return;
 		}
 


### PR DESCRIPTION
### Description
- Replace deprecated FILTER_SANITIZE_STRING with FILTER_SANITIZE_FULL_SPECIAL_CHARS to maintain PHP 8.1 compatibility.

### VIP Log


6453 | preprod | preprod | 2023-10-23T12:30:23.139443119Z | PHP message: PHP Deprecated:  Constant FILTER_SANITIZE_STRING is deprecated in /var/www/wp-content/plugins/newspack-ads/includes/integrations/class-bidding-gam.php on line 325
-- | -- | -- | -- | --




### Platform Description
- WP 6.3.2
- PHP 8.1
- WP VIP Site