### PR TITLE
feat(perf): don't enqueue CSS if ads are not to be displayed

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -56,6 +56,10 @@ final class Core {
 	 * Enqueue front-end styles.
 	 */
 	public static function enqueue_scripts() {
+		if ( ! newspack_ads_should_show_ads() ) {
+			return;
+		}
+
 		\wp_register_style(
 			'newspack-ads-frontend',
 			plugins_url( '../dist/frontend.css', __FILE__ ),


### PR DESCRIPTION
If the page should not display ads, don't enqueue CSS. 

## How to test 

1. Visit a page that will display ads, observe that `frontend.css` file is downloaded
2. Visit a page that has ads disabled, observe that the file is not downloaded