### PR TITLE
feat(gam): support "site" custom targeting key-val

### DIFF
--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -1086,6 +1086,9 @@ final class GAM_Model {
 	public static function get_ad_targeting( $ad_unit ) {
 		$targeting = [];
 
+		// Add site url.
+		$targeting['site'] = \get_bloginfo( 'url' );
+
 		if ( is_singular() ) {
 			// Add the post slug to targeting.
 			$slug = get_post_field( 'post_name' );


### PR DESCRIPTION
Implements "site" custom targeting key-val with type "PREDEFINED" and reportable type set to "CUSTOM_DIMENSION".

The `Targeting_Keys::update_default_targeting_keys()` method was also updated to use the `Targeting_Keys::create_targeting_key()` method instead of its own logic for better maintenance.

### Testing

1. If you have the `site` targeting key already created, visit your GAM Inventory -> Key-values, edit and delete each value, then delete the key (mind that GAM never deletes an entity, it's only archived)
3. Make sure you are connected to a GAM account in your Newspack instance
4. Check out this branch, visit Newspack -> Advertising, and confirm the targeting key is created:
<img width="734" alt="image" src="https://github.com/Automattic/newspack-ads/assets/820752/094db1bc-557e-44b1-a3af-d96af58b3de0">

5. Visit your GAM inventory and confirm the `site` is created with the previously available values plus your instance's URL