### PR TITLE
fix(gam): parse targeting site url

### DIFF
--- a/includes/providers/gam/api/class-targeting-keys.php
+++ b/includes/providers/gam/api/class-targeting-keys.php
@@ -36,6 +36,24 @@ final class Targeting_Keys extends Api_Object {
 	];
 
 	/**
+	 * Parse site URL for targeting.
+	 *
+	 * @param string $url The URL to parse.
+	 *
+	 * @return string The parsed URL.
+	 */
+	public static function parse_site_url( $url ) {
+		// Remove the protocol.
+		$url = str_replace( 'https://', '', $url );
+		$url = str_replace( 'http://', '', $url );
+		// Remove the trailing slash.
+		$url = rtrim( $url, '/' );
+		// Remove the www. subdomain.
+		$url = str_replace( 'www.', '', $url );
+		return $url;
+	}
+
+	/**
 	 * Get config for generating a targeting key-val.
 	 *
 	 * @param string $key The key name.
@@ -56,7 +74,7 @@ final class Targeting_Keys extends Api_Object {
 			case 'site':
 				$config['type']            = 'PREDEFINED';
 				$config['reportable_type'] = 'CUSTOM_DIMENSION';
-				$config['values']          = [ \get_bloginfo( 'url' ) ];
+				$config['values']          = [ self::parse_site_url( \get_bloginfo( 'url' ) ) ];
 				break;
 		}
 		return $config;


### PR DESCRIPTION
GAM limits a targeting key value to 40 characters. To reduce the chances of a site URL reaching the limit, this PR implements some parsing to remove the protocol, `www.` and trailing slash.

### How to test

Same as #770, but the value should now be `example.com` instead of `https://www.example.com/`