### PR TITLE
feat: filter for settings access

### DIFF
--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -15,7 +15,6 @@ defined( 'ABSPATH' ) || exit;
 final class Settings {
 
 	const API_NAMESPACE      = 'newspack-ads/v1';
-	const API_CAPABILITY     = 'manage_options';
 	const OPTION_NAME_PREFIX = '_newspack_ads_';
 
 	/**
@@ -29,7 +28,6 @@ final class Settings {
 	 * Register the endpoints needed to fetch and update settings.
 	 */
 	public static function register_api_endpoints() {
-
 		register_rest_route(
 			self::API_NAMESPACE,
 			'/settings',
@@ -62,12 +60,19 @@ final class Settings {
 	}
 
 	/**
+	 * Can current user manage the settings?
+	 */
+	public static function can_current_user_manage_settings() {
+		return apply_filters( 'newspack_ads_can_current_user_manage_settings', current_user_can( 'manage_options' ) );
+	}
+
+	/**
 	 * Check capabilities for using API.
 	 *
 	 * @return bool|\WP_Error True or error object.
 	 */
 	public static function api_permissions_check() {
-		if ( ! current_user_can( self::API_CAPABILITY ) ) {
+		if ( ! self::can_current_user_manage_settings() ) {
 			return new \WP_Error(
 				'newspack_ads_rest_forbidden',
 				esc_html__( 'You cannot use this resource.', 'newspack-ads' ),

--- a/includes/customizer/class-customizer.php
+++ b/includes/customizer/class-customizer.php
@@ -90,7 +90,6 @@ final class Customizer {
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/customizer/class-placement-customize-control.php';
 
 		$placements = Placements::get_placements();
-		$capability = Settings::API_CAPABILITY;
 
 		// Register panel.
 		$wp_customize->add_panel(
@@ -114,15 +113,16 @@ final class Customizer {
 					'panel' => 'newspack-ads',
 				]
 			);
-			$wp_customize->add_setting(
-				$setting_id,
-				[
-					'type'              => 'option',
-					'capability'        => $capability,
-					'transport'         => 'postMessage',
-					'sanitize_callback' => [ __CLASS__, 'sanitize' ],
-				]
-			);
+			if ( Settings::can_current_user_manage_settings() ) {
+				$wp_customize->add_setting(
+					$setting_id,
+					[
+						'type'              => 'option',
+						'transport'         => 'postMessage',
+						'sanitize_callback' => [ __CLASS__, 'sanitize' ],
+					]
+				);
+			}
 			$wp_customize->add_control(
 				new Placement_Customize_Control(
 					$wp_customize,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds filtering of admin panel access. This will be used by upcoming changes in the Newspack Plugin, which will introduce granular capabilities management. 

### How to test the changes in this Pull Request:

1. There should be no functional changes for end users, this is a backend feature. Verify that Newspack Advertising wizard can still be accessed as an admin* user 

\* a user with `manage_options` capability

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->