### PR TITLE
fix(gam): sanitize URL for "site" targeting key-val

### DIFF
--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -1087,7 +1087,7 @@ final class GAM_Model {
 		$targeting = [];
 
 		// Add site url.
-		$targeting['site'] = \get_bloginfo( 'url' );
+		$targeting['site'] = GAM_Api\Targeting_Keys::sanitize_url( \get_bloginfo( 'url' ) );
 
 		if ( is_singular() ) {
 			// Add the post slug to targeting.


### PR DESCRIPTION
1200550061930446-as-1206445581284648

The "site" targeting key-val for GAM is created with pre-defined values that are sanitized. The targeting in the slot is currently missing the sanitization. This PR sanitizes the URL that is sent to the ad slot.

### How to test

1. While on the `release` branch, make sure you have a GAM ad rendered on your site
2. Visit the page with an ad with the `?googfc` query param
3. Open the targeting info for the slot and confirm the "site" value includes the URL protocol and possibly trailing slash
4. Check out this branch, refresh and confirm it doesn't include protocol or trailing slash