### PR TITLE
Fix/avoid fatal

### DIFF
--- a/includes/providers/gam/api/class-targeting-keys.php
+++ b/includes/providers/gam/api/class-targeting-keys.php
@@ -160,6 +160,10 @@ final class Targeting_Keys extends Api_Object {
 	public function upsert_targeting_key_values( $targeting_key, $values ) {
 		$service          = ( new ServiceFactory() )->createCustomTargetingService( $this->session );
 		$key_id           = $targeting_key->getId();
+
+		// Discard empty values.
+		$values = array_values( array_filter( $values ) );
+
 		$values_statement = new Statement(
 			"WHERE customTargetingKeyId = :key_id AND name = :name AND status = 'ACTIVE'",
 			[


### PR DESCRIPTION
If you call `upsert_targeting_key_values` and `$values` has one empty value in it, this method will throw a Fatal error:

```
PHP Fatal error:  Uncaught Google\AdsApi\AdManager\v202305\ApiException: [CustomTargetingError.VALUE_NAME_EMPTY @ name]
```

Let's avoid that from happening by removing empty values from the array in case it happens.