### PR TITLE
fix: address dynamic prop warnings in gam api class

### DIFF
--- a/includes/providers/gam/api/class-api.php
+++ b/includes/providers/gam/api/class-api.php
@@ -73,6 +73,48 @@ class Api {
 	private $credentials = null;
 
 	/**
+	 * Advertisers
+	 *
+	 * @var Api\Advertisers
+	 */
+	public $advertisers = null;
+
+	/**
+	 * Creatives
+	 *
+	 * @var Api\Creatives
+	 */
+	public $creatives = null;
+
+	/**
+	 * Targeting Keys
+	 *
+	 * @var Api\Targeting_Keys
+	 */
+	public $targeting_keys = null;
+
+	/**
+	 * Ad Units
+	 *
+	 * @var Api\Ad_Units
+	 */
+	public $ad_units = null;
+
+	/**
+	 * Line Items
+	 *
+	 * @var Api\Line_Items
+	 */
+	public $line_items = null;
+
+	/**
+	 * Orders
+	 *
+	 * @var Api\Orders
+	 */
+	public $orders = null;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string|AdManagerSession $auth_method_or_session Authentication method or session.


### PR DESCRIPTION
Closes [0/1206638335395048/1206638704028951/f](https://app.asana.com/0/1206638335395048/1206638704028951/f)

This fixes some deprecated dynamic property warnings that were showing up in the logs when configuring GAM ad placements:
![Screenshot 2024-03-12 at 13 00 13](https://github.com/Automattic/newspack-ads/assets/17905991/c6e9d5b9-ab03-4b87-a514-4b0de3efa99a)

### Testing instructions
1. If you haven't already, connect GAM via Newspack > Connections
![Screenshot 2024-03-12 at 14 01 24](https://github.com/Automattic/newspack-ads/assets/17905991/fb076727-c0d4-4cac-b007-363df01d202f)
2. While monitoring `debug.log`, go to Advertising placement settings and start enabling some ad placements via Newspack > Advertising > Placements.
3. On `trunk` you will see some of the deprecated warnings in the image above. In this branch, you should not. Note that some of the Ad Manager dependency code will still trigger these warnings, but that is out of our control.