### PR TITLE
feat: add reader_status key-val targeting

### DIFF
--- a/includes/providers/gam/api/class-targeting-keys.php
+++ b/includes/providers/gam/api/class-targeting-keys.php
@@ -33,6 +33,7 @@ final class Targeting_Keys extends Api_Object {
 		'post_type',
 		'template',
 		'site',
+		'reader_status',
 	];
 
 	/**

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -1096,6 +1096,11 @@ final class GAM_Model {
 			if ( method_exists( 'Newspack\Reader_Data', 'get_data' ) ) {
 				$reader_data = \Newspack\Reader_Data::get_data( get_current_user_id() );
 
+				// If the reader is signed up for any newsletters.
+				if ( ! empty( $reader_data['is_newsletter_subscriber'] ) ) {
+					$targeting['reader_status'][] = 'newsletter_subscriber';
+				}
+
 				// If reader has donated.
 				if ( ! empty( $reader_data['is_donor'] ) ) {
 					$targeting['reader_status'][] = 'donor';

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -1089,6 +1089,25 @@ final class GAM_Model {
 		// Add site url.
 		$targeting['site'] = GAM_Api\Targeting_Keys::sanitize_url( \get_bloginfo( 'url' ) );
 
+		// Add current reader status.
+		$targeting['reader_status'] = []; // Empty value indicates that the current user is not logged in or is not a reader-type user.
+		if ( \is_user_logged_in() && method_exists( 'Newspack\Reader_Activation', 'is_user_reader' ) && \Newspack\Reader_Activation::is_user_reader( \wp_get_current_user() ) ) {
+			$targeting['reader_status'][] = 'logged_in'; // The currently logged-in user is a reader.
+			if ( method_exists( 'Newspack\Reader_Data', 'get_data' ) ) {
+				$reader_data = \Newspack\Reader_Data::get_data();
+
+				// If reader has donated.
+				if ( ! empty( $reader_data['is_donor'] ) ) {
+					$targeting['reader_status'][] = 'donor';
+				}
+
+				// If reader has any currently active non-donation subscriptions.
+				if ( ! empty( $reader_data['active_subscriptions'] ) ) {
+					$targeting['reader_status'][] = 'subscriber';
+				}
+			}
+		}
+
 		if ( is_singular() ) {
 			// Add the post slug to targeting.
 			$slug = get_post_field( 'post_name' );

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -1094,7 +1094,7 @@ final class GAM_Model {
 		if ( \is_user_logged_in() && method_exists( 'Newspack\Reader_Activation', 'is_user_reader' ) && \Newspack\Reader_Activation::is_user_reader( \wp_get_current_user() ) ) {
 			$targeting['reader_status'][] = 'logged_in'; // The currently logged-in user is a reader.
 			if ( method_exists( 'Newspack\Reader_Data', 'get_data' ) ) {
-				$reader_data = \Newspack\Reader_Data::get_data();
+				$reader_data = \Newspack\Reader_Data::get_data( get_current_user_id() );
 
 				// If reader has donated.
 				if ( ! empty( $reader_data['is_donor'] ) ) {


### PR DESCRIPTION
Opened as a hotfix as this is needed by a site currently in migration.

Adds GAM key-val targeting for `reader_status`. The following values are supported:

- Empty value: Indicates that the current user is not logged in or is not a reader-type user.
- `logged_in`: Indicates that the current user is logged in and a reader-type user.
- `newsletter_subscriber`: Indicates that the current user is signed up for at least one newsletter list.
- `donor`: Indicates that the current user has made a donation to the site.
- `subscriber`: Indicates that the current user has at least one active non-donation Woo subscription.

To test:

1. Check out this branch.
2. In WP admin, visit **Newspack > Advertising** and enable/connect Google Ad Manager. Confirm that you see a message here stating that a new key/val target has been created in GAM.
3. Visit the site as a new reader. View source and search for `reader_status`. Confirm that you see the new key/val pair alongside the other existing ones, and that it's empty (because you haven't logged in):

```json
"targeting":{"site":"site.url","reader_status":[] }
```

4. Log in as an existing reader or register for a new account. View source again and confirm that the `reader_status` value reflects the reader's activity as described above.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206945246351620