### PR TITLE
fix(gam): improve error messaging when using constant-contact-forms plugin

### DIFF
--- a/includes/providers/gam/api/class-api.php
+++ b/includes/providers/gam/api/class-api.php
@@ -125,9 +125,9 @@ class Api {
 	 * @throws \Exception If the credentials are invalid or the environment is incompatible.
 	 */
 	public function __construct( $auth_method_or_session, $credentials = null, $network_code = null ) {
-
-		if ( false === self::is_environment_compatible() ) {
-			throw new \Exception( esc_html__( 'The environment is not compatible with the GAM API.', 'newspack-ads' ) );
+		$environment_compatible = self::is_environment_compatible();
+		if ( is_wp_error( $environment_compatible ) ) {
+			throw new \Exception( esc_html( $environment_compatible->get_error_message() ) );
 		}
 
 		if ( 'string' === gettype( $auth_method_or_session ) ) {
@@ -218,12 +218,12 @@ class Api {
 	/**
 	 * Verify WP environment to make sure it's safe to use the GAM API.
 	 *
-	 * @return bool Whether it's safe to use GAM.
+	 * @return bool|WP_Erro True if it's safe to use GAM, error otherwise.
 	 */
 	private static function is_environment_compatible() {
 		// Constant Contact Form plugin loads an old version of Guzzle that breaks the SDK.
 		if ( class_exists( 'Constant_Contact' ) ) {
-			return false;
+			return new \WP_Error( 'newspack_ads_gam_error', __( 'The Constant Contact plugin is not compatible with the GAM API.', 'newspack-ads' ) );
 		}
 		return true;
 	}

--- a/includes/providers/gam/api/class-api.php
+++ b/includes/providers/gam/api/class-api.php
@@ -125,11 +125,6 @@ class Api {
 	 * @throws \Exception If the credentials are invalid or the environment is incompatible.
 	 */
 	public function __construct( $auth_method_or_session, $credentials = null, $network_code = null ) {
-		$environment_compatible = self::is_environment_compatible();
-		if ( is_wp_error( $environment_compatible ) ) {
-			throw new \Exception( esc_html( $environment_compatible->get_error_message() ) );
-		}
-
 		if ( 'string' === gettype( $auth_method_or_session ) ) {
 			$auth_method = $auth_method_or_session;
 			if ( ! in_array( $auth_method, [ 'oauth2', 'service_account' ], true ) ) {
@@ -213,19 +208,6 @@ class Api {
 				'level'  => 'warning',
 			)
 		);
-	}
-
-	/**
-	 * Verify WP environment to make sure it's safe to use the GAM API.
-	 *
-	 * @return bool|WP_Erro True if it's safe to use GAM, error otherwise.
-	 */
-	private static function is_environment_compatible() {
-		// Constant Contact Form plugin loads an old version of Guzzle that breaks the SDK.
-		if ( class_exists( 'Constant_Contact' ) ) {
-			return new \WP_Error( 'newspack_ads_gam_error', __( 'The Constant Contact plugin is not compatible with the GAM API.', 'newspack-ads' ) );
-		}
-		return true;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

**Update: the error message was removed, it's not needed anymore (see discussion below)**

Instead of a cryptic "The environment is not compatible with the GAM API." message if the Constant Contact plugin is active, use a descriptive "The Constant Contact plugin is not compatible with the GAM API." message:

| Before | After | 
|--------------|-----------|
| <img width="945" alt="image" src="https://github.com/Automattic/newspack-ads/assets/7383192/a7351609-a3cf-4707-a14d-41d4decd6a20"> | <img width="932" alt="image" src="https://github.com/Automattic/newspack-ads/assets/7383192/e4c2b746-70c2-42f9-ad3b-29bb73652b16"> |

### How to test the changes in this Pull Request:

1. Install the [constant-contact-forms](https://wordpress.org/plugins/constant-contact-forms/) plugin
2. Load the Advertising Wizard in Newspack Plugin
3. Observe the updated error message 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->