### PR TITLE
fix: update above-header hook to use `wp_body_open`

### DIFF
--- a/includes/class-placements.php
+++ b/includes/class-placements.php
@@ -365,7 +365,7 @@ final class Placements {
 			'global_above_header' => array(
 				'name'        => __( 'Global: Above Header', 'newspack-ads' ),
 				'description' => __( 'Choose an ad unit to display above the header.', 'newspack-ads' ),
-				'hook_name'   => 'before_header',
+				'hook_name'   => 'wp_body_open',
 			),
 			'global_below_header' => array(
 				'name'        => __( 'Global: Below Header', 'newspack-ads' ),


### PR DESCRIPTION
In https://github.com/Automattic/newspack-popups/pull/1302, I updated the hook the above-header prompt placement used from `before_header` to `wp_body_open` to make sure it worked with block themes. This had the inadvertant side effect of switching the order of the above header ad and above header prompt.

This PR also updates the ads plugin to use `wp_body_open` for the above header ad placement. This will return the order to normal, and will also make this Global Placement work with block themes.

I've set this up as a regular PR but given the size and that it's impacting some publisher sites, we may want to apply it as a hotfix early next week.

See: p1717780063436159-slack-newspack-support

## Steps to test

1. On a test site, set up an above header ad space, and an above header prompt. 
2. [Steps 2-4 are optional, to see what this originally looked like] In the Newspack Popups plugin, edit [this line](https://github.com/Automattic/newspack-popups/blob/301c41cd55e8ed468afe7e6b614be11a61db441d/includes/class-newspack-popups-inserter.php#L94) to use the `before_header` hook instead to recreate what this used to look like before https://github.com/Automattic/newspack-popups/pull/1302 landed.
3. View on the front-end; if you don't have ads fully set up and working, you can also view in the Customizer to see the old placement:

![image](https://github.com/Automattic/newspack-ads/assets/177561/d58ca79b-4855-4557-9c00-865f3234e8a5)

4. Revert the Newspack Popups change you made locally and see what it looks like now on live sites:

![image](https://github.com/Automattic/newspack-ads/assets/177561/060a2c47-d0c1-4971-a99f-77863ff6b091)

5. Apply this PR; confirm that the order is now back to what it used to be before the Newspack Campaigns change:

![image](https://github.com/Automattic/newspack-ads/assets/177561/b7e07a90-912b-4999-874b-eb58b6bd8992)
