### PR TITLE
feat: add Complianz integration

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -101,6 +101,7 @@ final class Core {
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-placements.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-sidebar-placements.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/integrations/class-scaip.php';
+		include_once NEWSPACK_ADS_ABSPATH . '/includes/integrations/class-complianz.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/integrations/class-ad-refresh-control.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-blocks.php';
 		include_once NEWSPACK_ADS_ABSPATH . '/includes/class-widget.php';

--- a/includes/integrations/class-complianz.php
+++ b/includes/integrations/class-complianz.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Newspack Ads Complianz Integration
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Ads\Integrations;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Newspack Ads Complianz Integration Class.
+ */
+final class Complianz {
+
+	/**
+	 * Initialize hooks
+	 */
+	public static function init() {
+		add_filter( 'newspack_ads_ad_targeting', [ __CLASS__, 'gam_ad_targeting' ] );
+	}
+
+	/**
+	 * Whether to allow reader data to be used for ad targeting.
+	 */
+	private static function should_allow_reader_data() {
+		// Allow reader data if consent strategy is not detected.
+		if ( ! function_exists( 'cmplz_has_consent' ) ) {
+			return true;
+		}
+		return cmplz_has_consent( 'marketing' );
+	}
+
+	/**
+	 * Filter GAM ad targeting according to Complianz settings.
+	 *
+	 * @param array $targeting Ad targeting.
+	 *
+	 * @return array Filtered ad targeting.
+	 */
+	public static function gam_ad_targeting( $targeting ) {
+		if ( ! self::should_allow_reader_data() ) {
+			// Unset reader data (reader_*) from targeting.
+			foreach ( $targeting as $key => $value ) {
+				if ( 0 === strpos( $key, 'reader_' ) ) {
+					unset( $targeting[ $key ] );
+				}
+			}
+		}
+		return $targeting;
+	}
+}
+Complianz::init();


### PR DESCRIPTION
Implements integration with the [Complianz plugin](https://br.wordpress.org/plugins/complianz-gdpr/) to determine whether there's consent to send reader data to GAM through the ad slot targeting strategy.

### How to test this PR

#### Test without the plugin

1. Check out this branch and make sure you don't have Complianz installed
2. In a fresh session, authenticate to a reader account and confirm the `reader_status` targeting key is added to the ad slot targeting. For that, visit a page with ads with the `?googfc` parameter and click "Open Targeting Info" of an ad slot.

#### With the plugin, but not configured

1. Install the Complianz plugin without configuring it
2. Repeat step number 2 of the previous test and confirm the targeting key is added

#### With Complianz configured 

1. Configure Complianz
2. In a fresh session, authenticate to a reader account and confirm the `reader_status` targeting key is not added
3. Close the GAM overlay and allow "Marketing" data through the consent banner preferences
4. Refresh the page with the `?googfc` parameter, recheck the targeting info and confirm the `reader_status` key is populated

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207722207289374