### PR TITLE
fix(gam): add 1x1 size to all viewports for ad units that supports it

### DIFF
--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -826,6 +826,11 @@ final class GAM_Model {
 		$size_map = [];
 		foreach ( $viewports as $viewport_width ) {
 			foreach ( $sizes as $size ) {
+				// If size is 1x1, we want it in all viewports.
+				if ( 1 === $size[0] && 1 === $size[1] ) {
+					$size_map[ $viewport_width ][] = $size;
+					continue;
+				}
 				$is_in_viewport     = $size[0] <= $viewport_width;
 				$is_above_threshold = false !== $width_threshold && $width_threshold <= $size[0];
 				if ( 0 === $size[0] ) {
@@ -874,13 +879,6 @@ final class GAM_Model {
 		$width_threshold = apply_filters( 'newspack_ads_gam_size_map_width_threshold', 600, $ad_unit, $sizes );
 
 		$size_map = self::get_responsive_size_map( $sizes, $width_diff_ratio, $width_threshold );
-
-		// Add 1x1 size to all viewports.
-		foreach ( $size_map as $viewport => $sizes ) {
-			if ( ! in_array( [ 1, 1 ], $sizes, true ) ) {
-				array_unshift( $size_map[ $viewport ], [ 1, 1 ] );
-			}
-		}
 
 		/**
 		 * Filters the ad unit size map rules.


### PR DESCRIPTION
1200550061930446-as-1207127071414329/f

#837 and #887 misinterpreted the task at hand.

The 1x1 size must be added to all viewports for ad units that have that size, not all ad units. This PR changes it so the size map strategy adds 1x1 to every viewport, without creating the new size.

### How to test

1. Create an ad unit with the following sizes: 1x1, 300x50 and 970x250
2. Use this ad unit in the "Above header" placement
3. Visit the page with `?googfc` and confirm the slot supports the sizes 1x1 and 970x250
4. Switch to mobile viewport, refresh and confirm the slot supports the sizes 1x1 and 300x50