### PR TITLE
fix: add clear: both to global ads

### DIFF
--- a/src/frontend/style.scss
+++ b/src/frontend/style.scss
@@ -15,6 +15,7 @@
 }
 
 .newspack_global_ad {
+	clear: both;
 	max-width: 100%;
 	flex: 1 1 auto;
 	&.fixed-height {


### PR DESCRIPTION
While we're accounting for this in our ad insertion logic, sometimes ads end up a little too close to floated images and end up getting stuck behind them. This can happen with smaller paragraphs paired with taller images.

This PR adds a universal `clear: both` to the `.newspack_global_ad` class.

### Steps to test

The easiest way to test this might be to use some trickery:

1. Set up a post with at least one floated image, and a bunch of text in very short paragraphs.
2. On the front end, if the in-story ad is not placed near the image, edit the post in the element inspector to move the image closer to the ad.
3. Confirm that the ad sits below the image rather than beside it. 

Before this fix:

![CleanShot 2024-10-25 at 11 14 59](https://github.com/user-attachments/assets/b6f77ad6-2609-4481-ab1c-e58459160008)

After this fix: 

![CleanShot 2024-10-25 at 11 15 22](https://github.com/user-attachments/assets/7b2263e4-2b0b-43e7-8a0e-23f1383dd285)

@kmwilkerson flagging for you in case there's any issues with these styles (like if there's a case where ads should respect and flow around floated content). 
