### PR TITLE
fix: update CSS selector for tabs to work outside of media kit

### DIFF
--- a/src/blocks/tabs/editor.scss
+++ b/src/blocks/tabs/editor.scss
@@ -61,13 +61,8 @@
 				padding-top: 10px;
 			}
 
-			&:not(
-			:has(
-				.wp-block-paragraph[data-empty="true"]
-				+ .block-list-appender
-			)
-		) {
-			.block-list-appender {
+			&:not(:has(.wp-block-paragraph[data-empty="true"] + .block-list-appender)) {
+				.block-list-appender {
 					display: flex;
 					flex-direction: row-reverse;
 					margin: 0;
@@ -75,7 +70,6 @@
 				}
 			}
 		}
-
 
 		& .wp-block-paragraph.is-selected + .block-list-appender {
 			display: none;

--- a/src/blocks/tabs/editor.scss
+++ b/src/blocks/tabs/editor.scss
@@ -136,7 +136,7 @@
 }
 
 .has-background .wp-block-newspack-tabs .tab-header {
-	margin-left: var(--newspack-ui-spacer-5, 24px);
+	margin-left: calc(var(--newspack-ui-spacer-5, 24px) * -1);
 }
 
 .wp-block[data-type="newspack/tabs-item"] + .block-list-appender {

--- a/src/blocks/tabs/editor.scss
+++ b/src/blocks/tabs/editor.scss
@@ -62,12 +62,12 @@
 			}
 
 			&:not(
-				:has(
-					.wp-block-paragraph[data-empty="true"]
-					+ .block-list-appender
-				)
-			) {
-				.block-list-appender {
+			:has(
+				.wp-block-paragraph[data-empty="true"]
+				+ .block-list-appender
+			)
+		) {
+			.block-list-appender {
 					display: flex;
 					flex-direction: row-reverse;
 					margin: 0;

--- a/src/blocks/tabs/editor.scss
+++ b/src/blocks/tabs/editor.scss
@@ -15,6 +15,7 @@
 
 .wp-block[data-type="newspack/tabs"] {
 	& .newspack-ads__tab-group {
+		position: relative;
 		& > .block-editor-inner-blocks
 		.wp-block[data-type="newspack/tabs-item"] {
 			&.has-child-selected,
@@ -54,23 +55,27 @@
 		}
 
 		&
-		.block-editor-block-list__layout:not(
-			:has(
-				.wp-block-paragraph[data-empty="true"]
-				+ .block-list-appender
-			)
-		) {
+		.block-editor-block-list__layout {
 			> *:first-child {
 				margin-top: 0;
 				padding-top: 10px;
 			}
-			.block-list-appender {
-				display: flex;
-				flex-direction: row-reverse;
-				margin: 0;
-				position: relative;
+
+			&:not(
+				:has(
+					.wp-block-paragraph[data-empty="true"]
+					+ .block-list-appender
+				)
+			) {
+				.block-list-appender {
+					display: flex;
+					flex-direction: row-reverse;
+					margin: 0;
+					position: relative;
+				}
 			}
 		}
+
 
 		& .wp-block-paragraph.is-selected + .block-list-appender {
 			display: none;
@@ -134,6 +139,10 @@
 		border-radius: 2px;
 		margin-left: calc(var(--newspack-ui-spacer-base, 8px) / 2);
 	}
+}
+
+.has-background .wp-block-newspack-tabs .tab-header {
+	margin-left: var(--newspack-ui-spacer-5, 24px);
 }
 
 .wp-block[data-type="newspack/tabs-item"] + .block-list-appender {

--- a/src/blocks/tabs/style.scss
+++ b/src/blocks/tabs/style.scss
@@ -9,7 +9,7 @@
 	padding: var(--newspack-ui-spacer-5, 24px);
 }
 
-.media-kit-page__wrapper {
+.wp-block-newspack-tabs {
 	.tab-list {
 		display: flex;
 		font-family: var(--newspack-ui-font-family, system-ui, sans-serif);

--- a/src/blocks/tabs/style.scss
+++ b/src/blocks/tabs/style.scss
@@ -2,14 +2,7 @@
 
 .wp-block-newspack-tabs {
 	background: var(--newspack-ui-color-body-bg, #fff);
-}
 
-.has-background .wp-block-newspack-tabs {
-	border-radius: var(--newspack-ui-border-radius-m, 6px);
-	padding: var(--newspack-ui-spacer-5, 24px);
-}
-
-.wp-block-newspack-tabs {
 	.tab-list {
 		display: flex;
 		font-family: var(--newspack-ui-font-family, system-ui, sans-serif);
@@ -145,4 +138,9 @@
 			}
 		}
 	}
+}
+
+.has-background .wp-block-newspack-tabs {
+	border-radius: var(--newspack-ui-border-radius-m, 6px);
+	padding: var(--newspack-ui-spacer-5, 24px);
 }


### PR DESCRIPTION
The Tabs block was added to the Ads plugin as part of the Media Kit.

This PR changes a selector in the Media Kit styles, to make sure the tabs block looks ok outside of the Media Kit patterns.

### Steps to test

1. Add a tabs block to a regular post or page, and publish.
2. Note the appearance on the front-end -- it doesn't match the editor:

![CleanShot 2025-01-08 at 10 50 48](https://github.com/user-attachments/assets/0ec1cef8-a099-45a3-a6c1-043f2d38dbdc)

![CleanShot 2025-01-08 at 10 49 43](https://github.com/user-attachments/assets/3cbb48ce-04ee-4af8-8511-4a613d04f793)

4. Apply this PR and run `npm run build`.
5. Confirm that the tabs block matches in the editor and on the front-end:

![CleanShot 2025-01-08 at 10 51 12](https://github.com/user-attachments/assets/b50b00c8-4e79-4ca2-9075-d9eb3b2adc11)
 