### PR TITLE
feat(gam): add filter for ad config data in gtag

### DIFF
--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -137,6 +137,13 @@ final class GAM_Scripts {
 		];
 
 		/**
+		 * Filters the ad config data parsed for gtag.
+		 *
+		 * @param array $ad_config Ad config data.
+		 */
+		$ad_config = apply_filters( 'newspack_ads_gtag_ad_config', $ad_config );
+
+		/**
 		 * Filters the ads data parsed for gtag.
 		 *
 		 * @param array $data {


### PR DESCRIPTION
p1733840865403849-slack-C07UT1REAGJ

Adds a filter to GAM's script so the ad config data can be modified. This is mostly useful for Google MCM support, which allows a "parent" network code to manage the inventory for a "child" GAM account. See more on #170.

Eventually, we should implement the solution proposed in https://github.com/Automattic/newspack-ads/issues/170#issuecomment-925014706

### Testing

With GAM configured, check out this branch and confirm that the ads are rendered as expected. The addition of the filter shouldn't have any impact on GAM ad rendering.