### PR TITLE
fix(gam): better handling of broken ad unit

### DIFF
--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -363,6 +363,8 @@ final class GAM_Model {
 							$created_unit = $api->ad_units->create_ad_unit( $ad_unit_config );
 							if ( ! is_wp_error( $created_unit ) ) {
 								$gam_ad_unit = $created_unit;
+							} else {
+								continue;
 							}
 						}
 						$ad_units[ $ad_unit_key ] = $gam_ad_unit;

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -772,7 +772,7 @@ final class GAM_Model {
 		$network_code = self::get_active_network_code();
 		$unique_id    = $unique_id ?? uniqid();
 
-		if ( empty( $ad_unit['sizes'] ) || ! is_array( $ad_unit['sizes'] ) ) {
+		if ( ! is_array( $ad_unit['sizes'] ) ) {
 			$ad_unit['sizes'] = [];
 		}
 
@@ -859,7 +859,7 @@ final class GAM_Model {
 	public static function get_ad_unit_size_map( $ad_unit, $sizes = [] ) {
 
 		if ( empty( $sizes ) ) {
-			$sizes = $ad_unit['sizes'] ?? [];
+			$sizes = $ad_unit['sizes'];
 		}
 
 		/**

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -770,7 +770,7 @@ final class GAM_Model {
 		$network_code = self::get_active_network_code();
 		$unique_id    = $unique_id ?? uniqid();
 
-		if ( ! is_array( $ad_unit['sizes'] ) ) {
+		if ( empty( $ad_unit['sizes'] ) || ! is_array( $ad_unit['sizes'] ) ) {
 			$ad_unit['sizes'] = [];
 		}
 
@@ -857,7 +857,7 @@ final class GAM_Model {
 	public static function get_ad_unit_size_map( $ad_unit, $sizes = [] ) {
 
 		if ( empty( $sizes ) ) {
-			$sizes = $ad_unit['sizes'];
+			$sizes = $ad_unit['sizes'] ?? [];
 		}
 
 		/**

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -101,7 +101,7 @@ final class GAM_Scripts {
 
 			$prepared_unit_data[ $container_id ] = [
 				'unique_id'        => $unique_id,
-				'name'             => esc_attr( $ad_unit['name'] ?? '' ),
+				'name'             => esc_attr( $ad_unit['name'] ),
 				'code'             => esc_attr( $ad_unit['code'] ),
 				'path'             => $ad_unit['path'] ?? '',
 				'sizes'            => $sizes,

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -101,7 +101,7 @@ final class GAM_Scripts {
 
 			$prepared_unit_data[ $container_id ] = [
 				'unique_id'        => $unique_id,
-				'name'             => esc_attr( $ad_unit['name'] ),
+				'name'             => esc_attr( $ad_unit['name'] ?? '' ),
 				'code'             => esc_attr( $ad_unit['code'] ),
 				'path'             => $ad_unit['path'] ?? '',
 				'sizes'            => $sizes,


### PR DESCRIPTION
GAM may fail to create the default ad units. Our implementation currently doesn't handle that and is storing the default ad units as `null` and breaking our GAM ad renderer.

### Testing

1. Make sure you have GAM setup with placements using default ad units
2. Force the default ad unit creation to fail by adding the following to line 300 of `includes/providers/gam/api/class-ad-units.php`:
```php
return new \WP_Error( 'test_error, 'Test Error' );
```
3. Also ensure an attempt to create will be made by preventing it from finding an already created ad unit. Replace line 353 of `includes/providers/gam/class-gam-model.php` with:
```php
$ad_unit_idx = false;
```
3. Then, delete the currently stored data via CLI: `wp option delete _newspack_ads_gam_default_units`
5. Visit `Newspack -> Advertising` to trigger the creation
6. After the page loads, confirm the options are stored like this:
```
$ wp option get _newspack_ads_gam_default_units
array (
  'newspack_below_header' => NULL,
  'newspack_sticky_footer' => NULL,
  'newspack_sidebar_1' => NULL,
  'newspack_sidebar_2' => NULL,
  'newspack_in_article_1' => NULL,
  'newspack_in_article_2' => NULL,
  'newspack_in_article_3' => NULL,
)
```
7. Visit a page that renders a default ad unit and confirm you get a fatal error
8. Checkout this branch, repeat steps 2-5 but the stored ad units are stored with the correct local values
9. Visit a page that renders a default ad unit and confirm the page renders without issues

