### PR TITLE
fix(ad-block-recovery): remove redundant nonce field

### DIFF
--- a/includes/providers/gam/class-gam-ad-block-recovery.php
+++ b/includes/providers/gam/class-gam-ad-block-recovery.php
@@ -51,14 +51,6 @@ final class GAM_Ad_Block_Recovery {
 					'type'        => 'string',
 					'public'      => true,
 				],
-				[
-					'description' => __( 'Nonce', 'newspack-ads' ),
-					'help'        => __( '"Nonce" value provided by GAM. E.g.: Ab3De6GhiJklMnoPqRstUV', 'newspack-ads' ),
-					'section'     => self::SECTION,
-					'key'         => 'nonce',
-					'type'        => 'string',
-					'public'      => true,
-				],
 			],
 			$settings_list
 		);
@@ -72,12 +64,12 @@ final class GAM_Ad_Block_Recovery {
 		if ( empty( $settings ) ) {
 			return;
 		}
-		if ( ! $settings['active'] || empty( $settings['pub'] ) || empty( $settings['nonce'] ) ) {
+		if ( ! $settings['active'] || empty( $settings['pub'] ) ) {
 			return;
 		}
 		?>
-		<script async src="https://fundingchoicesmessages.google.com/i/pub-<?php echo \esc_attr( $settings['pub'] ); ?>?ers=1" nonce="<?php echo \esc_attr( $settings['nonce'] ); ?>"></script>
-		<script nonce="<?php echo \esc_attr( $settings['nonce'] ); ?>">
+		<script async src="https://fundingchoicesmessages.google.com/i/pub-<?php echo \esc_attr( $settings['pub'] ); ?>?ers=1"></script>
+		<script>
 			( function() {
 				function signalGooglefcPresent() {
 					if ( !window.frames['googlefcPresent'] ) {


### PR DESCRIPTION
Closes https://app.asana.com/1/26890605006346/project/1205919985867982/task/1209510306904233

This PR removes the ad block recovery nonce field since this setting is no longer required.

![Screenshot 2025-03-13 at 12 39 29](https://github.com/user-attachments/assets/bd0623b3-33f0-4fab-8551-a09d03052839)

## Testing instructions

1. Navigate to Newspack > Advertising > Settings
2. Enable Ad Block Recovery and confirm no nonce field is present
3. Add any value to the PUB field
4. As a reader visit the site
5. Using the browser inspector, search for the pub ID you entered in step 3 (`pub-YOURVALUE`)  
6. Confirm the two scripts have been added and match this format (from the asana task):

```
<script async src="https://fundingchoicesmessages.google.com/i/pub-InsertIdHere?ers=1"></script><script>(function() {function signalGooglefcPresent() {if (!window.frames['googlefcPresent']) {if (document.body) {const iframe = document.createElement('iframe'); iframe.style = 'width: 0; height: 0; border: none; z-index: -1000; left: -1000px; top: -1000px;'; iframe.style.display = 'none'; iframe.name = 'googlefcPresent'; document.body.appendChild(iframe);} else {setTimeout(signalGooglefcPresent, 0);}}}signalGooglefcPresent();})();</script>
```