### PR TITLE
chore: prevent PHP Notice about translations loading too early

### DIFF
--- a/includes/class-placements.php
+++ b/includes/class-placements.php
@@ -40,7 +40,7 @@ final class Placements {
 	 * Initialize settings.
 	 */
 	public static function init() {
-		self::register_default_placements();
+		add_action( 'init', [ __CLASS__, 'register_default_placements' ] );
 		add_action( 'rest_api_init', [ __CLASS__, 'register_api_endpoints' ] );
 	}
 
@@ -360,7 +360,7 @@ final class Placements {
 	/**
 	 * Register default placements.
 	 */
-	private static function register_default_placements() {
+	public static function register_default_placements() {
 		$placements = array(
 			'global_above_header' => array(
 				'name'        => __( 'Global: Above Header', 'newspack-ads' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Some code called the i18n function too early, triggering a PHP Notice. Might be WP 6.8 related (tested on `6.8-RC1`)

### How to test the changes in this Pull Request:

1. On `trunk`, observe a PHP Notice logged: `PHP Notice:  Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>newspack-ads</code> domain was triggered too early.`
2. Switch to this branch, observe no notice logged.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->