### PR TITLE
fix(suppress-ads): check whether post type supports meta

### DIFF
--- a/includes/class-suppression.php
+++ b/includes/class-suppression.php
@@ -201,7 +201,7 @@ final class Suppression {
 	 */
 	public static function enqueue_block_editor_assets() {
 		$post_type = \get_current_screen()->post_type;
-		if ( ! empty( $post_type ) && \is_post_type_viewable( $post_type ) ) {
+		if ( ! empty( $post_type ) && \is_post_type_viewable( $post_type ) && \post_type_supports( $post_type, 'custom-fields' ) ) {
 			\wp_enqueue_script( 'newspack-ads-suppress-ads', Core::plugin_url( 'dist/suppress-ads.js' ), [], NEWSPACK_ADS_VERSION, true );
 			$placements = Placements::get_placements();
 			\wp_localize_script(

--- a/src/suppress-ads/index.js
+++ b/src/suppress-ads/index.js
@@ -4,7 +4,7 @@
  * WordPress dependencies
  */
 import { registerPlugin } from '@wordpress/plugins';
-import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { PluginDocumentSettingPanel } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { ToggleControl } from '@wordpress/components';
 import { Fragment, Component } from '@wordpress/element';

--- a/src/suppress-ads/index.js
+++ b/src/suppress-ads/index.js
@@ -69,8 +69,11 @@ class NewspackSuppressAdsPanel extends Component {
 
 const ComposedPanel = compose( [
 	withSelect( select => {
-		const { newspack_ads_suppress_ads, newspack_ads_suppress_ads_placements } =
-			select( 'core/editor' ).getEditedPostAttribute( 'meta' );
+		const meta = select( 'core/editor' ).getEditedPostAttribute( 'meta' );
+		if ( ! meta ) {
+			return {};
+		}
+		const { newspack_ads_suppress_ads, newspack_ads_suppress_ads_placements } = meta;
 		return { newspack_ads_suppress_ads, newspack_ads_suppress_ads_placements };
 	} ),
 	withDispatch( dispatch => ( {


### PR DESCRIPTION
https://github.com/Automattic/newspack-plugin/pull/4000#issuecomment-2920758330

When a post type doesn't include support for `custom-fields`, the selector `select( 'core/editor' ).getEditedPostAttribute( 'meta' )` returns `undefined`. This needs to be handled in the editor plugin for ad suppression.

While at it, I also updated the `PluginDocumentSettingPanel` package dependency, which [moved to `@wordpress/editor` in WP 6.6](https://make.wordpress.org/core/2024/06/18/editor-unified-extensibility-apis-in-6-6/).

### Testing

1. Register a post type without support for `custom-fields`:

```php
register_post_type(
	'suppress-ads-test',
	[
		'label'        => 'Suppress Ads Test',
		'public'       => true,
		'supports'     => [ 'title', 'editor' ],
		'show_in_rest' => true,
	]
);
```

2. Navigate to `/wp-admin/post-new.php?post_type=suppress-ads-test`
3. Confirm you get the following error:

<img width="960" alt="image" src="https://github.com/user-attachments/assets/819f548f-beb4-4a3b-bfd0-67e073715b0d" />

4. Checkout this branch, refresh the page, and confirm the error is gone
5. Edit a regular post a confirm the "Newspack Ads Settings" panel renders and behaves as expected
