### PR TITLE
fix(ad-block): handle missing ad unit

### DIFF
--- a/includes/blocks/class-ad-unit-block.php
+++ b/includes/blocks/class-ad-unit-block.php
@@ -91,7 +91,10 @@ final class Ad_Unit_Block {
 	private static function register_block_placement( $attrs ) {
 		$data = self::get_block_placement_data( $attrs );
 		if ( ! $data['ad_unit'] ) {
-			return;
+			return new \WP_Error(
+				'newspack_ads_block_placement_missing_ad_unit',
+				__( 'Could not determine ad unit for placement', 'newspack-ads' )
+			);
 		}
 		$placement_id     = sprintf( 'block_%s', $data['id'] );
 		$hook_name        = sprintf( 'newspack_ads_%s_render', $placement_id );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds error handling in line with the method signature. `register_block_placement` should return either an array or `WP_Error`.

### How to test the changes in this Pull Request:

Not sure how to reproduce, I saw 

```
PHP Warning:  Trying to access array offset on null in […]/includes/blocks/class-ad-unit-block.php on line 138
```

on a live site and dug.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->