### PR TITLE
feat(gam): parent ad unit inventory

### DIFF
--- a/includes/providers/gam/api/class-ad-units.php
+++ b/includes/providers/gam/api/class-ad-units.php
@@ -75,8 +75,8 @@ final class Ad_Units extends Api_Object {
 		);
 
 		$ad_units = [];
-				// Retrieve a small amount of items at a time, paging through until all items have been retrieved.
-				$total_result_set_size = 0;
+		// Retrieve a small amount of items at a time, paging through until all items have been retrieved.
+		$total_result_set_size = 0;
 		do {
 			$page = $inventory_service->getAdUnitsByStatement(
 				$statement_builder->toStatement()

--- a/includes/providers/gam/api/class-ad-units.php
+++ b/includes/providers/gam/api/class-ad-units.php
@@ -7,7 +7,6 @@
 
 namespace Newspack_Ads\Providers\GAM\Api;
 
-use Newspack_Ads\Providers\GAM\Api;
 use Newspack_Ads\Providers\GAM\Api\Api_Object;
 use Google\AdsApi\AdManager\Util\v202505\StatementBuilder;
 use Google\AdsApi\AdManager\v202505\ServiceFactory;
@@ -146,7 +145,7 @@ final class Ad_Units extends Api_Object {
 	 * @param int[]   $ids              Optional array of ad unit ids.
 	 * @param boolean $include_archived Whether to include archived ad units.
 	 *
-	 * @return array[] Array of serialized ad units.
+	 * @return array[]|\WP_Error Array of serialized ad units or error.
 	 */
 	public function get_serialized_ad_units( $parent_id = null, $ids = [], $include_archived = false ) {
 		try {
@@ -244,7 +243,7 @@ final class Ad_Units extends Api_Object {
 			}
 			$inventory_service = $this->get_inventory_service();
 
-			$statement_builder = self::get_statement_builder( [ $id ] );
+			$statement_builder = self::get_statement_builder( null, [ $id ] );
 			$result            = $inventory_service->performAdUnitAction(
 				$action,
 				$statement_builder->toStatement()
@@ -265,7 +264,7 @@ final class Ad_Units extends Api_Object {
 	 * Given a configuration object and an AdUnit instance, return modified AdUnit.
 	 * If the AdUnit is not provided, create a new one.
 	 *
-	 * @param object $config  Configuration for the Ad Unit.
+	 * @param array  $config  Configuration for the Ad Unit.
 	 * @param AdUnit $ad_unit Ad Unit.
 	 *
 	 * @return AdUnit Ad Unit.
@@ -280,7 +279,11 @@ final class Ad_Units extends Api_Object {
 			$ad_unit = new AdUnit();
 			$ad_unit->setAdUnitCode( uniqid( $slug . '-' ) );
 			$network = $this->api->get_network();
-			$ad_unit->setParentId( $network->getEffectiveRootAdUnitId() );
+			if ( ! empty( $config['parent_id'] ) ) {
+				$ad_unit->setParentId( $config['parent_id'] );
+			} else {
+				$ad_unit->setParentId( $network->getEffectiveRootAdUnitId() );
+			}
 			$ad_unit->setTargetWindow( AdUnitTargetWindow::BLANK );
 		}
 
@@ -314,13 +317,14 @@ final class Ad_Units extends Api_Object {
 	/**
 	 * Update Ad Unit.
 	 *
-	 * @param object $config Ad Unit configuration.
-	 * @return AdUnit|WP_Error Updated AdUnit or error.
+	 * @param array $config Ad Unit configuration.
+	 *
+	 * @return AdUnit|\WP_Error Updated AdUnit or error.
 	 */
 	public function update_ad_unit( $config ) {
 		try {
 			$inventory_service = $this->get_inventory_service();
-			$found_ad_units    = $this->get_ad_units( [ $config['id'] ] );
+			$found_ad_units    = $this->get_ad_units( null, [ $config['id'] ] );
 			if ( empty( $found_ad_units ) ) {
 				return $this->api->get_error( null, __( 'Ad Unit was not found.', 'newspack-ads' ) );
 			}
@@ -339,12 +343,12 @@ final class Ad_Units extends Api_Object {
 	/**
 	 * Create a GAM Ad Unit.
 	 *
-	 * @param object $config Configuration of the ad unit.
-	 * @return AdUnit|WP_Error Created AdUnit or error.
+	 * @param array $config Configuration of the ad unit.
+	 *
+	 * @return array|\WP_Error Created ad unit or error.
 	 */
 	public function create_ad_unit( $config ) {
 		try {
-			$network           = $this->api->get_network();
 			$inventory_service = $this->get_inventory_service();
 			$ad_unit           = $this->modify_ad_unit( $config );
 			$created_ad_units  = $inventory_service->createAdUnits( [ $ad_unit ] );

--- a/includes/providers/gam/api/class-ad-units.php
+++ b/includes/providers/gam/api/class-ad-units.php
@@ -40,35 +40,79 @@ final class Ad_Units extends Api_Object {
 	/**
 	 * Create a statement builder for ad unit retrieval.
 	 *
+	 * @param int     $parent_id        Optional parent ad unit id.
 	 * @param int[]   $ids              Optional array of ad unit ids.
 	 * @param boolean $include_archived Whether to include archived ad units.
 	 *
 	 * @return StatementBuilder Statement builder.
 	 */
-	private static function get_statement_builder( $ids = [], $include_archived = false ) {
+	private static function get_statement_builder( $parent_id = null, $ids = [], $include_archived = false ) {
 		// Get all non-archived ad units, unless ids are specified.
 		$statement_builder = new StatementBuilder();
 		if ( ! empty( $ids ) ) {
 			$statement_builder->where( 'ID IN(' . implode( ', ', $ids ) . ')' );
 		} elseif ( ! $include_archived ) {
-			$statement_builder->where( "Status IN('ACTIVE')" );
+			if ( $parent_id ) {
+				$statement_builder->where( 'parentId = ' . $parent_id . " AND Status IN('ACTIVE')" );
+			} else {
+				$statement_builder->where( "Status IN('ACTIVE')" );
+			}
 		}
 		$statement_builder->orderBy( 'name ASC' )->limit( StatementBuilder::SUGGESTED_PAGE_LIMIT );
 		return $statement_builder;
 	}
 
 	/**
+	 * Get parent ad units with children.
+	 *
+	 * @return array Array of serialzied AdUnits.
+	 */
+	public function get_parent_ad_units() {
+		$statement_builder = self::get_statement_builder();
+		$statement_builder->where( 'hasChildren = TRUE' );
+		$inventory_service = $this->get_inventory_service();
+		$page = $inventory_service->getAdUnitsByStatement(
+			$statement_builder->toStatement()
+		);
+
+		$ad_units = [];
+				// Retrieve a small amount of items at a time, paging through until all items have been retrieved.
+				$total_result_set_size = 0;
+		do {
+			$page = $inventory_service->getAdUnitsByStatement(
+				$statement_builder->toStatement()
+			);
+
+			if ( $page->getResults() !== null ) {
+				$total_result_set_size = $page->getTotalResultSetSize();
+				foreach ( $page->getResults() as $item ) {
+					$ad_unit_name = $item->getName();
+					if ( 0 === strpos( $ad_unit_name, 'ca-pub-' ) ) {
+						// There are these phantom ad units with 'ca-pub-<int>' names.
+						continue;
+					}
+					$ad_units[] = $item;
+				}
+			}
+			$statement_builder->increaseOffsetBy( StatementBuilder::SUGGESTED_PAGE_LIMIT );
+		} while ( $statement_builder->getOffset() < $total_result_set_size );
+
+		return array_map( [ __CLASS__, 'get_serialized_ad_unit' ], $ad_units );
+	}
+
+	/**
 	 * Get all GAM Ad Units in the user's network.
 	 * If $ids parameter is not specified, will return all ad units found.
 	 *
+	 * @param int     $parent_id        Optional parent ad unit id.
 	 * @param int[]   $ids              Optional array of ad unit ids.
 	 * @param boolean $include_archived Whether to include archived ad units.
 	 *
 	 * @return AdUnit[] Array of AdUnits.
 	 */
-	private function get_ad_units( $ids = [], $include_archived = false ) {
+	private function get_ad_units( $parent_id = null, $ids = [], $include_archived = false ) {
 		$gam_ad_units      = [];
-		$statement_builder = self::get_statement_builder( $ids, $include_archived );
+		$statement_builder = self::get_statement_builder( $parent_id, $ids, $include_archived );
 		$inventory_service = $this->get_inventory_service();
 
 		// Retrieve a small amount of items at a time, paging through until all items have been retrieved.
@@ -98,14 +142,15 @@ final class Ad_Units extends Api_Object {
 	/**
 	 * Get all GAM Ad Units in the user's network, serialized.
 	 *
+	 * @param int     $parent_id        Optional parent ad unit id.
 	 * @param int[]   $ids              Optional array of ad unit ids.
 	 * @param boolean $include_archived Whether to include archived ad units.
 	 *
 	 * @return array[] Array of serialized ad units.
 	 */
-	public function get_serialized_ad_units( $ids = [], $include_archived = false ) {
+	public function get_serialized_ad_units( $parent_id = null, $ids = [], $include_archived = false ) {
 		try {
-			$ad_units            = $this->get_ad_units( $ids, $include_archived );
+			$ad_units            = $this->get_ad_units( $parent_id, $ids, $include_archived );
 			$ad_units_serialised = [];
 			foreach ( $ad_units as $ad_unit ) {
 				$ad_units_serialised[] = $this->get_serialized_ad_unit( $ad_unit );
@@ -157,13 +202,14 @@ final class Ad_Units extends Api_Object {
 		);
 
 		$ad_unit = [
-			'id'     => $gam_ad_unit->getId(),
-			'path'   => $path,
-			'code'   => $gam_ad_unit->getAdUnitCode(),
-			'status' => $gam_ad_unit->getStatus(),
-			'name'   => $gam_ad_unit->getName(),
-			'fluid'  => $gam_ad_unit->getIsFluid(),
-			'sizes'  => [],
+			'id'           => $gam_ad_unit->getId(),
+			'path'         => $path,
+			'code'         => $gam_ad_unit->getAdUnitCode(),
+			'status'       => $gam_ad_unit->getStatus(),
+			'name'         => $gam_ad_unit->getName(),
+			'fluid'        => $gam_ad_unit->getIsFluid(),
+			'has_children' => $gam_ad_unit->getHasChildren(),
+			'sizes'        => [],
 		];
 		$sizes   = $gam_ad_unit->getAdUnitSizes();
 		if ( $sizes ) {

--- a/includes/providers/gam/api/class-ad-units.php
+++ b/includes/providers/gam/api/class-ad-units.php
@@ -68,7 +68,7 @@ final class Ad_Units extends Api_Object {
 	 */
 	public function get_parent_ad_units() {
 		$statement_builder = self::get_statement_builder();
-		$statement_builder->where( 'hasChildren = TRUE' );
+		$statement_builder->where( "hasChildren = TRUE AND Status IN('ACTIVE')" );
 		$inventory_service = $this->get_inventory_service();
 		$page = $inventory_service->getAdUnitsByStatement(
 			$statement_builder->toStatement()

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -31,6 +31,8 @@ final class GAM_Model {
 
 	const OPTION_NAME_DEFAULT_UNITS = '_newspack_ads_gam_default_units';
 
+	const OPTION_NAME_PARENT_AD_UNIT = '_newspack_ads_gam_parent_ad_unit';
+
 	/**
 	 * GAM Api
 	 *
@@ -343,7 +345,8 @@ final class GAM_Model {
 		if ( true === $sync ) {
 			$api = self::get_api();
 			if ( $api ) {
-				$gam_ad_units = $api->ad_units->get_serialized_ad_units( [], true );
+				$parent_ad_unit_id = self::get_parent_ad_unit_id();
+				$gam_ad_units      = $api->ad_units->get_serialized_ad_units( $parent_ad_unit_id, [], true );
 				if ( ! is_wp_error( $gam_ad_units ) ) {
 					foreach ( $ad_units as $ad_unit_key => $ad_unit_config ) {
 						/** Validate config before continuing. */
@@ -356,7 +359,7 @@ final class GAM_Model {
 							/** Update ad unit status to 'ACTIVE' if not active. */
 							if ( 'ACTIVE' !== $gam_ad_unit['status'] ) {
 								$api->ad_units->update_ad_unit_status( $gam_ad_unit['id'], 'ACTIVE' );
-								$gam_ad_unit = $api->ad_units->get_serialized_ad_units( [ $gam_ad_unit['id'] ] )[0];
+								$gam_ad_unit = $api->ad_units->get_serialized_ad_units( null, [ $gam_ad_unit['id'] ] )[0];
 							}
 						} else {
 							/** Create ad unit if not synced. */
@@ -436,6 +439,28 @@ final class GAM_Model {
 	}
 
 	/**
+	 * Get parent ad unit id.
+	 *
+	 * @return int|false Parent ad unit id or false if not set.
+	 */
+	public static function get_parent_ad_unit_id() {
+		return get_option( self::OPTION_NAME_PARENT_AD_UNIT, false );
+	}
+
+	/**
+	 * Get parent ad units with children.
+	 *
+	 * @return array Array of ad units.
+	 */
+	public static function get_parent_ad_units() {
+		$api = self::get_api();
+		if ( $api ) {
+			return $api->ad_units->get_parent_ad_units();
+		}
+		return [];
+	}
+
+	/**
 	 * Get the ad units.
 	 *
 	 * @param bool $sync Whether to attempt sync with connected GAM.
@@ -448,7 +473,8 @@ final class GAM_Model {
 			if ( self::is_api_connected() ) {
 				$api = self::get_api();
 				if ( $api ) {
-					$gam_ad_units = $api->ad_units->get_serialized_ad_units();
+					$parent_ad_unit_id = self::get_parent_ad_unit_id();
+					$gam_ad_units      = $api->ad_units->get_serialized_ad_units( $parent_ad_unit_id );
 					if ( ! \is_wp_error( $gam_ad_units ) && ! empty( $gam_ad_units ) ) {
 						self::sync_gam_settings( $gam_ad_units );
 						self::$synced = true;
@@ -643,7 +669,8 @@ final class GAM_Model {
 	public static function sync_gam_settings( $serialised_ad_units = null, $settings = null ) {
 		$api = self::get_api();
 		if ( null === $serialised_ad_units ) {
-			$serialised_ad_units = $api->ad_units->get_serialized_ad_units();
+			$parent_ad_unit_id = self::get_parent_ad_unit_id();
+			$serialised_ad_units = $api->ad_units->get_serialized_ad_units( $parent_ad_unit_id );
 		}
 		if ( null === $settings ) {
 			try {

--- a/includes/providers/gam/class-gam-model.php
+++ b/includes/providers/gam/class-gam-model.php
@@ -510,6 +510,10 @@ final class GAM_Model {
 	public static function add_ad_unit( $ad_unit ) {
 		if ( self::is_api_connected() ) {
 			$api    = self::get_api();
+			$parent_ad_unit_id = self::get_parent_ad_unit_id();
+			if ( $parent_ad_unit_id ) {
+				$ad_unit['parent_id'] = $parent_ad_unit_id;
+			}
 			$result = $api->ad_units->create_ad_unit( $ad_unit );
 			self::sync_gam_settings();
 		} else {

--- a/languages/newspack-ads.pot
+++ b/languages/newspack-ads.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-07-30T16:46:52+00:00\n"
+"POT-Creation-Date: 2025-07-30T17:16:16+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: newspack-ads\n"
@@ -919,21 +919,21 @@ msgstr ""
 msgid "Media Kit page created successfully - post ID: %d"
 msgstr ""
 
-#: includes/providers/gam/api/class-ad-units.php:160
+#: includes/providers/gam/api/class-ad-units.php:159
 msgid "Unable to fetch ad units."
 msgstr ""
 
-#: includes/providers/gam/api/class-ad-units.php:325
+#: includes/providers/gam/api/class-ad-units.php:329
 msgid "Ad Unit was not found."
 msgstr ""
 
-#: includes/providers/gam/api/class-ad-units.php:331
 #: includes/providers/gam/api/class-ad-units.php:335
+#: includes/providers/gam/api/class-ad-units.php:339
 msgid "Ad Unit was not updated."
 msgstr ""
 
-#: includes/providers/gam/api/class-ad-units.php:352
 #: includes/providers/gam/api/class-ad-units.php:356
+#: includes/providers/gam/api/class-ad-units.php:360
 msgid "Ad Unit was not created."
 msgstr ""
 
@@ -1041,23 +1041,23 @@ msgstr ""
 msgid "A multiplier applied to margins on mobile devices. This allows varying margins on mobile vs. desktop."
 msgstr ""
 
-#: includes/providers/gam/class-gam-model.php:636
+#: includes/providers/gam/class-gam-model.php:640
 msgid "Not connected to GAM"
 msgstr ""
 
-#: includes/providers/gam/class-gam-model.php:681
+#: includes/providers/gam/class-gam-model.php:685
 msgid "Unable to synchronize with GAM"
 msgstr ""
 
-#: includes/providers/gam/class-gam-model.php:1118
+#: includes/providers/gam/class-gam-model.php:1122
 msgid "Invalid credentials configuration."
 msgstr ""
 
-#: includes/providers/gam/class-gam-model.php:1125
+#: includes/providers/gam/class-gam-model.php:1129
 msgid "Unable to update GAM credentials"
 msgstr ""
 
-#: includes/providers/gam/class-gam-model.php:1139
+#: includes/providers/gam/class-gam-model.php:1143
 msgid "Unable to remove GAM credentials"
 msgstr ""
 

--- a/languages/newspack-ads.pot
+++ b/languages/newspack-ads.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL2.
 msgid ""
 msgstr ""
-"Project-Id-Version: Newspack Ads 3.5.4\n"
+"Project-Id-Version: Newspack Ads 3.5.5\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/project\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-07-29T09:45:44+00:00\n"
+"POT-Creation-Date: 2025-07-30T16:46:52+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: newspack-ads\n"
@@ -919,21 +919,21 @@ msgstr ""
 msgid "Media Kit page created successfully - post ID: %d"
 msgstr ""
 
-#: includes/providers/gam/api/class-ad-units.php:115
+#: includes/providers/gam/api/class-ad-units.php:160
 msgid "Unable to fetch ad units."
 msgstr ""
 
-#: includes/providers/gam/api/class-ad-units.php:279
+#: includes/providers/gam/api/class-ad-units.php:325
 msgid "Ad Unit was not found."
 msgstr ""
 
-#: includes/providers/gam/api/class-ad-units.php:285
-#: includes/providers/gam/api/class-ad-units.php:289
+#: includes/providers/gam/api/class-ad-units.php:331
+#: includes/providers/gam/api/class-ad-units.php:335
 msgid "Ad Unit was not updated."
 msgstr ""
 
-#: includes/providers/gam/api/class-ad-units.php:306
-#: includes/providers/gam/api/class-ad-units.php:310
+#: includes/providers/gam/api/class-ad-units.php:352
+#: includes/providers/gam/api/class-ad-units.php:356
 msgid "Ad Unit was not created."
 msgstr ""
 
@@ -1041,23 +1041,23 @@ msgstr ""
 msgid "A multiplier applied to margins on mobile devices. This allows varying margins on mobile vs. desktop."
 msgstr ""
 
-#: includes/providers/gam/class-gam-model.php:610
+#: includes/providers/gam/class-gam-model.php:636
 msgid "Not connected to GAM"
 msgstr ""
 
-#: includes/providers/gam/class-gam-model.php:654
+#: includes/providers/gam/class-gam-model.php:681
 msgid "Unable to synchronize with GAM"
 msgstr ""
 
-#: includes/providers/gam/class-gam-model.php:1091
+#: includes/providers/gam/class-gam-model.php:1118
 msgid "Invalid credentials configuration."
 msgstr ""
 
-#: includes/providers/gam/class-gam-model.php:1098
+#: includes/providers/gam/class-gam-model.php:1125
 msgid "Unable to update GAM credentials"
 msgstr ""
 
-#: includes/providers/gam/class-gam-model.php:1112
+#: includes/providers/gam/class-gam-model.php:1139
 msgid "Unable to remove GAM credentials"
 msgstr ""
 


### PR DESCRIPTION
Allow a site to select a parent ad unit to determine the site's ad unit inventory. If set, only the selected ad unit's children will be available to be used in placements.

<img width="1273" height="631" alt="image" src="https://github.com/user-attachments/assets/4d10e431-0ef4-474c-a6b7-1533831a74a4" />

### Testing

1. Before switching to this branch, make sure you have GAM properly connected and some placements with ad units
2. Checkout this branch and navigate to Advertising -> Providers and click on "Configure" GAM.
3. Confirm the new select field set to "None (all ad units will be used)"
4. Confirm all your placements continue to behave as before
5. Create a new ad unit and confirm it's created without a parent ad unit
6. Set an ad unit to a placement and confirm the placement uses the ad unit in the frontend
7. Back in the ad unit configuration page, change the parent ad unit
8. Confirm the selection persists and your inventory now shows the child units and the Newspack defaults
9. Create an ad unit and confirm in your GAM dashboard that it was created as a child ad unit
10. Visit Placements and confirm the available ad units for selection reflects the new inventory