### PR TITLE
fix(placements): fix side rail main element

### DIFF
--- a/src/frontend/side-rail-placements.js
+++ b/src/frontend/side-rail-placements.js
@@ -5,7 +5,7 @@ import { domReady, debounce, elementCollides, hasStickyHeader } from './utils';
  *
  * @type {string}
  */
-const mainElement = '#main';
+const mainElement = '#primary';
 
 /**
  * Selectors for elements to detect collisions with.
@@ -14,8 +14,9 @@ const mainElement = '#main';
  */
 const collisionElements = [
 	'#masthead',
-	'#main',
+	'#primary',
 	'.above-footer-widgets',
+	'.scaip .newspack_global_ad',
 	'#colophon',
 	'.newspack_global_ad.sticky',
 ];


### PR DESCRIPTION
The `#main` element does not work well for the side rail placements in archive pages.

`#primary` is a better fit as it works for all templates in the Newspack theme.

### Testing

1. While on the release branch, make sure you have ad units set to both side rail placements
2. Navigate to a category archive page and confirm the placements are mislocated
3. Checkout this branch, refresh, and confirm they are now properly placed
4. Edit a post and confirm it renders properly for each available page template
