### PR TITLE
fix(placements): side rail placement dimension race condition

### DIFF
--- a/includes/integrations/class-side-rail-placements.php
+++ b/includes/integrations/class-side-rail-placements.php
@@ -24,6 +24,7 @@ class Side_Rail_Placements {
 		add_action( 'init', [ __CLASS__, 'register_placements' ] );
 		add_filter( 'newspack_ads_gtag_ads_data', [ __CLASS__, 'filter_ad_units' ] );
 		add_filter( 'newspack_ads_placement_classnames', [ __CLASS__, 'filter_classnames' ], 10, 2 );
+		add_filter( 'newspack_ads_gam_ad_unit_initial_display', [ __CLASS__, 'filter_ad_unit_initial_display' ], 10, 2 );
 	}
 
 	/**
@@ -80,6 +81,21 @@ class Side_Rail_Placements {
 			$classnames['fixed-height'] = false;
 		}
 		return $classnames;
+	}
+
+	/**
+	 * Filter ad unit initial display.
+	 *
+	 * @param string|null $initial_display Ad unit initial display.
+	 * @param array       $ad_unit         Ad unit data.
+	 *
+	 * @return string|null
+	 */
+	public static function filter_ad_unit_initial_display( $initial_display, $ad_unit ) {
+		if ( 'left_side_rail' === $ad_unit['placement'] || 'right_side_rail' === $ad_unit['placement'] ) {
+			return 'none';
+		}
+		return $initial_display;
 	}
 }
 Side_Rail_Placements::init();

--- a/includes/providers/gam/class-gam-scripts.php
+++ b/includes/providers/gam/class-gam-scripts.php
@@ -112,6 +112,7 @@ final class GAM_Scripts {
 				'size_map'         => GAM_Model::get_ad_unit_size_map( $ad_unit ),
 				'bounds_selectors' => $bounds_selectors,
 				'bounds_bleed'     => (int) $bounds_bleed ?? 0,
+				'initial_display'  => apply_filters( 'newspack_ads_gam_ad_unit_initial_display', null, $ad_unit, $sizes ),
 			];
 		}
 
@@ -373,6 +374,9 @@ final class GAM_Scripts {
 						if ( ! ad_unit ) {
 							return;
 						}
+						if ( event.size ) {
+							container._size = event.size;
+						}
 						<?php
 						/**
 						 * Lock fixed height ad unit size mapping to prevent larger
@@ -388,6 +392,9 @@ final class GAM_Scripts {
 						 * Handle slot visibility.
 						 */
 						?>
+						if ( ad_unit.initial_display ) {
+							container.style.display = ad_unit.initial_display;
+						}
 						if ( event.isEmpty && ( ad_unit.sticky || ! ad_unit.fixed_height.active || ( ad_unit.fixed_height.active && ! ad_unit.in_viewport ) ) ) {
 							container.parentNode.style.display = 'none';
 						} else {

--- a/src/frontend/side-rail-placements.js
+++ b/src/frontend/side-rail-placements.js
@@ -21,6 +21,8 @@ const collisionElements = [
 	'.newspack_global_ad.sticky',
 ];
 
+window.googletag = window.googletag || { cmd: [] };
+
 /**
  * Initialize a side rail placement.
  *
@@ -53,10 +55,9 @@ function initPlacement(selector, side, elements) {
 
 	// Prepend a reference div to the element.
 	const refDiv = document.createElement('div');
-	refDiv.style.width = ad.offsetWidth + 'px';
-	refDiv.style.height = ad.offsetHeight + 'px';
+	refDiv.style.width = (ad._size ? ad._size[0] : ad.offsetWidth) + 'px';
+	refDiv.style.height = (ad._size ? ad._size[1] : ad.offsetHeight) + 'px';
 	refDiv.style.position = 'absolute';
-	refDiv.style.zIndex = '9999';
 	refDiv.style.pointerEvents = 'none';
 	element.prepend(refDiv);
 
@@ -67,6 +68,7 @@ function initPlacement(selector, side, elements) {
 	const showAd = () => {
 		ad.classList.remove('ad-hidden');
 		ad.classList.add('ad-visible');
+		ad.style.removeProperty('display');
 	};
 
 	const handleCollision = () => {

--- a/src/frontend/side-rail-placements.js
+++ b/src/frontend/side-rail-placements.js
@@ -53,6 +53,8 @@ function initPlacement(selector, side, elements) {
 
 	// Prepend a reference div to the element.
 	const refDiv = document.createElement('div');
+	refDiv.style.width = ad.offsetWidth + 'px';
+	refDiv.style.height = ad.offsetHeight + 'px';
 	refDiv.style.position = 'absolute';
 	refDiv.style.zIndex = '9999';
 	refDiv.style.pointerEvents = 'none';

--- a/src/frontend/side-rail-placements.js
+++ b/src/frontend/side-rail-placements.js
@@ -54,10 +54,6 @@ function initPlacement(selector, side, elements) {
 	// Prepend a reference div to the element.
 	const refDiv = document.createElement('div');
 	refDiv.style.position = 'absolute';
-	refDiv.style.top = '0';
-	refDiv.style.left = '0';
-	refDiv.style.width = '100%';
-	refDiv.style.height = '100%';
 	refDiv.style.zIndex = '9999';
 	refDiv.style.pointerEvents = 'none';
 	element.prepend(refDiv);
@@ -122,7 +118,8 @@ function initPlacement(selector, side, elements) {
 				if (ad.id !== event.slot.getSlotElementId()) {
 					return;
 				}
-				ad.style.width = event.size[0] + 'px';
+				refDiv.style.width = event.size[0] + 'px';
+				refDiv.style.height = event.size[1] + 'px';
 				handlePlacement();
 			});
 	});

--- a/src/frontend/side-rail-placements.js
+++ b/src/frontend/side-rail-placements.js
@@ -108,13 +108,16 @@ function initPlacement(selector, side, elements) {
 
 	const handleStickyAd = () => {
 		const stickyAd = document.querySelector('.newspack_global_ad.sticky');
-		const stickyAdClose = document.querySelector('.newspack_sticky_ad__close');
+		const stickyAdClose = document.querySelector(
+			'.newspack_sticky_ad__close'
+		);
 		if (stickyAd) {
 			element.style.bottom = `${stickyAd.offsetHeight}px`;
 		}
 		if (stickyAdClose) {
 			stickyAdClose.addEventListener('click', () => {
 				element.style.removeProperty('bottom');
+				handlePlacement();
 			});
 		}
 	};

--- a/src/frontend/side-rail-placements.js
+++ b/src/frontend/side-rail-placements.js
@@ -106,7 +106,21 @@ function initPlacement(selector, side, elements) {
 		element.style.width = `${newWidth}px`;
 	};
 
+	const handleStickyAd = () => {
+		const stickyAd = document.querySelector('.newspack_global_ad.sticky');
+		const stickyAdClose = document.querySelector('.newspack_sticky_ad__close');
+		if (stickyAd) {
+			element.style.bottom = `${stickyAd.offsetHeight}px`;
+		}
+		if (stickyAdClose) {
+			stickyAdClose.addEventListener('click', () => {
+				element.style.removeProperty('bottom');
+			});
+		}
+	};
+
 	const handlePlacement = () => {
+		handleStickyAd();
 		updateDimensions();
 		handleCollision();
 	};

--- a/src/frontend/style.scss
+++ b/src/frontend/style.scss
@@ -82,7 +82,7 @@
 .newspack_global_ad.right_side_rail {
 	position: fixed;
 	top: 40px;
-	bottom: 150px;
+	bottom: 40px;
 	box-sizing: border-box;
 	> * {
 		margin: 0;


### PR DESCRIPTION
If the ad renders before the side rail placement script, it won't catch the rendered ad dimensions and fail to handle collisions properly.

This PR tweaks the reference node to be more restrictive and also initializes it with the ad dimensions, in case it has already rendered.

### Testing

1. In release, put [the script initialization](https://github.com/Automattic/newspack-ads/blob/5094654a6625dc089661e092ec74ec782128d5f7/src/frontend/side-rail-placements.js#L131-L136) in a long  setTimeout() - enough to run after the ad renders
2. Visit a page that renders the side rail placements, adjust your browser height to be smaller than the rendered creative
3. Confirm the ad never gets hidden and is partially visible
4. Checkout this branch, apply the same setTimeout() and confirm that collision is properly handled once the script runs