### PR TITLE
fix: better positioning for side rail placements on large screens

### DIFF
--- a/src/frontend/style.scss
+++ b/src/frontend/style.scss
@@ -116,6 +116,8 @@
 
 .newspack_global_ad.left_side_rail {
 	left: 0;
+	justify-content: flex-end;
+	padding-right: 32px;
 	.ad-slot {
 		@starting-style {
 			transform: translateX(-20%);
@@ -128,6 +130,8 @@
 
 .newspack_global_ad.right_side_rail {
 	right: 0;
+	justify-content: flex-start;
+	padding-left: 32px;
 	.ad-slot {
 		@starting-style {
 			transform: translateX(20%);


### PR DESCRIPTION
The current positioning centers the ad in the available area between the edge and the content. This can look odd on large screens, as the ad will be rendered very far away from the content.

This PR tweaks that, attaching the ad to the content area:

| Before | After |
| --- | --- |
| <img width="1615" height="608" alt="image" src="https://github.com/user-attachments/assets/32848b0d-09d1-462c-9696-5d879d8c045d" /> | <img width="1620" height="631" alt="image" src="https://github.com/user-attachments/assets/1707d5f2-44a4-4560-93a4-c25e282411f6" /> | 

### How to test

1. Setup side rail placements
2. Navigate to a post and zoom out
3. Confirm the ad renders close to the content, as in the image above
