### PR TITLE
fix(providers): harden `get_provider()` argument check

### DIFF
--- a/includes/class-providers.php
+++ b/includes/class-providers.php
@@ -208,7 +208,7 @@ final class Providers {
 		if ( ! is_string( $provider_id ) || empty( $providers ) || ! isset( $providers[ $provider_id ] ) ) {
 			return false;
 		}
-		return $providers[ $provider_id ];
+		return self::$providers[ $provider_id ];
 	}
 
 	/**

--- a/includes/class-providers.php
+++ b/includes/class-providers.php
@@ -205,10 +205,10 @@ final class Providers {
 	 */
 	public static function get_provider( $provider_id ) {
 		$providers = self::get_providers();
-		if ( ! isset( $providers[ $provider_id ] ) ) {
+		if ( ! is_string( $provider_id ) || empty( $providers ) || ! isset( $providers[ $provider_id ] ) ) {
 			return false;
 		}
-		return self::$providers[ $provider_id ];
+		return $providers[ $provider_id ];
 	}
 
 	/**

--- a/tests/test-model.php
+++ b/tests/test-model.php
@@ -23,7 +23,9 @@ class ModelTest extends WP_UnitTestCase {
 	}
 
 	public function set_up() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
-		wp_delete_post( self::$legacy_ad_id );
+		if ( self::$legacy_ad_id ) {
+			wp_delete_post( self::$legacy_ad_id );
+		}
 
 		// Create a legacy ad unit (a CPT).
 		self::$legacy_ad_id = self::factory()->post->create(


### PR DESCRIPTION
NPPM-2498

The placement could have invalid provider data stored, which may cause a fatal error.

### Testing

1. With GAM enabled, configure a placement to use a GAM ad unit
2. Edit the DB entry for the placement (e.g. `_newspack_ads_placement_global_below_header`)
3. Change `"provider":"gam"` to `"provider":{}` and flush the object cache
4. While on trunk, visit the homepage and confirm you get a fatal error
5. Checkout this branch, visit the homepage and confirm you no longer get a fatal error
6. Restore the placement configuration and confirm the ad renders without issues