### PR TITLE
Add docblocks to constants

### DIFF
--- a/includes/bidders/class-openx.php
+++ b/includes/bidders/class-openx.php
@@ -27,8 +27,17 @@ final class OpenX {
 	 * Register bidder and its hooks.
 	 */
 	public static function init() {
-
-		// Require environment variable due to its experimental nature.
+		/**
+		 * Enables experimental header bidding integrations (OpenX, PubMatic, MediaNet, Sovrn).
+		 * These bidders are not fully tested and may have issues.
+		 *
+		 * @constant NEWSPACK_ADS_EXPERIMENTAL_BIDDERS
+		 * @type     bool
+		 * @default  Experimental bidders disabled
+		 * @status   draft
+		 *
+		 * @example define( 'NEWSPACK_ADS_EXPERIMENTAL_BIDDERS', true );
+		 */
 		if ( ! defined( 'NEWSPACK_ADS_EXPERIMENTAL_BIDDERS' ) ) {
 			return;
 		}

--- a/includes/integrations/class-side-rail-placements.php
+++ b/includes/integrations/class-side-rail-placements.php
@@ -17,6 +17,17 @@ class Side_Rail_Placements {
 	 * Initialize hooks.
 	 */
 	public static function init() {
+		/**
+		 * Enables experimental side rail ad placements that display ads
+		 * in sticky positions along the left and right margins of the content area.
+		 *
+		 * @constant NEWSPACK_ADS_SIDE_RAIL_PLACEMENTS
+		 * @type     bool
+		 * @default  Side rail ad placements disabled
+		 * @status   draft
+		 *
+		 * @example define( 'NEWSPACK_ADS_SIDE_RAIL_PLACEMENTS', true );
+		 */
 		if ( ! defined( 'NEWSPACK_ADS_SIDE_RAIL_PLACEMENTS' ) || ! NEWSPACK_ADS_SIDE_RAIL_PLACEMENTS ) {
 			return;
 		}

--- a/newspack-ads.php
+++ b/newspack-ads.php
@@ -25,6 +25,17 @@ define( 'NEWSPACK_ADS_ABSPATH', dirname( NEWSPACK_ADS_PLUGIN_FILE ) . '/' );
 
 define( 'NEWSPACK_ADS_BLOCKS_PATH', NEWSPACK_ADS_ABSPATH . 'src/blocks/' );
 
+/**
+ * Path to the Composer vendor directory for Newspack Ads.
+ * Useful when running with a custom autoloader setup.
+ *
+ * @constant NEWSPACK_ADS_COMPOSER_ABSPATH
+ * @type     string
+ * @default  Plugin vendor directory
+ * @status   draft
+ *
+ * @example define( 'NEWSPACK_ADS_COMPOSER_ABSPATH', '/path/to/vendor/' );
+ */
 if ( ! defined( 'NEWSPACK_ADS_COMPOSER_ABSPATH' ) ) {
 	define( 'NEWSPACK_ADS_COMPOSER_ABSPATH', dirname( NEWSPACK_ADS_PLUGIN_FILE ) . '/vendor/' );
 }


### PR DESCRIPTION
## Summary
- Adds PHPDoc-style docblocks to `NEWSPACK_` constants for documentation purposes

🤖 Generated with [Claude Code](https://claude.com/claude-code)