### PR TITLE
chore(gam): update api version

### DIFF
--- a/includes/providers/gam/api/class-ad-units.php
+++ b/includes/providers/gam/api/class-ad-units.php
@@ -8,19 +8,19 @@
 namespace Newspack_Ads\Providers\GAM\Api;
 
 use Newspack_Ads\Providers\GAM\Api\Api_Object;
-use Google\AdsApi\AdManager\Util\v202505\StatementBuilder;
-use Google\AdsApi\AdManager\v202505\ServiceFactory;
-use Google\AdsApi\AdManager\v202505\InventoryService;
-use Google\AdsApi\AdManager\v202505\Size;
-use Google\AdsApi\AdManager\v202505\EnvironmentType;
-use Google\AdsApi\AdManager\v202505\AdUnit;
-use Google\AdsApi\AdManager\v202505\AdUnitParent;
-use Google\AdsApi\AdManager\v202505\AdUnitSize;
-use Google\AdsApi\AdManager\v202505\AdUnitTargetWindow;
-use Google\AdsApi\AdManager\v202505\ArchiveAdUnits as ArchiveAdUnitsAction;
-use Google\AdsApi\AdManager\v202505\ActivateAdUnits as ActivateAdUnitsAction;
-use Google\AdsApi\AdManager\v202505\DeactivateAdUnits as DeactivateAdUnitsAction;
-use Google\AdsApi\AdManager\v202505\ApiException;
+use Google\AdsApi\AdManager\Util\v202511\StatementBuilder;
+use Google\AdsApi\AdManager\v202511\ServiceFactory;
+use Google\AdsApi\AdManager\v202511\InventoryService;
+use Google\AdsApi\AdManager\v202511\Size;
+use Google\AdsApi\AdManager\v202511\EnvironmentType;
+use Google\AdsApi\AdManager\v202511\AdUnit;
+use Google\AdsApi\AdManager\v202511\AdUnitParent;
+use Google\AdsApi\AdManager\v202511\AdUnitSize;
+use Google\AdsApi\AdManager\v202511\AdUnitTargetWindow;
+use Google\AdsApi\AdManager\v202511\ArchiveAdUnits as ArchiveAdUnitsAction;
+use Google\AdsApi\AdManager\v202511\ActivateAdUnits as ActivateAdUnitsAction;
+use Google\AdsApi\AdManager\v202511\DeactivateAdUnits as DeactivateAdUnitsAction;
+use Google\AdsApi\AdManager\v202511\ApiException;
 
 /**
  * Newspack Ads GAM Ad Units

--- a/includes/providers/gam/api/class-advertisers.php
+++ b/includes/providers/gam/api/class-advertisers.php
@@ -8,10 +8,10 @@
 namespace Newspack_Ads\Providers\GAM\Api;
 
 use Newspack_Ads\Providers\GAM\Api\Api_Object;
-use Google\AdsApi\AdManager\Util\v202505\StatementBuilder;
-use Google\AdsApi\AdManager\v202505\ServiceFactory;
-use Google\AdsApi\AdManager\v202505\Company;
-use Google\AdsApi\AdManager\v202505\CompanyType;
+use Google\AdsApi\AdManager\Util\v202511\StatementBuilder;
+use Google\AdsApi\AdManager\v202511\ServiceFactory;
+use Google\AdsApi\AdManager\v202511\Company;
+use Google\AdsApi\AdManager\v202511\CompanyType;
 
 /**
  * Newspack Ads GAM Advertisers

--- a/includes/providers/gam/api/class-api.php
+++ b/includes/providers/gam/api/class-api.php
@@ -14,10 +14,10 @@ use Google\Auth\OAuth2;
 use Google\AdsApi\Common\Configuration;
 use Google\AdsApi\AdManager\AdManagerSessionBuilder;
 use Google\AdsApi\AdManager\AdManagerSession;
-use Google\AdsApi\AdManager\v202505\ServiceFactory;
-use Google\AdsApi\AdManager\v202505\Network;
-use Google\AdsApi\AdManager\v202505\User;
-use Google\AdsApi\AdManager\v202505\ApiException;
+use Google\AdsApi\AdManager\v202511\ServiceFactory;
+use Google\AdsApi\AdManager\v202511\Network;
+use Google\AdsApi\AdManager\v202511\User;
+use Google\AdsApi\AdManager\v202511\ApiException;
 
 require_once NEWSPACK_ADS_COMPOSER_ABSPATH . 'autoload.php';
 require_once 'class-api-object.php';
@@ -35,7 +35,7 @@ class Api {
 	// https://developers.google.com/ad-manager/api/soap_xml: An arbitrary string name identifying your application. This will be shown in Google's log files.
 	const APP = 'Newspack';
 
-	const API_VERSION = 'v202505';
+	const API_VERSION = 'v202511';
 
 	/**
 	 * Codes of networks that the user has access to.

--- a/includes/providers/gam/api/class-creatives.php
+++ b/includes/providers/gam/api/class-creatives.php
@@ -9,10 +9,10 @@ namespace Newspack_Ads\Providers\GAM\Api;
 
 use Newspack_Ads\Providers\GAM\Api;
 use Newspack_Ads\Providers\GAM\Api\Api_Object;
-use Google\AdsApi\AdManager\Util\v202505\StatementBuilder;
-use Google\AdsApi\AdManager\v202505\ServiceFactory;
-use Google\AdsApi\AdManager\v202505\Creative;
-use Google\AdsApi\AdManager\v202505\Size;
+use Google\AdsApi\AdManager\Util\v202511\StatementBuilder;
+use Google\AdsApi\AdManager\v202511\ServiceFactory;
+use Google\AdsApi\AdManager\v202511\Creative;
+use Google\AdsApi\AdManager\v202511\Size;
 
 /**
  * Newspack Ads GAM Creatives

--- a/includes/providers/gam/api/class-line-items.php
+++ b/includes/providers/gam/api/class-line-items.php
@@ -9,21 +9,21 @@ namespace Newspack_Ads\Providers\GAM\Api;
 
 use Newspack_Ads\Providers\GAM\Api;
 use Newspack_Ads\Providers\GAM\Api\Api_Object;
-use Google\AdsApi\AdManager\Util\v202505\StatementBuilder;
-use Google\AdsApi\AdManager\v202505\ServiceFactory;
-use Google\AdsApi\AdManager\v202505\LineItemService;
-use Google\AdsApi\AdManager\v202505\LineItemCreativeAssociation;
-use Google\AdsApi\AdManager\v202505\LineItem;
-use Google\AdsApi\AdManager\v202505\Size;
-use Google\AdsApi\AdManager\v202505\Money;
-use Google\AdsApi\AdManager\v202505\Goal;
-use Google\AdsApi\AdManager\v202505\Targeting;
-use Google\AdsApi\AdManager\v202505\AdUnitTargeting;
-use Google\AdsApi\AdManager\v202505\InventoryTargeting;
-use Google\AdsApi\AdManager\v202505\CreativePlaceholder;
-use Google\AdsApi\AdManager\v202505\CustomCriteriaSet;
-use Google\AdsApi\AdManager\v202505\CustomCriteria;
-use Google\AdsApi\AdManager\v202505\ApiException;
+use Google\AdsApi\AdManager\Util\v202511\StatementBuilder;
+use Google\AdsApi\AdManager\v202511\ServiceFactory;
+use Google\AdsApi\AdManager\v202511\LineItemService;
+use Google\AdsApi\AdManager\v202511\LineItemCreativeAssociation;
+use Google\AdsApi\AdManager\v202511\LineItem;
+use Google\AdsApi\AdManager\v202511\Size;
+use Google\AdsApi\AdManager\v202511\Money;
+use Google\AdsApi\AdManager\v202511\Goal;
+use Google\AdsApi\AdManager\v202511\Targeting;
+use Google\AdsApi\AdManager\v202511\AdUnitTargeting;
+use Google\AdsApi\AdManager\v202511\InventoryTargeting;
+use Google\AdsApi\AdManager\v202511\CreativePlaceholder;
+use Google\AdsApi\AdManager\v202511\CustomCriteriaSet;
+use Google\AdsApi\AdManager\v202511\CustomCriteria;
+use Google\AdsApi\AdManager\v202511\ApiException;
 
 /**
  * Newspack Ads GAM Line Items

--- a/includes/providers/gam/api/class-orders.php
+++ b/includes/providers/gam/api/class-orders.php
@@ -9,11 +9,11 @@ namespace Newspack_Ads\Providers\GAM\Api;
 
 use Newspack_Ads\Providers\GAM\Api;
 use Newspack_Ads\Providers\GAM\Api\Api_Object;
-use Google\AdsApi\AdManager\Util\v202505\StatementBuilder;
-use Google\AdsApi\AdManager\v202505\ServiceFactory;
-use Google\AdsApi\AdManager\v202505\Order;
-use Google\AdsApi\AdManager\v202505\ArchiveOrders as ArchiveOrdersAction;
-use Google\AdsApi\AdManager\v202505\ApiException;
+use Google\AdsApi\AdManager\Util\v202511\StatementBuilder;
+use Google\AdsApi\AdManager\v202511\ServiceFactory;
+use Google\AdsApi\AdManager\v202511\Order;
+use Google\AdsApi\AdManager\v202511\ArchiveOrders as ArchiveOrdersAction;
+use Google\AdsApi\AdManager\v202511\ApiException;
 
 /**
  * Newspack Ads GAM Orders

--- a/includes/providers/gam/api/class-targeting-keys.php
+++ b/includes/providers/gam/api/class-targeting-keys.php
@@ -9,13 +9,13 @@ namespace Newspack_Ads\Providers\GAM\Api;
 
 use Newspack_Ads\Providers\GAM\Api;
 use Newspack_Ads\Providers\GAM\Api\Api_Object;
-use Google\AdsApi\AdManager\v202505\Statement;
-use Google\AdsApi\AdManager\v202505\String_ValueMapEntry;
-use Google\AdsApi\AdManager\v202505\TextValue;
-use Google\AdsApi\AdManager\v202505\SetValue;
-use Google\AdsApi\AdManager\v202505\CustomTargetingKey;
-use Google\AdsApi\AdManager\v202505\CustomTargetingValue;
-use Google\AdsApi\AdManager\v202505\ServiceFactory;
+use Google\AdsApi\AdManager\v202511\Statement;
+use Google\AdsApi\AdManager\v202511\String_ValueMapEntry;
+use Google\AdsApi\AdManager\v202511\TextValue;
+use Google\AdsApi\AdManager\v202511\SetValue;
+use Google\AdsApi\AdManager\v202511\CustomTargetingKey;
+use Google\AdsApi\AdManager\v202511\CustomTargetingValue;
+use Google\AdsApi\AdManager\v202511\ServiceFactory;
 
 /**
  * Newspack Ads GAM Default Targeting Keys


### PR DESCRIPTION
Update the GAM API version from v202505 to v202511.

## Testing

1. Connect to a GAM account
2. Create, update, and archive an ad unit
3. Confirm all actions work without issues