### PR TITLE
docs: add AI agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,39 +32,6 @@ npm run fix:php          # Auto-fix PHP issues (PHPCBF)
 
 ## PHP Backend
 
-### Bootstrap & Autoloading
-
-- **`newspack-ads.php`**: Main plugin file, defines constants (`NEWSPACK_ADS_VERSION`, `NEWSPACK_ADS_PLUGIN_FILE`, `NEWSPACK_ADS_ABSPATH`, `NEWSPACK_ADS_BLOCKS_PATH`, `NEWSPACK_ADS_COMPOSER_ABSPATH`), requires Composer autoloader, initializes `Core::instance()`.
-- **`includes/class-core.php`**: Singleton main class. The `includes()` method manually `include_once`s 29 files in a specific order. Adding a new file requires adding it here.
-
-### Class Initialization Patterns
-
-Two patterns:
-
-1. **`Core`**: Singleton via `Core::instance()` (only the main class).
-
-2. **Static `init()`**: Dominant pattern, used by most classes:
-
-```php
-namespace Newspack_Ads;
-
-class My_Feature {
-    public static function init() {
-        add_action( 'init', [ __CLASS__, 'register_things' ] );
-    }
-}
-My_Feature::init();
-```
-
-### Namespace Map
-
-| Namespace | Directory |
-|-----------|-----------|
-| `Newspack_Ads` | `includes/` (root, most classes) |
-| `Newspack_Ads\Providers` | `includes/providers/` |
-| `Newspack_Ads\Integrations` | `includes/integrations/` |
-| `Newspack_Ads\Bidders` | `includes/bidders/` |
-
 ### Core Entities
 
 **Providers** -- the ad server abstraction:
@@ -242,84 +209,6 @@ Key prefixes:
 | `newspack_ads_before_placement_ad` / `newspack_ads_after_placement_ad` | Before/after a placement renders |
 | `newspack_ads_before_update_setting` / `newspack_ads_after_update_setting` | Before/after a setting is updated |
 | `newspack_ads_setup_gam` | GAM provider setup complete |
-
-## Directory Structure
-
-```
-newspack-ads/
-├── newspack-ads.php              # Main plugin file: constants, bootstrap
-├── webpack.config.js             # Webpack config (extends newspack-scripts)
-├── includes/
-│   ├── class-core.php            # Singleton main class, includes all files
-│   ├── class-settings.php        # REST API settings management
-│   ├── class-placements.php      # Placement registration and rendering
-│   ├── class-providers.php       # Provider registry
-│   ├── class-bidding.php         # Header bidding (Prebid.js) configuration
-│   ├── class-suppression.php     # Ad suppression rules
-│   ├── class-custom-label.php    # Custom "Advertisement" labels
-│   ├── class-fixed-height.php    # Fixed height ad support
-│   ├── class-sidebar-placements.php # Sidebar-specific placements
-│   ├── class-widget.php          # Ad widget
-│   ├── utils.php                 # Utility functions
-│   ├── functions.php             # Public API functions (register_bidder, etc.)
-│   ├── providers/
-│   │   ├── interface-provider.php          # Provider interface
-│   │   ├── class-provider.php              # Abstract provider base class
-│   │   ├── gam/                            # Google Ad Manager provider
-│   │   │   ├── class-gam-provider.php      # GAM provider implementation
-│   │   │   ├── class-gam-model.php         # Data model, size mapping, targeting
-│   │   │   ├── class-gam-scripts.php       # GPT script rendering
-│   │   │   ├── class-gam-lazy-load.php     # Lazy loading
-│   │   │   ├── class-gam-ad-block-recovery.php # Ad blocker recovery
-│   │   │   └── api/                        # GAM SOAP API wrappers
-│   │   │       ├── class-api.php           # Main API client
-│   │   │       ├── class-api-object.php   # Abstract base for entity classes
-│   │   │       ├── class-ad-units.php
-│   │   │       ├── class-line-items.php
-│   │   │       ├── class-orders.php
-│   │   │       ├── class-creatives.php
-│   │   │       ├── class-advertisers.php
-│   │   │       └── class-targeting-keys.php
-│   │   └── broadstreet/
-│   │       └── class-broadstreet-provider.php
-│   ├── bidders/                  # Header bidding adapters
-│   │   ├── class-medianet.php
-│   │   ├── class-openx.php
-│   │   ├── class-pubmatic.php
-│   │   └── class-sovrn.php
-│   ├── integrations/
-│   │   ├── class-scaip.php              # SCAIP integration
-│   │   ├── class-bidding-gam.php        # Prebid + GAM automation
-│   │   ├── class-complianz.php          # Cookie consent
-│   │   ├── class-ad-refresh-control.php # Ad refresh
-│   │   └── class-side-rail-placements.php
-│   ├── blocks/
-│   │   ├── class-ad-unit-block.php
-│   │   ├── class-tabs-block.php
-│   │   └── class-tabs-item-block.php
-│   ├── customizer/
-│   │   └── class-customizer.php
-│   └── media-kit/
-│       └── class-media-kit.php
-├── src/
-│   ├── blocks/                   # Block editor and frontend code
-│   │   ├── ad-unit/
-│   │   ├── tabs/
-│   │   ├── tabs-item/
-│   │   └── utils/                # Shared block utilities
-│   ├── frontend/                 # Frontend scripts and styles
-│   ├── setup/                    # Editor and view setup scripts
-│   ├── placements/               # Placement control scripts
-│   ├── prebid/                   # Prebid.js with bidder adapter imports
-│   ├── wizard-settings/          # GAM header bidding settings script
-│   ├── suppress-ads/             # Ad suppression frontend
-│   ├── customizer/               # Customizer control and preview
-│   └── media-kit/                # Media kit frontend
-├── tests/                        # PHPUnit tests
-├── dist/                         # Compiled output (gitignored)
-├── vendor/                       # Composer dependencies (gitignored)
-└── languages/                    # Translation files
-```
 
 ## Recipes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,361 @@
+# Newspack Ads: Agent Instructions
+
+This file covers what is specific to `newspack-ads`. Shared conventions (Docker commands, `n` script, coding standards, git rules, etc.) are in the root `newspack-workspace/AGENTS.md`.
+
+## Overview
+
+`newspack-ads` is a WordPress plugin for ad placement management. It provides a provider-based architecture (Google Ad Manager, Broadstreet), a placement system for controlling where ads render, header bidding via Prebid.js, ad suppression, and WordPress Customizer integration for visual placement configuration.
+
+Key insight: the admin wizard UI (Advertising settings page) lives in `newspack-plugin` (via `Advertising_Wizard` and `Newspack_Ads_Configuration_Manager`), not in this repo. This plugin provides the backend APIs, Gutenberg blocks, and frontend rendering logic that the wizard consumes.
+
+## Linting Commands
+
+```bash
+npm run lint             # JS + SCSS only (see gotchas)
+npm run lint:js          # JavaScript linting
+npm run lint:scss        # SCSS linting
+npm run lint:php         # PHP linting (PHPCS)
+npm run fix:js           # Auto-fix JS issues
+npm run fix:php          # Auto-fix PHP issues (PHPCBF)
+```
+
+## Common Gotchas
+
+- **`npm run lint` runs JS + SCSS only.** PHP linting requires a separate `npm run lint:php`.
+- **No PSR-4/classmap autoloading for plugin classes.** Manual `include_once` in `Core::includes()`. After adding a new PHP file, you must add an `include_once` line there.
+- **The Advertising wizard UI (settings page) lives in `newspack-plugin`, not here.** This repo provides the REST API and rendering logic that the wizard consumes. Do not look for settings UI code in this repo.
+- **Settings are migrating from `Newspack_Ads_Configuration_Manager` (in newspack-plugin) to a REST API using `Newspack_Ads\Settings`.** New settings should use the `Settings` class in this repo.
+- **Header bidding (Prebid.js) is gated behind the `NEWSPACK_ADS_EXPERIMENTAL_BIDDERS` constant.** It must be `define( 'NEWSPACK_ADS_EXPERIMENTAL_BIDDERS', true );` in `wp-config.php` for bidding features to appear.
+- **The GAM provider requires `googleads-php-lib` (SOAP library).** PHP's SOAP extension must be enabled (it is in the Docker dev environment).
+- **The Broadstreet provider is a thin wrapper around the separate [Broadstreet WP plugin](https://wordpress.org/plugins/broadstreet/).** It must be installed and activated for the provider to work.
+- **All provider and integration checks are defensive** -- use `class_exists`/`function_exists`. The plugin must work standalone without any other Newspack plugin.
+
+## PHP Backend
+
+### Bootstrap & Autoloading
+
+- **`newspack-ads.php`**: Main plugin file, defines constants (`NEWSPACK_ADS_VERSION`, `NEWSPACK_ADS_PLUGIN_FILE`, `NEWSPACK_ADS_ABSPATH`, `NEWSPACK_ADS_BLOCKS_PATH`, `NEWSPACK_ADS_COMPOSER_ABSPATH`), requires Composer autoloader, initializes `Core::instance()`.
+- **`includes/class-core.php`**: Singleton main class. The `includes()` method manually `include_once`s 29 files in a specific order. Adding a new file requires adding it here.
+
+### Class Initialization Patterns
+
+Two patterns:
+
+1. **`Core`**: Singleton via `Core::instance()` (only the main class).
+
+2. **Static `init()`**: Dominant pattern, used by most classes:
+
+```php
+namespace Newspack_Ads;
+
+class My_Feature {
+    public static function init() {
+        add_action( 'init', [ __CLASS__, 'register_things' ] );
+    }
+}
+My_Feature::init();
+```
+
+### Namespace Map
+
+| Namespace | Directory |
+|-----------|-----------|
+| `Newspack_Ads` | `includes/` (root, most classes) |
+| `Newspack_Ads\Providers` | `includes/providers/` |
+| `Newspack_Ads\Integrations` | `includes/integrations/` |
+| `Newspack_Ads\Bidders` | `includes/bidders/` |
+
+### Core Entities
+
+**Providers** -- the ad server abstraction:
+- Interface: `includes/providers/interface-provider.php` defines `get_provider_id()`, `get_provider_name()`, `is_active()`, `get_units()`, `get_ad_code()`, `render_code()`.
+- Abstract class: `includes/providers/class-provider.php` implements the interface with sensible defaults.
+- Registration: `Providers::register_provider($provider)` in `includes/class-providers.php`.
+- Implementations: GAM (`includes/providers/gam/class-gam-provider.php`) and Broadstreet (`includes/providers/broadstreet/class-broadstreet-provider.php`).
+- Broadstreet is a great reference for a simple provider implementation.
+
+**Placements** -- where ads render:
+- Registration: `Placements::register_placement($key, $config)` in `includes/class-placements.php`.
+- Default placements: `global_above_header`, `global_below_header`, `global_above_footer`, `sticky`.
+- Config schema: `name`, `description`, `default_enabled`, `default_ad_unit`, `show_ui`, `hook_name`, `hooks` (array), `supports` (array, e.g. `stick_to_top`).
+- Hook-based rendering: call `do_action('hook_name')` in a template, the placement renders the configured ad.
+- The Ad Unit block creates dynamic placements via the same API.
+- SCAIP integration replaces widget areas with registered placements.
+
+**Settings** -- centralized settings management:
+- Class: `includes/class-settings.php`.
+- API namespace: `newspack-ads/v1` (constant `Settings::API_NAMESPACE`).
+- Option prefix: `_newspack_ads_` (constant `Settings::OPTION_NAME_PREFIX`).
+- REST endpoints: `GET/POST /settings`.
+- Permission: `manage_options` capability, filterable via `newspack_ads_can_current_user_manage_settings`.
+
+**Bidding** -- header bidding via Prebid.js:
+- Class: `includes/class-bidding.php`.
+- Gated by `NEWSPACK_ADS_EXPERIMENTAL_BIDDERS` constant.
+- Registration: `Newspack_Ads\register_bidder($id, $config)` (in `includes/class-bidding.php`, bottom of file).
+- Config schema: `name`, `ad_sizes`, `active_key`, `settings`.
+- Built-in bidders: Medianet, OpenX, PubMatic, Sovrn (in `includes/bidders/`).
+- Price granularity: low, medium, auto, dense (dense is default).
+- Each bidder must have a compatible Prebid.js adapter module imported in `src/prebid/index.js`.
+
+### GAM Provider (Deep Dive)
+
+The GAM provider is the most complex part of the plugin.
+
+**API Layer:**
+- Built on `googleads-php-lib` (SOAP library).
+- Main client: `includes/providers/gam/api/class-api.php`.
+- Entity-specific classes: `class-ad-units.php`, `class-line-items.php`, `class-orders.php`, `class-creatives.php`, `class-advertisers.php`, `class-targeting-keys.php`.
+- Authentication: service account credentials or OAuth proxied by Newspack Manager (`includes/providers/gam/class-gam-model.php`).
+
+**Targeting Key-Values:**
+- Auto-created keys when GAM connects: `id`, `slug`, `category`, `post_type`, `template`, `site`.
+- Values populated at render time from current page context.
+- Extensible via `newspack_ads_ad_targeting` filter.
+
+**Responsive Size Mapping:**
+- 600px viewport threshold separates mobile from desktop ad sizes.
+- Sizes within 30% of each other are grouped together.
+- "Bounds containers" detect parent elements (e.g., `.wp-block-column`) that restrict allowed sizes.
+- Filterable via `newspack_ads_gam_size_map`.
+
+**Supporting Classes:**
+- `class-gam-model.php`: data model, size mapping logic, targeting.
+- `class-gam-scripts.php`: renders Google Publisher Tag (GPT) scripts, bounds containers.
+- `class-gam-lazy-load.php`: lazy loading of ad slots.
+- `class-gam-ad-block-recovery.php`: ad block detection and recovery.
+
+### REST API
+
+Namespace: `newspack-ads/v1`. All endpoints require `manage_options` unless noted.
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/settings` | GET | Get all plugin settings |
+| `/settings` | POST | Update settings (section + values) |
+| `/placements` | GET | Get all registered placements |
+| `/placements/{key}` | POST | Update placement configuration |
+| `/placements/{key}` | DELETE | Disable a placement |
+| `/providers` | GET | Get active providers and their units |
+| `/suppression` | GET/POST | Get/update ad suppression config |
+| `/bidding/gam/orders` | GET | List header bidding GAM orders |
+| `/bidding/gam/order` | GET | Get specific GAM order details |
+
+### Integrations
+
+| Class | File | Purpose |
+|-------|------|---------|
+| `SCAIP` | `integrations/class-scaip.php` | Replaces SCAIP widget areas with registered placements |
+| `Bidding_GAM` | `integrations/class-bidding-gam.php` | Automates GAM setup for header bidding (creates advertiser, keys, creatives, orders, line items, LICAs) |
+| `Complianz` | `integrations/class-complianz.php` | Cookie consent integration for GDPR compliance |
+| `Ad_Refresh_Control` | `integrations/class-ad-refresh-control.php` | Controls ad refresh frequency |
+| `Side_Rail_Placements` | `integrations/class-side-rail-placements.php` | Sticky sidebar ad placements |
+
+## Frontend (JS/SCSS)
+
+### Webpack Entry Points
+
+Defined in `webpack.config.js` using `newspack-scripts/config/getWebpackConfig`:
+
+| Entry | Source | Purpose |
+|-------|--------|---------|
+| `editor` | All `src/blocks/*/editor.js` | Combined block editor bundle |
+| `frontend` | `src/frontend/index.js` | Frontend scripts (side rail, utilities) |
+| `suppress-ads` | `src/suppress-ads/index.js` | Ad suppression logic |
+| `customizer-preview` | `src/customizer/preview.js` | Customizer live preview |
+| `customizer-control` | `src/customizer/control.js` | Customizer controls |
+| `header-bidding-gam` | `src/wizard-settings/header-bidding-gam/index.js` | GAM header bidding config |
+| `prebid` | `src/prebid/index.js` | Prebid.js with bidder adapters |
+| `media-kit-frontend` | `src/media-kit/index.js` | Media kit page scripts |
+| `<block>/view` | Each `src/blocks/*/view.js` | Per-block frontend scripts |
+
+Note: Prebid.js has a custom Babel configuration in `webpack.config.js` because the library's source requires specific transforms.
+
+### Blocks
+
+Three custom blocks:
+
+| Block | Directory | Purpose |
+|-------|-----------|---------|
+| `newspack-ads/ad-unit` | `src/blocks/ad-unit/` | Place individual ad units in content. Creates dynamic placements. |
+| `newspack-ads/tabs` | `src/blocks/tabs/` | Tab container for organizing ad content |
+| `newspack-ads/tabs-item` | `src/blocks/tabs-item/` | Individual tab within tabs block |
+
+Block registration follows static class pattern in `includes/blocks/`:
+- `class-ad-unit-block.php` -- registers block, enqueues editor assets, render callback.
+- `class-tabs-block.php`
+- `class-tabs-item-block.php`
+
+### Customizer
+
+Visual placement configuration via WordPress Customizer:
+- `includes/customizer/class-customizer.php` -- registers sections and controls.
+- `src/customizer/control.js` -- placement selection controls.
+- `src/customizer/preview.js` -- live preview of ad placement changes.
+
+## Testing
+
+```bash
+n test-php                    # Run all PHPUnit tests (from within repo directory)
+n test-php --filter test_name # Run specific test
+npm run lint                  # Run all linters
+```
+
+- Config: `phpunit.xml` with single `main` suite.
+- Bootstrap: `tests/bootstrap.php` (defines `IS_TEST_ENV` constant).
+- Test files: `test-model.php`, `test-bidding.php`, `test-providers.php`, `test-settings.php`, `test-gam-api.php`.
+- Mock provider: `tests/class-newspack-ads-test-provider.php`.
+- No PHPUnit groups currently defined.
+- No JavaScript tests.
+
+## Hooks & Extension Points
+
+The plugin exposes many hooks. Rather than listing them all here (they change over time), use grep to find current hooks:
+
+```bash
+grep -r 'apply_filters\|do_action' includes/ --include='*.php'
+```
+
+Key prefixes:
+- `newspack_ads_*` -- general plugin hooks.
+- `newspack_ads_placement_*` -- placement-specific hooks.
+- `newspack_ads_gam_*` -- GAM provider hooks.
+
+**Important filters:**
+
+| Filter | Purpose |
+|--------|---------|
+| `newspack_ads_should_show_ads` | Global ad suppression |
+| `newspack_ads_placements` | Modify registered placements |
+| `newspack_ads_placement_data` | Modify placement data before render |
+| `newspack_ads_ad_targeting` | Extend GAM targeting key-values |
+| `newspack_ads_gam_size_map` | Customize responsive size mapping |
+| `newspack_ads_settings_list` | Extend settings |
+| `newspack_ads_bidders` | Modify registered bidders |
+| `newspack_ads_prebid_ad_units` | Modify Prebid.js ad unit config |
+| `newspack_ads_can_current_user_manage_settings` | Permission override |
+
+**Important actions:**
+
+| Action | Purpose |
+|--------|---------|
+| `newspack_ads_before_placement_ad` / `newspack_ads_after_placement_ad` | Before/after a placement renders |
+| `newspack_ads_before_update_setting` / `newspack_ads_after_update_setting` | Before/after a setting is updated |
+| `newspack_ads_setup_gam` | GAM provider setup complete |
+
+## Directory Structure
+
+```
+newspack-ads/
+├── newspack-ads.php              # Main plugin file: constants, bootstrap
+├── webpack.config.js             # Webpack config (extends newspack-scripts)
+├── includes/
+│   ├── class-core.php            # Singleton main class, includes all files
+│   ├── class-settings.php        # REST API settings management
+│   ├── class-placements.php      # Placement registration and rendering
+│   ├── class-providers.php       # Provider registry
+│   ├── class-bidding.php         # Header bidding (Prebid.js) configuration
+│   ├── class-suppression.php     # Ad suppression rules
+│   ├── class-custom-label.php    # Custom "Advertisement" labels
+│   ├── class-fixed-height.php    # Fixed height ad support
+│   ├── class-sidebar-placements.php # Sidebar-specific placements
+│   ├── class-widget.php          # Ad widget
+│   ├── utils.php                 # Utility functions
+│   ├── functions.php             # Public API functions (register_bidder, etc.)
+│   ├── providers/
+│   │   ├── interface-provider.php          # Provider interface
+│   │   ├── class-provider.php              # Abstract provider base class
+│   │   ├── gam/                            # Google Ad Manager provider
+│   │   │   ├── class-gam-provider.php      # GAM provider implementation
+│   │   │   ├── class-gam-model.php         # Data model, size mapping, targeting
+│   │   │   ├── class-gam-scripts.php       # GPT script rendering
+│   │   │   ├── class-gam-lazy-load.php     # Lazy loading
+│   │   │   ├── class-gam-ad-block-recovery.php # Ad blocker recovery
+│   │   │   └── api/                        # GAM SOAP API wrappers
+│   │   │       ├── class-api.php           # Main API client
+│   │   │       ├── class-api-object.php   # Abstract base for entity classes
+│   │   │       ├── class-ad-units.php
+│   │   │       ├── class-line-items.php
+│   │   │       ├── class-orders.php
+│   │   │       ├── class-creatives.php
+│   │   │       ├── class-advertisers.php
+│   │   │       └── class-targeting-keys.php
+│   │   └── broadstreet/
+│   │       └── class-broadstreet-provider.php
+│   ├── bidders/                  # Header bidding adapters
+│   │   ├── class-medianet.php
+│   │   ├── class-openx.php
+│   │   ├── class-pubmatic.php
+│   │   └── class-sovrn.php
+│   ├── integrations/
+│   │   ├── class-scaip.php              # SCAIP integration
+│   │   ├── class-bidding-gam.php        # Prebid + GAM automation
+│   │   ├── class-complianz.php          # Cookie consent
+│   │   ├── class-ad-refresh-control.php # Ad refresh
+│   │   └── class-side-rail-placements.php
+│   ├── blocks/
+│   │   ├── class-ad-unit-block.php
+│   │   ├── class-tabs-block.php
+│   │   └── class-tabs-item-block.php
+│   ├── customizer/
+│   │   └── class-customizer.php
+│   └── media-kit/
+│       └── class-media-kit.php
+├── src/
+│   ├── blocks/                   # Block editor and frontend code
+│   │   ├── ad-unit/
+│   │   ├── tabs/
+│   │   ├── tabs-item/
+│   │   └── utils/                # Shared block utilities
+│   ├── frontend/                 # Frontend scripts and styles
+│   ├── setup/                    # Editor and view setup scripts
+│   ├── placements/               # Placement control scripts
+│   ├── prebid/                   # Prebid.js with bidder adapter imports
+│   ├── wizard-settings/          # GAM header bidding settings script
+│   ├── suppress-ads/             # Ad suppression frontend
+│   ├── customizer/               # Customizer control and preview
+│   └── media-kit/                # Media kit frontend
+├── tests/                        # PHPUnit tests
+├── dist/                         # Compiled output (gitignored)
+├── vendor/                       # Composer dependencies (gitignored)
+└── languages/                    # Translation files
+```
+
+## Recipes
+
+### Add a new provider
+
+1. Create `includes/providers/<name>/class-<name>-provider.php`.
+2. Extend `Newspack_Ads\Providers\Provider`, implement `get_ad_code()`.
+3. Set `$this->provider_id` and `$this->provider_name` in the constructor.
+4. `include_once` the file in `includes/class-core.php`.
+5. Register: the provider auto-registers when `Providers::init()` runs if it is instantiated via `include_once`.
+6. See `class-broadstreet-provider.php` for a minimal example.
+
+### Add a new placement
+
+1. Call `Placements::register_placement($key, $config)` (typically in a class `init()` method hooked to `init`).
+2. Config must include: `name`, `hook_name` (or `hooks` array).
+3. In the theme/template, call `do_action('hook_name')` where the ad should render.
+4. The placement automatically appears in the UI if `show_ui` is true (default).
+
+### Add a new bidder
+
+1. Create `includes/bidders/class-<name>.php`.
+2. Call `Newspack_Ads\register_bidder($id, $config)` with `name`, `ad_sizes`, `active_key`, `settings`.
+3. Import the corresponding Prebid.js adapter module in `src/prebid/index.js`.
+4. `include_once` the file in `includes/class-core.php`.
+5. Rebuild: `n build` (Prebid.js bundle changes).
+
+### Modify GAM targeting
+
+Use the `newspack_ads_ad_targeting` filter:
+
+```php
+add_filter( 'newspack_ads_ad_targeting', function( $targeting ) {
+    $targeting['my_key'] = 'my_value';
+    return $targeting;
+} );
+```
+
+The key must exist in GAM (auto-created on connection or manually via the API).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,250 +1,61 @@
-# Newspack Ads: Agent Instructions
+# AI agent instructions
 
-This file covers what is specific to `newspack-ads`. Shared conventions (Docker commands, `n` script, coding standards, git rules, etc.) are in the root `newspack-workspace/AGENTS.md`.
+See `../../AGENTS.md` for shared workspace conventions (Docker, `n` script, coding standards, git rules).
 
-## Overview
+## Gotchas
 
-`newspack-ads` is a WordPress plugin for ad placement management. It provides a provider-based architecture (Google Ad Manager, Broadstreet), a placement system for controlling where ads render, header bidding via Prebid.js, ad suppression, and WordPress Customizer integration for visual placement configuration.
+- **No PHP autoloading.** Every new PHP file must be manually added as `include_once` in `Core::includes()` (`includes/class-core.php`). Missing this causes "class not found" errors at runtime. GAM API classes additionally need `require_once` in `includes/providers/gam/api/class-api.php`.
+- **`npm run lint` runs JS and SCSS only.** PHP linting requires separate `npm run lint:php`. Running only `npm run lint` will miss PHP violations.
+- **The advertising settings UI lives in `newspack-plugin`, not here.** This repo provides REST APIs, blocks, and frontend rendering. The wizard page that consumes them is `Newspack_Ads_Configuration_Manager` in newspack-plugin.
+- **Settings are migrating.** Old settings live in `Newspack_Ads_Configuration_Manager` (in newspack-plugin). New settings should use the `Settings` class in this repo (`includes/class-settings.php`).
+- **Bidding features are gated.** Header bidding (Prebid.js) only activates when `NEWSPACK_ADS_EXPERIMENTAL_BIDDERS` is defined as `true` in `wp-config.php`. Without it, bidding code exists but never runs.
+- **Prebid.js has a custom Babel rule** in `webpack.config.js` that loads `.babelrc.js` from the `prebid.js` npm package. Upgrading prebid.js may break the build if the Babel config format changes.
+- **New JS entry points must import setup first.** `__webpack_public_path__` is set dynamically via `src/setup/public-path.js`. Import `src/setup/editor.js` or `src/setup/view.js` at the top of new entry points.
+- **Two block registration patterns coexist.** `ad-unit` uses manual `registerBlockType()`. `tabs`/`tabs-item` use `block.json` + `wp.domReady()` + `registerBlock()` helper. Use the `block.json` pattern for new blocks.
+- **All provider and integration checks must be defensive.** Use `class_exists()`/`function_exists()` guards. The plugin must work standalone without any other Newspack plugin.
 
-Key insight: the admin wizard UI (Advertising settings page) lives in `newspack-plugin` (via `Advertising_Wizard` and `Newspack_Ads_Configuration_Manager`), not in this repo. This plugin provides the backend APIs, Gutenberg blocks, and frontend rendering logic that the wizard consumes.
-
-## Linting Commands
-
-```bash
-npm run lint             # JS + SCSS only (see gotchas)
-npm run lint:js          # JavaScript linting
-npm run lint:scss        # SCSS linting
-npm run lint:php         # PHP linting (PHPCS)
-npm run fix:js           # Auto-fix JS issues
-npm run fix:php          # Auto-fix PHP issues (PHPCBF)
-```
-
-## Common Gotchas
-
-- **`npm run lint` runs JS + SCSS only.** PHP linting requires a separate `npm run lint:php`.
-- **No PSR-4/classmap autoloading for plugin classes.** Manual `include_once` in `Core::includes()`. After adding a new PHP file, you must add an `include_once` line there.
-- **The Advertising wizard UI (settings page) lives in `newspack-plugin`, not here.** This repo provides the REST API and rendering logic that the wizard consumes. Do not look for settings UI code in this repo.
-- **Settings are migrating from `Newspack_Ads_Configuration_Manager` (in newspack-plugin) to a REST API using `Newspack_Ads\Settings`.** New settings should use the `Settings` class in this repo.
-- **Header bidding (Prebid.js) is gated behind the `NEWSPACK_ADS_EXPERIMENTAL_BIDDERS` constant.** It must be `define( 'NEWSPACK_ADS_EXPERIMENTAL_BIDDERS', true );` in `wp-config.php` for bidding features to appear.
-- **The GAM provider requires `googleads-php-lib` (SOAP library).** PHP's SOAP extension must be enabled (it is in the Docker dev environment).
-- **The Broadstreet provider is a thin wrapper around the separate [Broadstreet WP plugin](https://wordpress.org/plugins/broadstreet/).** It must be installed and activated for the provider to work.
-- **All provider and integration checks are defensive** -- use `class_exists`/`function_exists`. The plugin must work standalone without any other Newspack plugin.
-
-## PHP Backend
-
-### Core Entities
-
-**Providers** -- the ad server abstraction:
-- Interface: `includes/providers/interface-provider.php` defines `get_provider_id()`, `get_provider_name()`, `is_active()`, `get_units()`, `get_ad_code()`, `render_code()`.
-- Abstract class: `includes/providers/class-provider.php` implements the interface with sensible defaults.
-- Registration: `Providers::register_provider($provider)` in `includes/class-providers.php`.
-- Implementations: GAM (`includes/providers/gam/class-gam-provider.php`) and Broadstreet (`includes/providers/broadstreet/class-broadstreet-provider.php`).
-- Broadstreet is a great reference for a simple provider implementation.
-
-**Placements** -- where ads render:
-- Registration: `Placements::register_placement($key, $config)` in `includes/class-placements.php`.
-- Default placements: `global_above_header`, `global_below_header`, `global_above_footer`, `sticky`.
-- Config schema: `name`, `description`, `default_enabled`, `default_ad_unit`, `show_ui`, `hook_name`, `hooks` (array), `supports` (array, e.g. `stick_to_top`).
-- Hook-based rendering: call `do_action('hook_name')` in a template, the placement renders the configured ad.
-- The Ad Unit block creates dynamic placements via the same API.
-- SCAIP integration replaces widget areas with registered placements.
-
-**Settings** -- centralized settings management:
-- Class: `includes/class-settings.php`.
-- API namespace: `newspack-ads/v1` (constant `Settings::API_NAMESPACE`).
-- Option prefix: `_newspack_ads_` (constant `Settings::OPTION_NAME_PREFIX`).
-- REST endpoints: `GET/POST /settings`.
-- Permission: `manage_options` capability, filterable via `newspack_ads_can_current_user_manage_settings`.
-
-**Bidding** -- header bidding via Prebid.js:
-- Class: `includes/class-bidding.php`.
-- Gated by `NEWSPACK_ADS_EXPERIMENTAL_BIDDERS` constant.
-- Registration: `Newspack_Ads\register_bidder($id, $config)` (in `includes/class-bidding.php`, bottom of file).
-- Config schema: `name`, `ad_sizes`, `active_key`, `settings`.
-- Built-in bidders: Medianet, OpenX, PubMatic, Sovrn (in `includes/bidders/`).
-- Price granularity: low, medium, auto, dense (dense is default).
-- Each bidder must have a compatible Prebid.js adapter module imported in `src/prebid/index.js`.
-
-### GAM Provider (Deep Dive)
-
-The GAM provider is the most complex part of the plugin.
-
-**API Layer:**
-- Built on `googleads-php-lib` (SOAP library).
-- Main client: `includes/providers/gam/api/class-api.php`.
-- Entity-specific classes: `class-ad-units.php`, `class-line-items.php`, `class-orders.php`, `class-creatives.php`, `class-advertisers.php`, `class-targeting-keys.php`.
-- Authentication: service account credentials or OAuth proxied by Newspack Manager (`includes/providers/gam/class-gam-model.php`).
-
-**Targeting Key-Values:**
-- Auto-created keys when GAM connects: `id`, `slug`, `category`, `post_type`, `template`, `site`.
-- Values populated at render time from current page context.
-- Extensible via `newspack_ads_ad_targeting` filter.
-
-**Responsive Size Mapping:**
-- 600px viewport threshold separates mobile from desktop ad sizes.
-- Sizes within 30% of each other are grouped together.
-- "Bounds containers" detect parent elements (e.g., `.wp-block-column`) that restrict allowed sizes.
-- Filterable via `newspack_ads_gam_size_map`.
-
-**Supporting Classes:**
-- `class-gam-model.php`: data model, size mapping logic, targeting.
-- `class-gam-scripts.php`: renders Google Publisher Tag (GPT) scripts, bounds containers.
-- `class-gam-lazy-load.php`: lazy loading of ad slots.
-- `class-gam-ad-block-recovery.php`: ad block detection and recovery.
-
-### REST API
-
-Namespace: `newspack-ads/v1`. All endpoints require `manage_options` unless noted.
-
-| Endpoint | Method | Purpose |
-|----------|--------|---------|
-| `/settings` | GET | Get all plugin settings |
-| `/settings` | POST | Update settings (section + values) |
-| `/placements` | GET | Get all registered placements |
-| `/placements/{key}` | POST | Update placement configuration |
-| `/placements/{key}` | DELETE | Disable a placement |
-| `/providers` | GET | Get active providers and their units |
-| `/suppression` | GET/POST | Get/update ad suppression config |
-| `/bidding/gam/orders` | GET | List header bidding GAM orders |
-| `/bidding/gam/order` | GET | Get specific GAM order details |
-
-### Integrations
-
-| Class | File | Purpose |
-|-------|------|---------|
-| `SCAIP` | `integrations/class-scaip.php` | Replaces SCAIP widget areas with registered placements |
-| `Bidding_GAM` | `integrations/class-bidding-gam.php` | Automates GAM setup for header bidding (creates advertiser, keys, creatives, orders, line items, LICAs) |
-| `Complianz` | `integrations/class-complianz.php` | Cookie consent integration for GDPR compliance |
-| `Ad_Refresh_Control` | `integrations/class-ad-refresh-control.php` | Controls ad refresh frequency |
-| `Side_Rail_Placements` | `integrations/class-side-rail-placements.php` | Sticky sidebar ad placements |
-
-## Frontend (JS/SCSS)
-
-### Webpack Entry Points
-
-Defined in `webpack.config.js` using `newspack-scripts/config/getWebpackConfig`:
-
-| Entry | Source | Purpose |
-|-------|--------|---------|
-| `editor` | All `src/blocks/*/editor.js` | Combined block editor bundle |
-| `frontend` | `src/frontend/index.js` | Frontend scripts (side rail, utilities) |
-| `suppress-ads` | `src/suppress-ads/index.js` | Ad suppression logic |
-| `customizer-preview` | `src/customizer/preview.js` | Customizer live preview |
-| `customizer-control` | `src/customizer/control.js` | Customizer controls |
-| `header-bidding-gam` | `src/wizard-settings/header-bidding-gam/index.js` | GAM header bidding config |
-| `prebid` | `src/prebid/index.js` | Prebid.js with bidder adapters |
-| `media-kit-frontend` | `src/media-kit/index.js` | Media kit page scripts |
-| `<block>/view` | Each `src/blocks/*/view.js` | Per-block frontend scripts |
-
-Note: Prebid.js has a custom Babel configuration in `webpack.config.js` because the library's source requires specific transforms.
-
-### Blocks
-
-Three custom blocks:
-
-| Block | Directory | Purpose |
-|-------|-----------|---------|
-| `newspack-ads/ad-unit` | `src/blocks/ad-unit/` | Place individual ad units in content. Creates dynamic placements. |
-| `newspack-ads/tabs` | `src/blocks/tabs/` | Tab container for organizing ad content |
-| `newspack-ads/tabs-item` | `src/blocks/tabs-item/` | Individual tab within tabs block |
-
-Block registration follows static class pattern in `includes/blocks/`:
-- `class-ad-unit-block.php` -- registers block, enqueues editor assets, render callback.
-- `class-tabs-block.php`
-- `class-tabs-item-block.php`
-
-### Customizer
-
-Visual placement configuration via WordPress Customizer:
-- `includes/customizer/class-customizer.php` -- registers sections and controls.
-- `src/customizer/control.js` -- placement selection controls.
-- `src/customizer/preview.js` -- live preview of ad placement changes.
-
-## Testing
-
-```bash
-n test-php                    # Run all PHPUnit tests (from within repo directory)
-n test-php --filter test_name # Run specific test
-npm run lint                  # Run all linters
-```
-
-- Config: `phpunit.xml` with single `main` suite.
-- Bootstrap: `tests/bootstrap.php` (defines `IS_TEST_ENV` constant).
-- Test files: `test-model.php`, `test-bidding.php`, `test-providers.php`, `test-settings.php`, `test-gam-api.php`.
-- Mock provider: `tests/class-newspack-ads-test-provider.php`.
-- No PHPUnit groups currently defined.
-- No JavaScript tests.
-
-## Hooks & Extension Points
-
-The plugin exposes many hooks. Rather than listing them all here (they change over time), use grep to find current hooks:
-
-```bash
-grep -r 'apply_filters\|do_action' includes/ --include='*.php'
-```
-
-Key prefixes:
-- `newspack_ads_*` -- general plugin hooks.
-- `newspack_ads_placement_*` -- placement-specific hooks.
-- `newspack_ads_gam_*` -- GAM provider hooks.
-
-**Important filters:**
-
-| Filter | Purpose |
-|--------|---------|
-| `newspack_ads_should_show_ads` | Global ad suppression |
-| `newspack_ads_placements` | Modify registered placements |
-| `newspack_ads_placement_data` | Modify placement data before render |
-| `newspack_ads_ad_targeting` | Extend GAM targeting key-values |
-| `newspack_ads_gam_size_map` | Customize responsive size mapping |
-| `newspack_ads_settings_list` | Extend settings |
-| `newspack_ads_bidders` | Modify registered bidders |
-| `newspack_ads_prebid_ad_units` | Modify Prebid.js ad unit config |
-| `newspack_ads_can_current_user_manage_settings` | Permission override |
-
-**Important actions:**
-
-| Action | Purpose |
-|--------|---------|
-| `newspack_ads_before_placement_ad` / `newspack_ads_after_placement_ad` | Before/after a placement renders |
-| `newspack_ads_before_update_setting` / `newspack_ads_after_update_setting` | Before/after a setting is updated |
-| `newspack_ads_setup_gam` | GAM provider setup complete |
-
-## Recipes
-
-### Add a new provider
-
-1. Create `includes/providers/<name>/class-<name>-provider.php`.
-2. Extend `Newspack_Ads\Providers\Provider`, implement `get_ad_code()`.
-3. Set `$this->provider_id` and `$this->provider_name` in the constructor.
-4. `include_once` the file in `includes/class-core.php`.
-5. Register: the provider auto-registers when `Providers::init()` runs if it is instantiated via `include_once`.
-6. See `class-broadstreet-provider.php` for a minimal example.
-
-### Add a new placement
-
-1. Call `Placements::register_placement($key, $config)` (typically in a class `init()` method hooked to `init`).
-2. Config must include: `name`, `hook_name` (or `hooks` array).
-3. In the theme/template, call `do_action('hook_name')` where the ad should render.
-4. The placement automatically appears in the UI if `show_ui` is true (default).
-
-### Add a new bidder
-
-1. Create `includes/bidders/class-<name>.php`.
-2. Call `Newspack_Ads\register_bidder($id, $config)` with `name`, `ad_sizes`, `active_key`, `settings`.
-3. Import the corresponding Prebid.js adapter module in `src/prebid/index.js`.
-4. `include_once` the file in `includes/class-core.php`.
-5. Rebuild: `n build` (Prebid.js bundle changes).
-
-### Modify GAM targeting
-
-Use the `newspack_ads_ad_targeting` filter:
+## Dominant pattern for new PHP classes
 
 ```php
-add_filter( 'newspack_ads_ad_targeting', function( $targeting ) {
-    $targeting['my_key'] = 'my_value';
-    return $targeting;
-} );
+// includes/class-my-feature.php
+namespace Newspack_Ads;
+
+defined( 'ABSPATH' ) || exit;
+
+class My_Feature {
+	public static function init() {
+		// Register hooks here.
+	}
+}
+My_Feature::init();
 ```
 
-The key must exist in GAM (auto-created on connection or manually via the API).
+Then add to `includes/class-core.php`:
+
+```php
+include_once NEWSPACK_ADS_ABSPATH . '/includes/class-my-feature.php';
+```
+
+## Recipe: add a new provider
+
+1. Create `includes/providers/<name>/class-<name>-provider.php` extending `Provider`. Set `$this->provider_id` and `$this->provider_name` in the constructor.
+2. Add `include_once` in `includes/class-core.php`.
+3. In `includes/class-providers.php`: add a `use` import and call `self::register_provider( new <Name>_Provider() );` in `init()`. Forgetting this step means the provider silently won't appear.
+4. See `class-broadstreet-provider.php` for a minimal implementation.
+
+## Recipe: register a new placement
+
+1. Call `Placements::register_placement( $key, $config )` during the `init` hook. Config requires `name` and either `hook_name` (single hook) or `hooks` (array of hooks).
+2. The placement auto-appears in the admin UI unless `show_ui => false`.
+3. The ad renders when the theme calls `do_action( 'hook_name' )`. If the theme doesn't fire the hook, the placement exists in the UI but never renders on the frontend.
+4. See `register_default_placements()` in `includes/class-placements.php` for examples.
+
+## Recipe: add a new bidder
+
+Requires both PHP and JS changes, plus a gated constant:
+
+1. Create `includes/bidders/class-<name>.php`, call `Newspack_Ads\register_bidder( $id, $config )`.
+2. Add `include_once` in `includes/class-core.php`.
+3. Import the corresponding Prebid.js adapter module in `src/prebid/index.js`.
+4. Rebuild: `n build` (Prebid.js bundle changes).
+5. Test with `define( 'NEWSPACK_ADS_EXPERIMENTAL_BIDDERS', true );` in `wp-config.php`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add repo-specific AI instruction files so coding agents can work effectively with newspack-ads without falling into common traps.

- `CLAUDE.md` — references `@AGENTS.md`
- `AGENTS.md` — hazard-focused runbook (61 lines) covering gotchas, the dominant PHP class pattern, and recipes for adding providers, placements, and bidders

This follows the approach that agent context files should warn about landmines rather than describe architecture that agents can discover by reading code. The file was reduced from 251 lines of inventories and architecture descriptions to 61 lines of non-discoverable hazards and recipes.

Shared conventions (Docker, coding standards, git rules) are in the workspace-level AGENTS.md and are not duplicated here.

Closes NPPD-1256.

### How to test the changes in this Pull Request:

1. Review `AGENTS.md` for accuracy — verify the gotchas match actual codebase behavior (e.g., manual `include_once` in `Core::includes()`, `npm run lint` skipping PHP, bidding gated behind `NEWSPACK_ADS_EXPERIMENTAL_BIDDERS`).
2. Confirm the dominant pattern template matches the convention used by existing classes (EOF `::init()` call, namespace, etc.).
3. Verify recipe steps: e.g., adding a provider requires registration in `Providers::init()`, not just an `include_once`.
4. Check that no information in the file duplicates the workspace-level `AGENTS.md`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?