### PR TITLE
fix: remove ability to hide ad blocks

### DIFF
--- a/src/blocks/ad-unit/index.js
+++ b/src/blocks/ad-unit/index.js
@@ -50,6 +50,7 @@ export const settings = {
 			text: false,
 			background: true,
 		},
+		visibility: false,
 	},
 	edit,
 	save: () => null, // to use Newspack_Ads_Blocks::render_block()


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes the option to hide the Newspack Ads block. 

Closes NEWS-1719

### How to test the changes in this Pull Request:
1. Apply this PR and run `npm run build`.
2. Try adding the Ad Unit block to the editor.
3. Click the `...` menu in the block toolbar.
4. Confirm you don't have an option to 'Hide' the block.
5. Bonus test: update to the WordPress 7.0 RC, hard refresh, and repeat steps 3 and 4. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->