### PR TITLE
fix: update newspack-scripts to npm registry version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 			},
 			"devDependencies": {
 				"classnames": "^2.5.1",
-				"newspack-scripts": "github:Automattic/newspack-scripts#chore/refresh-dependencies"
+				"newspack-scripts": "^5.9.7"
 			}
 		},
 		"node_modules/@10up/component-tabs": {
@@ -25375,8 +25375,9 @@
 			}
 		},
 		"node_modules/newspack-scripts": {
-			"version": "5.8.0",
-			"resolved": "git+ssh://git@github.com/Automattic/newspack-scripts.git#a1ef78fa78f125d50852d6042cf14d69bd28c4e8",
+			"version": "5.9.7",
+			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.9.7.tgz",
+			"integrity": "sha512-lEzBFkGGHIu0q6K6ry/V1jxz3fd5QZuTgMgIIt2sNIHci7rKDY6NYblhs394+2gK98ivHoXS+HWanoumNfOFXw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
 	},
 	"devDependencies": {
 		"classnames": "^2.5.1",
-		"newspack-scripts": "github:Automattic/newspack-scripts#chore/refresh-dependencies"
+		"newspack-scripts": "^5.9.7"
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Switches the `newspack-scripts` dependency from a deleted GitHub branch reference (`github:Automattic/newspack-scripts#chore/refresh-dependencies`) to the published npm registry version (`^5.9.7`).

The old reference resolved to an older commit that lacked the `scripts/github/post-release.sh` file, which caused the post-release workflow to fail with exit code 127. This meant the v3.10.2 release was published without a .zip asset.

### How to test the changes in this Pull Request:

1. Verify that `package.json` now has `"newspack-scripts": "^5.9.7"` under `devDependencies`.
2. Run `npm ci` and confirm it completes successfully.
3. Verify `node_modules/newspack-scripts/scripts/github/post-release.sh` exists after install.
4. Run `npm run build` to confirm the build still works with the updated dependency.
5. After merging, trigger or wait for the next release and confirm the post-release job succeeds and a .zip asset is attached to the GitHub release.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?