### PR TITLE
feat: add a warning message when hidden block contains an ad

### DIFF
--- a/src/frontend/style.scss
+++ b/src/frontend/style.scss
@@ -147,6 +147,6 @@
 .wp-block-hidden-tablet,
 .wp-block-hidden-mobile {
 	&:has(.wp-block-newspack-blocks-wp-block-newspack-ads-blocks-ad-unit) {
-		display: block !important;
+		display: revert !important;
 	}
 }

--- a/src/frontend/style.scss
+++ b/src/frontend/style.scss
@@ -141,3 +141,12 @@
 		}
 	}
 }
+
+// Don't allow hiding blocks containing ad blocks.
+.wp-block-hidden-desktop,
+.wp-block-hidden-tablet,
+.wp-block-hidden-mobile {
+	&:has(.wp-block-newspack-blocks-wp-block-newspack-ads-blocks-ad-unit) {
+		display: block !important;
+	}
+}

--- a/src/frontend/style.scss
+++ b/src/frontend/style.scss
@@ -142,10 +142,11 @@
 	}
 }
 
-// Don't allow hiding blocks containing ad blocks.
+// Force visibility on parent blocks the user has hidden when they contain an ad unit.
 .wp-block-hidden-desktop,
 .wp-block-hidden-tablet,
 .wp-block-hidden-mobile {
+	// This CSS class seems wrong, but please don't fix! The double prefix matches what's output by the plugin.
 	&:has(.wp-block-newspack-blocks-wp-block-newspack-ads-blocks-ad-unit) {
 		display: revert !important;
 	}

--- a/src/setup/editor.js
+++ b/src/setup/editor.js
@@ -3,3 +3,4 @@
  */
 import './public-path';
 import './category';
+import './visibility-warning';

--- a/src/setup/visibility-warning.js
+++ b/src/setup/visibility-warning.js
@@ -33,7 +33,7 @@ const AdVisibilityWarning = () => {
 					'A hidden block contains an ad unit. Ads and their containers must stay visible at all breakpoints to avoid penalties — use your ad provider settings to control ad visibility. Find hidden blocks in Document Overview > List view.',
 					'newspack-ads'
 				),
-				{ id: NOTICE_ID, isDismissible: true }
+				{ id: NOTICE_ID, isDismissible: false }
 			);
 		} else {
 			removeNotice( NOTICE_ID );

--- a/src/setup/visibility-warning.js
+++ b/src/setup/visibility-warning.js
@@ -20,7 +20,7 @@ const AdVisibilityWarning = () => {
 			if ( getBlockName( id ) !== AD_BLOCK ) {
 				return false;
 			}
-			return getBlockParents( id ).some( isHidden );
+			return [ id, ...getBlockParents( id ) ].some( isHidden );
 		} );
 	}, [] );
 

--- a/src/setup/visibility-warning.js
+++ b/src/setup/visibility-warning.js
@@ -30,18 +30,11 @@ const AdVisibilityWarning = () => {
 	useEffect( () => {
 		if ( hasHiddenAdContainer ) {
 			createWarningNotice(
-				'<p>' +
-					__(
-						'One or more hidden blocks contain an ad unit. Ad blocks and their containers will remain visible on all screen sizes — hiding ads with CSS may result in penalties.',
-						'newspack-ads'
-					) +
-					'</p><p>' +
-					__(
-						'To control which ads appear at different breakpoints, use your ad provider settings. To find the hidden block, go to Document Overview > List view.',
-						'newspack-ads'
-					) +
-					'</p>',
-				{ id: NOTICE_ID, isDismissible: true, __unstableHTML: true }
+				__(
+					'One or more hidden blocks contain an ad unit. Ad blocks and their containers will remain visible on all screen sizes — hiding ads with CSS may result in penalties. To control which ads appear at different breakpoints, use your ad provider settings. To find the hidden block, go to Document Overview > List view.',
+					'newspack-ads'
+				),
+				{ id: NOTICE_ID, isDismissible: true }
 			);
 		} else {
 			removeNotice( NOTICE_ID );

--- a/src/setup/visibility-warning.js
+++ b/src/setup/visibility-warning.js
@@ -31,7 +31,7 @@ const AdVisibilityWarning = () => {
 		if ( hasHiddenAdContainer ) {
 			createWarningNotice(
 				__(
-					'One or more hidden blocks contain an ad unit. Ad blocks and their containers will remain visible on all screen sizes — hiding ads with CSS may result in penalties. To control which ads appear at different breakpoints, use your ad provider settings. To find the hidden block, go to Document Overview > List view.',
+					'A hidden block contains an ad unit. Ads and their containers must stay visible at all breakpoints to avoid penalties — use your ad provider settings to control ad visibility. Find hidden blocks in Document Overview > List view.',
 					'newspack-ads'
 				),
 				{ id: NOTICE_ID, isDismissible: true }

--- a/src/setup/visibility-warning.js
+++ b/src/setup/visibility-warning.js
@@ -11,8 +11,7 @@ const NOTICE_ID = 'newspack-ads/ad-visibility-warning';
 
 const AdVisibilityWarning = () => {
 	const hasHiddenAdContainer = useSelect( select => {
-		const { getClientIdsWithDescendants, getBlockName, getBlockParents, getBlockAttributes } =
-			select( 'core/block-editor' );
+		const { getClientIdsWithDescendants, getBlockName, getBlockParents, getBlockAttributes } = select( 'core/block-editor' );
 		const isHidden = clientId => {
 			const viewport = getBlockAttributes( clientId )?.metadata?.blockVisibility?.viewport;
 			return viewport && Object.values( viewport ).some( visible => visible === false );

--- a/src/setup/visibility-warning.js
+++ b/src/setup/visibility-warning.js
@@ -30,7 +30,7 @@ const AdVisibilityWarning = () => {
 		if ( hasHiddenAdContainer ) {
 			createWarningNotice(
 				__(
-					'A hidden block contains an ad unit. Ads and their containers must stay visible at all breakpoints to avoid penalties — use your ad provider settings to control ad visibility. Find hidden blocks in Document Overview > List view.',
+					'A hidden block contains an ad unit. Ads and their containers must stay visible at all breakpoints to avoid penalties — use your ad provider settings to control ad visibility instead.',
 					'newspack-ads'
 				),
 				{ id: NOTICE_ID, isDismissible: false }

--- a/src/setup/visibility-warning.js
+++ b/src/setup/visibility-warning.js
@@ -1,0 +1,54 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { registerPlugin } from '@wordpress/plugins';
+import { __ } from '@wordpress/i18n';
+
+const AD_BLOCK = 'newspack-ads/ad-unit';
+const NOTICE_ID = 'newspack-ads/ad-visibility-warning';
+
+const AdVisibilityWarning = () => {
+	const hasHiddenAdContainer = useSelect( select => {
+		const { getClientIdsWithDescendants, getBlockName, getBlockParents, getBlockAttributes } =
+			select( 'core/block-editor' );
+		const isHidden = clientId => {
+			const viewport = getBlockAttributes( clientId )?.metadata?.blockVisibility?.viewport;
+			return viewport && Object.values( viewport ).some( visible => visible === false );
+		};
+		return getClientIdsWithDescendants().some( id => {
+			if ( getBlockName( id ) !== AD_BLOCK ) {
+				return false;
+			}
+			return getBlockParents( id ).some( isHidden );
+		} );
+	}, [] );
+
+	const { createWarningNotice, removeNotice } = useDispatch( 'core/notices' );
+
+	useEffect( () => {
+		if ( hasHiddenAdContainer ) {
+			createWarningNotice(
+				'<p>' +
+					__(
+						'One or more hidden blocks contain an ad unit. Ad blocks and their containers will remain visible on all screen sizes — hiding ads with CSS may result in penalties.',
+						'newspack-ads'
+					) +
+					'</p><p>' +
+					__(
+						'To control which ads appear at different breakpoints, use your ad provider settings. To find the hidden block, go to Document Overview > List view.',
+						'newspack-ads'
+					) +
+					'</p>',
+				{ id: NOTICE_ID, isDismissible: true, __unstableHTML: true }
+			);
+		} else {
+			removeNotice( NOTICE_ID );
+		}
+	}, [ hasHiddenAdContainer, createWarningNotice, removeNotice ] );
+
+	return null;
+};
+
+registerPlugin( 'newspack-ads-visibility-warning', { render: AdVisibilityWarning } );


### PR DESCRIPTION
In WordPress 7.0, there's a new option to hide blocks at certain breakpoints.

Since hiding ads with CSS can be problematic and cause issues with ad providers, we've already removed this option from the ad blocks themselves. With this PR:

* If you hide a block at certain breakpoints and it contains an ad block, a warning will display at the top of the editor
* If you hide a block outright that contains an ad block, no warning is displayed - that's because these blocks aren't output at all on the front-end
* On the front-end, if you've hidden a block at a certain breakpoint and it contains an ad block, we use CSS to force it to be visible

This approach is a little subpar - I had wanted to also force the blocks to be visible in the editor, but it looks like they're removed from the output in the editor unless they're focused on. So I hope the notice + force-showing on the front-end is enough! 😬 

## Steps to test

1. Start on a test site running the latest WordPress 7.0 RC.
2. Add a columns or group block to the editor, and then add an ad block inside of it.
3. Click the parent block, select the kebab (`...`) menu in the block toolbar, and select Hide.
4. Check 'Omit from published content'. Confirm that you get no errors/weirdness in the editor, and that the block doesn't appear at all in the markup rendered on the front-end:

<img width="415" height="419" alt="CleanShot 2026-04-14 at 10 59 14" src="https://github.com/user-attachments/assets/5198881e-6f81-4093-80e9-a9dd610d98d0" />

5. Repeat step 3, but this time, pick one of the other options (you can check one breakpoint, or all three). Confirm you get an error at the top of the editor:

<img width="1265" height="370" alt="CleanShot 2026-04-14 at 11 20 15" src="https://github.com/user-attachments/assets/fc653149-d048-4363-8c6a-3115c1ccde7d" />

6. Publish the post/page and confirm this second hidden block is visible at all breakpoints. 
7. Try removing the ad block and confirming the warning goes away in the editor, and that the block's hidden as expected based on your settings on the front-end.
8. Repeat the testing steps on a site running the latest version of WP 6.9. The hide option is just a simple toggle within the dropdown menu (no modal, and no options to choose a breakpoint). It should work just like the "Omit from published content" in 7.0, and do nothing.