### PR TITLE
fix(tabs): align tab-header overlay precisely over its button

### DIFF
--- a/src/blocks/tabs/edit.js
+++ b/src/blocks/tabs/edit.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
  */
 import { createBlock } from '@wordpress/blocks';
 import { compose, ifCondition, useRefEffect } from '@wordpress/compose';
-import { useState, useEffect, useCallback, Fragment } from '@wordpress/element';
+import { useState, useEffect, useLayoutEffect, useCallback, Fragment } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { Button, NavigableMenu } from '@wordpress/components';
 import { plus } from '@wordpress/icons';
@@ -90,29 +90,58 @@ const TabsEdit = props => {
 	}, [ selectBlock, clientId, tabCount, setTabCount, editTab, block, innerBlocks, removeBlock, activeClass, blockElement ] );
 
 	/**
-	 * Hacky solution to positioning the tab header in the correct place
+	 * Position each `.tab-header` overlay precisely on top of its corresponding tab
+	 * button. The overlay lives inside `.newspack-ads__tab-group` (a different
+	 * positioning context than the buttons), so we translate the button's viewport
+	 * rect into the overlay's containing block. A ResizeObserver keeps the overlays
+	 * in sync when buttons reflow (e.g. text wrap on viewport resize) without
+	 * waiting for a React render.
 	 */
-	useEffect( () => {
+	useLayoutEffect( () => {
 		if ( ! blockElement ) {
 			return;
 		}
-		const rafId = requestAnimationFrame( () => {
-			innerBlocks.forEach( innerBlock => {
-				const tabHeaderButton = blockElement.querySelector( `.components-tab-panel__tabs-item[data-tab-block="${ innerBlock.clientId }"]` );
 
-				if ( ! tabHeaderButton ) {
-					return;
-				}
-				const tabHeader = blockElement.querySelector( `.tab-header[data-tab-block="${ innerBlock.clientId }"]` );
+		const positionTabHeader = innerBlock => {
+			const tabHeaderButton = blockElement.querySelector( `.components-tab-panel__tabs-item[data-tab-block="${ innerBlock.clientId }"]` );
+			if ( ! tabHeaderButton ) {
+				return;
+			}
+			const tabHeader = blockElement.querySelector( `.tab-header[data-tab-block="${ innerBlock.clientId }"]` );
+			// `offsetParent` is null while the tab is hidden (display:none); we
+			// reposition once it becomes visible (editTab change re-runs this effect).
+			const containingBlock = tabHeader && tabHeader.offsetParent;
+			if ( ! containingBlock ) {
+				return;
+			}
+			const containerRect = containingBlock.getBoundingClientRect();
+			const buttonRect = tabHeaderButton.getBoundingClientRect();
+			tabHeader.style.left = `${ buttonRect.left - containerRect.left }px`;
+			tabHeader.style.top = `${ buttonRect.top - containerRect.top }px`;
+			tabHeader.style.width = `${ buttonRect.width }px`;
+			tabHeader.style.height = `${ buttonRect.height }px`;
+		};
 
-				if ( tabHeader && tabHeaderButton ) {
-					tabHeader.style.left = `${ tabHeaderButton.offsetLeft }px`;
-					tabHeader.style.top = `-${ tabHeader.offsetHeight }px`;
-				}
-			} );
+		const positionAll = () => innerBlocks.forEach( positionTabHeader );
+
+		positionAll();
+
+		// Track size changes of the block and each button (covers viewport resizes,
+		// text wrapping mid-edit, font loading, etc. — anything that shifts the
+		// button's rect without triggering a React render of this component).
+		if ( typeof ResizeObserver === 'undefined' ) {
+			return;
+		}
+		const observer = new ResizeObserver( positionAll );
+		observer.observe( blockElement );
+		innerBlocks.forEach( innerBlock => {
+			const button = blockElement.querySelector( `.components-tab-panel__tabs-item[data-tab-block="${ innerBlock.clientId }"]` );
+			if ( button ) {
+				observer.observe( button );
+			}
 		} );
-		return () => cancelAnimationFrame( rafId );
-	}, [ blockElement, innerBlocks ] );
+		return () => observer.disconnect();
+	}, [ blockElement, innerBlocks, editTab ] );
 
 	const tabPanels = innerBlocks.map( innerBlock => {
 		// eslint-disable-next-line @typescript-eslint/no-shadow

--- a/src/blocks/tabs/editor.scss
+++ b/src/blocks/tabs/editor.scss
@@ -25,10 +25,13 @@
 		}
 
 		& .tab-header {
+			align-items: center;
 			color: var(--newspack-ui-color-neutral-90, #1e1e1e);
+			display: flex;
 			font-family: inherit;
 			font-size: inherit;
 			font-weight: 600;
+			justify-content: center;
 			position: absolute;
 
 			& .rich-text {
@@ -44,9 +47,8 @@
 				padding:
 					var(--newspack-ui-spacer-2, 12px)
 					var(--newspack-ui-spacer-3, 16px);
-				position: relative;
-				top: 0;
-				width: auto;
+				text-align: center;
+				width: 100%;
 			}
 		}
 

--- a/src/blocks/tabs/editor.scss
+++ b/src/blocks/tabs/editor.scss
@@ -108,6 +108,7 @@
 		padding:
 			var(--newspack-ui-spacer-2, 12px)
 			var(--newspack-ui-spacer-3, 16px);
+		white-space: pre-wrap;
 	}
 }
 


### PR DESCRIPTION
Follow-up to #1031, fixing the tab-header rendering glitch, present in `trunk` as well. When clicking back on an existing tab, the editable header overlay would appear duplicated, misaligned with the tab button, and only "snap" into place once typing forced a re-render.

The strategy has been refactored to track each button's bounding rect with a ResizeObserver and write the position synchronously via useLayoutEffect so the overlay stays in register through wraps, viewport resizes, and tab visibility changes. It also centers the overlay's rich-text with flex to match the button's flex centering, eliminating the vertical drift on multi-line tabs.

## Testing

1. Draft a post and add the Tabs block
2. Resize your browser window so it's narrower
3. Add multiple tabs, make sure some of them wrap
4. Switch between them, editing the tab header text
5. Make sure the editable text is always snapped in the correct position