### PR TITLE
fix: hide SCAIP's panel when Newspack Ads in active, since it has its own visibility controls

### DIFF
--- a/includes/integrations/class-scaip.php
+++ b/includes/integrations/class-scaip.php
@@ -291,8 +291,16 @@ final class SCAIP {
 	 * registered, so any value already saved is still respected.
 	 */
 	public static function dequeue_scaip_document_panel() {
-		wp_dequeue_script( 'scaip-document-panel' );
-		wp_deregister_script( 'scaip-document-panel' );
+		if ( ! defined( 'SCAIP_PLUGIN_FILE' ) ) {
+			return;
+		}
+		if (
+			wp_script_is( 'scaip-document-panel', 'registered' ) ||
+			wp_script_is( 'scaip-document-panel', 'enqueued' )
+		) {
+			wp_dequeue_script( 'scaip-document-panel' );
+			wp_deregister_script( 'scaip-document-panel' );
+		}
 	}
 }
 SCAIP::init();

--- a/includes/integrations/class-scaip.php
+++ b/includes/integrations/class-scaip.php
@@ -49,6 +49,9 @@ final class SCAIP {
 		// Block filtering hooks.
 		add_filter( 'scaip_allowing_insertion_blocks', [ __CLASS__, 'filter_allowed_blocks' ] );
 
+		// Hide SCAIP's per-post toggle panel.
+		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'dequeue_scaip_document_panel' ], 100 );
+
 		// Setup Newspack Ads defaults on activation.
 		add_action( 'newspack_ads_activation_hook', array( __CLASS__, 'register_defaults' ) );
 
@@ -276,6 +279,20 @@ final class SCAIP {
 		}
 
 		return $allowed_blocks;
+	}
+
+	/**
+	 * Dequeue SCAIP's document settings panel script in the block editor.
+	 *
+	 * SCAIP ships a per-post "Prevent automatic addition of ads" toggle as a
+	 * PluginDocumentSettingPanel. When Newspack Ads is active, the Suppress
+	 * Ads panel covers the same use case via this integration's placements,
+	 * so SCAIP's panel would be a duplicate UI. The post meta itself stays
+	 * registered, so any value already saved is still respected.
+	 */
+	public static function dequeue_scaip_document_panel() {
+		wp_dequeue_script( 'scaip-document-panel' );
+		wp_deregister_script( 'scaip-document-panel' );
 	}
 }
 SCAIP::init();


### PR DESCRIPTION
In https://github.com/Automattic/super-cool-ad-inserter-plugin/pull/261, SCAIP's built in option to hide ads its inserted in a post has been updated from a post meta box to a PluginDocumentSettingPanel.

As part of that change, the panel became a lot more noticeable, and it seemed a lot more redundant when paired with Newspack Ads, which has its own per-SCAIP-placement visibility toggle.

This PR hides the SCAIP panel when Newspack Ads is active, to avoid the duplication. 

## Steps to test

1. Apply https://github.com/Automattic/super-cool-ad-inserter-plugin/pull/261 to SCAIP, if it isn't merged already
2. Edit a post; note you have both a Newspack Ads and Super Cool Ad Inserter panel in the sidebar:


<img width="288" height="203" alt="CleanShot 2026-05-06 at 18 18 17" src="https://github.com/user-attachments/assets/d12ab5e0-a6e2-4830-b170-afc30d7a7432" />


3. Apply this PR and run `npm run build`. 
4. Refresh the post editor and confirm you only have the Newspack Ads panel in the sidebar.
5. Disable Newspack Ads.
6. Refresh the post editor and confirm you have the Super Cool Ad Inserter panel again.
7. Reactivate Newspack Ads and smoke test the toggles for individual SCAIP visibility.

