### PR TITLE
fix: correct spacing between ad suppression toggles for WP 7.0

### DIFF
--- a/includes/class-suppression.php
+++ b/includes/class-suppression.php
@@ -203,6 +203,7 @@ final class Suppression {
 		$post_type = \get_current_screen()->post_type;
 		if ( ! empty( $post_type ) && \is_post_type_viewable( $post_type ) && \post_type_supports( $post_type, 'custom-fields' ) ) {
 			\wp_enqueue_script( 'newspack-ads-suppress-ads', Core::plugin_url( 'dist/suppress-ads.js' ), [], NEWSPACK_ADS_VERSION, true );
+			\wp_enqueue_style( 'newspack-ads-suppress-ads', Core::plugin_url( 'dist/suppress-ads.css' ), [], NEWSPACK_ADS_VERSION );
 			$placements = Placements::get_placements();
 			\wp_localize_script(
 				'newspack-ads-suppress-ads',

--- a/src/suppress-ads/editor.scss
+++ b/src/suppress-ads/editor.scss
@@ -1,4 +1,4 @@
-.newspack-ads-suppress-ads {
+.newspack-ads-settings {
 	.components-toggle-control:not(:last-child) {
 		margin-bottom: 12px;
 	}

--- a/src/suppress-ads/editor.scss
+++ b/src/suppress-ads/editor.scss
@@ -1,0 +1,5 @@
+.newspack-ads-suppress-ads {
+	.components-toggle-control:not(:last-child) {
+		margin-bottom: 12px;
+	}
+}

--- a/src/suppress-ads/index.js
+++ b/src/suppress-ads/index.js
@@ -24,7 +24,7 @@ class NewspackSuppressAdsPanel extends Component {
 		const placements = window.newspackAdsSuppressAds?.placements || {};
 		const { newspack_ads_suppress_ads, newspack_ads_suppress_ads_placements, updateSuppressAds, updateSuppressPlacements } = this.props;
 		return (
-			<PluginDocumentSettingPanel name="newspack-ad-free" title={ __( 'Newspack Ads Settings', 'newspack-ads' ) } className="newspack-ads-suppress-ads">
+			<PluginDocumentSettingPanel name="newspack-ad-free" title={ __( 'Newspack Ads Settings', 'newspack-ads' ) } className="newspack-ads-settings">
 				<ToggleControl
 					label={ __( "Don't show ads on this content", 'newspack-ads' ) }
 					checked={ newspack_ads_suppress_ads }

--- a/src/suppress-ads/index.js
+++ b/src/suppress-ads/index.js
@@ -12,6 +12,11 @@ import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 
 /**
+ * Internal dependencies
+ */
+import './editor.scss';
+
+/**
  * Add a section to the Document settings with a toggle for suppressing ads on the current single.
  */
 class NewspackSuppressAdsPanel extends Component {
@@ -19,7 +24,7 @@ class NewspackSuppressAdsPanel extends Component {
 		const placements = window.newspackAdsSuppressAds?.placements || {};
 		const { newspack_ads_suppress_ads, newspack_ads_suppress_ads_placements, updateSuppressAds, updateSuppressPlacements } = this.props;
 		return (
-			<PluginDocumentSettingPanel name="newspack-ad-free" title={ __( 'Newspack Ads Settings', 'newspack-ads' ) } className="newspack-subtitle">
+			<PluginDocumentSettingPanel name="newspack-ad-free" title={ __( 'Newspack Ads Settings', 'newspack-ads' ) } className="newspack-ads-suppress-ads">
 				<ToggleControl
 					label={ __( "Don't show ads on this content", 'newspack-ads' ) }
 					checked={ newspack_ads_suppress_ads }

--- a/src/suppress-ads/index.js
+++ b/src/suppress-ads/index.js
@@ -24,7 +24,11 @@ class NewspackSuppressAdsPanel extends Component {
 		const placements = window.newspackAdsSuppressAds?.placements || {};
 		const { newspack_ads_suppress_ads, newspack_ads_suppress_ads_placements, updateSuppressAds, updateSuppressPlacements } = this.props;
 		return (
-			<PluginDocumentSettingPanel name="newspack-ad-free" title={ __( 'Newspack Ads Settings', 'newspack-ads' ) } className="newspack-ads-settings">
+			<PluginDocumentSettingPanel
+				name="newspack-ad-free"
+				title={ __( 'Newspack Ads Settings', 'newspack-ads' ) }
+				className="newspack-ads-settings"
+			>
 				<ToggleControl
 					label={ __( "Don't show ads on this content", 'newspack-ads' ) }
 					checked={ newspack_ads_suppress_ads }


### PR DESCRIPTION
WordPress 7.0 changed how some components get spacing, and it's created a couple weird display issues in our components, including the suppress ads sidebar on posts and pages.

This hotfix re-adds the spacing by adding a panel-specific CSS file, and also updates the panel's CSS class to actually reflect what it's for.

Closes NEWS-2165

## Steps to test

1. Test on a site with the latest WordPress 7.0 RC and with Newspack Ads set up.
2. Edit a post and note the appearance of the Newspack Ads Settings panel:

<img width="277" height="274" alt="CleanShot 2026-05-07 at 16 23 10" src="https://github.com/user-attachments/assets/2b519c0d-ba95-43c6-82c6-86ff221dfc45" />

3. Apply the PR and run `npm run build`
4. Refresh the page and confirm the panel looks better:

<img width="288" height="376" alt="CleanShot 2026-05-07 at 16 22 12" src="https://github.com/user-attachments/assets/b1e61410-4199-44c8-90a7-02e548761b0a" />

5. Smoke test with WP 6.9.4 just to make sure things look okay (the spacing should match)