### PR TITLE
fix(suppression): guard get_current_screen() in customizer preview

### DIFF
--- a/includes/class-suppression.php
+++ b/includes/class-suppression.php
@@ -203,7 +203,14 @@ final class Suppression {
 		if ( ! \wp_should_load_block_editor_scripts_and_styles() ) {
 			return;
 		}
-		$post_type = \get_current_screen()->post_type;
+		if ( ! \function_exists( 'get_current_screen' ) ) {
+			return;
+		}
+		$screen = \get_current_screen();
+		if ( ! $screen instanceof \WP_Screen ) {
+			return;
+		}
+		$post_type = $screen->post_type;
 		if ( ! empty( $post_type ) && \is_post_type_viewable( $post_type ) && \post_type_supports( $post_type, 'custom-fields' ) ) {
 			\wp_enqueue_script( 'newspack-ads-suppress-ads', Core::plugin_url( 'dist/suppress-ads.js' ), [], NEWSPACK_ADS_VERSION, true );
 			$placements = Placements::get_placements();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Hotfix for a fatal error that breaks the Customize page.

`Suppression::enqueue_block_assets()` is hooked to `enqueue_block_assets`, which fires on the front end as well as in admin. The customizer loads the site front end inside its preview iframe, where `get_current_screen()` is not available (it is a `wp-admin`-only function). The unguarded `get_current_screen()->post_type` call therefore triggered `Call to undefined function get_current_screen()`, fataling the request and breaking the Customize screen.

The handler now bails out cleanly when `get_current_screen()` is unavailable or does not return a `WP_Screen` instance, so the block ad-suppression script only enqueues on real block-editor screens. This also fixes a latent crash in other non-screen contexts (e.g. AJAX) where `get_current_screen()` returns `null`.

### How to test the changes in this Pull Request:

1. On `release` (without this fix), with newspack-ads active, open **Appearance → Customize**. Confirm the page fails to render and the PHP error log shows `Call to undefined function get_current_screen() in .../class-suppression.php`.
2. Check out this branch and rebuild/deploy newspack-ads.
3. Reload **Appearance → Customize**. The customizer should now load normally with no fatal in the PHP error log.
4. Open a post/page in the block editor and confirm ad-suppression UI still works (the `newspack-ads-suppress-ads` script is enqueued and the per-post "Suppress ads" controls behave as before).
5. View a regular front-end page and confirm there are no PHP errors from `enqueue_block_assets`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?