### PR TITLE
feat: add 'sticky' option to ad unit block

### DIFF
--- a/includes/blocks/class-ad-unit-block.php
+++ b/includes/blocks/class-ad-unit-block.php
@@ -138,6 +138,13 @@ final class Ad_Unit_Block {
 		if ( strpos( $classes, 'aligncenter' ) == true ) {
 			$align = 'center';
 		}
+		$styles = array( sprintf( 'text-align:%s', $align ) );
+		if ( 'sticky' === ( $attrs['style']['position']['type'] ?? '' ) ) {
+			$sticky_top = $attrs['style']['position']['top'] ?? null;
+			if ( null !== $sticky_top ) {
+				$styles[] = sprintf( '--wp--style--position-sticky-top:%s', $sticky_top );
+			}
+		}
 		ob_start();
 		do_action( $placement_config['hook_name'] );
 		$content = ob_get_clean();
@@ -145,9 +152,9 @@ final class Ad_Unit_Block {
 			return '';
 		}
 		return sprintf(
-			'<div class="%1$s" style="text-align:%2$s">%3$s</div>',
+			'<div class="%1$s" style="%2$s">%3$s</div>',
 			esc_attr( $classes ),
-			esc_attr( $align ),
+			esc_attr( implode( ';', $styles ) ),
 			$content
 		);
 	}
@@ -194,6 +201,9 @@ final class Ad_Unit_Block {
 		if ( isset( $attributes['backgroundColor'] ) ) {
 			array_push( $classes, 'has-background' );
 			array_push( $classes, sprintf( 'has-%s-background-color', $attributes['backgroundColor'] ) );
+		}
+		if ( 'sticky' === ( $attributes['style']['position']['type'] ?? '' ) ) {
+			$classes[] = 'is-position-sticky';
 		}
 		return implode( ' ', $classes );
 	}

--- a/includes/blocks/class-ad-unit-block.php
+++ b/includes/blocks/class-ad-unit-block.php
@@ -145,6 +145,8 @@ final class Ad_Unit_Block {
 				$styles[] = sprintf( '--wp--style--position-sticky-top:%s', $sticky_top );
 			}
 		}
+		// Sanitize the inline style so user-supplied attribute values can't inject arbitrary CSS declarations.
+		$style_attr = safecss_filter_attr( implode( ';', $styles ) );
 		ob_start();
 		do_action( $placement_config['hook_name'] );
 		$content = ob_get_clean();
@@ -154,7 +156,7 @@ final class Ad_Unit_Block {
 		return sprintf(
 			'<div class="%1$s" style="%2$s">%3$s</div>',
 			esc_attr( $classes ),
-			esc_attr( implode( ';', $styles ) ),
+			esc_attr( $style_attr ),
 			$content
 		);
 	}

--- a/src/blocks/ad-unit/index.js
+++ b/src/blocks/ad-unit/index.js
@@ -52,6 +52,9 @@ export const settings = {
 			background: true,
 		},
 		visibility: false,
+		position: {
+			sticky: true,
+		},
 	},
 	edit,
 	save: () => null, // to use Newspack_Ads_Blocks::render_block()


### PR DESCRIPTION
This PR adds support for the 'sticky' position for the Ad Unit blocks for themes that support it (block themes). 

Closes NPPD-1402

Note: The block builds its own wrapper rather than using `get_block_wrapper_attributes()`. Core would normally automatically add some of the sticky style related stuff with `get_block_wrapper_attributes()`; we're manually adding it in this PR instead.

If it'd be preferred to move this block to use `get_block_wrapper_attributes()`, let me know! I just didn't want to make the PR any more complicated than I had to 😅 

## Steps to test

1. On a site running a block theme, apply this PR and build.
2. Create a new page, and insert a columns block. In one column add a bunch of text; in the other, add an Ad block.
3. Using the sidebar option, set the ad unit to be 'sticky':

<img width="282" height="347" alt="CleanShot 2026-05-18 at 16 59 15" src="https://github.com/user-attachments/assets/605753e6-9fd1-4821-9870-f7f72d9ffbd5" />

4. Publish and view on the front-end; scroll. Confirm your ad unit sticks as you scroll. If it doesn't, verify that no parent elements have `overflow` styles -- that will prevent the stickiness from working. 
